### PR TITLE
Add CircleCI/ZenHub badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # Singularity Image Format (SIF)
+
+<a href="https://circleci.com/gh/sylabs/sif"><img src="https://circleci.com/gh/sylabs/sif.svg?style=shield&circle-token=7e762a71efecb4da6cd6981e90cf4cc9c5e4291e"/></a>
+<a href="https://app.zenhub.com/workspace/o/sylabs/sif/boards"><img src="https://raw.githubusercontent.com/ZenHubIO/support/master/zenhub-badge.png"></a>
+
 This repository holds the golang reference implementation of the Singularity Container Image Format.


### PR DESCRIPTION
Because everything is about achievements and badges these days... add CI/ZenHub badges to `README`.

Closes #2 