### PR TITLE
Centralize the formatting routines.

### DIFF
--- a/cmd/siftool/info.go
+++ b/cmd/siftool/info.go
@@ -14,33 +14,6 @@ import (
 	"time"
 )
 
-// readableSize returns the size in human readable format
-func readableSize(size uint64) string {
-	var divs int
-	var conversion string
-
-	for ; size != 0; size >>= 10 {
-		if size < 1024 {
-			break
-		}
-		divs++
-	}
-
-	switch divs {
-	case 0:
-		conversion = fmt.Sprintf("%d", size)
-	case 1:
-		conversion = fmt.Sprintf("%dKB", size)
-	case 2:
-		conversion = fmt.Sprintf("%dMB", size)
-	case 3:
-		conversion = fmt.Sprintf("%dGB", size)
-	case 4:
-		conversion = fmt.Sprintf("%dTB", size)
-	}
-	return conversion
-}
-
 // cmdHeader displays a SIF file global header to stdout
 func cmdHeader(args []string) error {
 	if len(args) != 1 {
@@ -53,87 +26,9 @@ func cmdHeader(args []string) error {
 	}
 	defer fimg.UnloadContainer()
 
-	fmt.Println("Launch:  ", string(fimg.Header.Launch[:]))
-	fmt.Println("Magic:   ", string(fimg.Header.Magic[:]))
-	fmt.Println("Version: ", string(fimg.Header.Version[:]))
-	fmt.Println("Arch:    ", sif.GetGoArch(string(fimg.Header.Arch[:sif.HdrArchLen-1])))
-	fmt.Println("ID:      ", fimg.Header.ID)
-	fmt.Println("Ctime:   ", time.Unix(fimg.Header.Ctime, 0))
-	fmt.Println("Mtime:   ", time.Unix(fimg.Header.Mtime, 0))
-	fmt.Println("Dfree:   ", fimg.Header.Dfree)
-	fmt.Println("Dtotal:  ", fimg.Header.Dtotal)
-	fmt.Println("Descoff: ", fimg.Header.Descroff)
-	fmt.Println("Descrlen:", readableSize(uint64(fimg.Header.Descrlen)))
-	fmt.Println("Dataoff: ", fimg.Header.Dataoff)
-	fmt.Println("Datalen: ", readableSize(uint64(fimg.Header.Datalen)))
+	fmt.Print(fimg.FmtHeader())
 
 	return nil
-}
-
-// datatypeStr returns a string representation of a datatype
-func datatypeStr(dtype sif.Datatype) string {
-	switch dtype {
-	case sif.DataDeffile:
-		return "Def.FILE"
-	case sif.DataEnvVar:
-		return "Env.Vars"
-	case sif.DataLabels:
-		return "JSON.Labels"
-	case sif.DataPartition:
-		return "FS"
-	case sif.DataSignature:
-		return "Signature"
-	case sif.DataGenericJSON:
-		return "JSON.Generic"
-	}
-	return "Unknown data-type"
-}
-
-// fstypeStr returns a string representation of a file system type
-func fstypeStr(ftype sif.Fstype) string {
-	switch ftype {
-	case sif.FsSquash:
-		return "Squashfs"
-	case sif.FsExt3:
-		return "Ext3"
-	case sif.FsImmuObj:
-		return "Archive"
-	case sif.FsRaw:
-		return "Raw"
-	}
-	return "Unknown fs-type"
-}
-
-// parttypeStr returns a string representation of a partition type
-func parttypeStr(ptype sif.Parttype) string {
-	switch ptype {
-	case sif.PartSystem:
-		return "System"
-	case sif.PartPrimSys:
-		return "*System"
-	case sif.PartData:
-		return "Data"
-	case sif.PartOverlay:
-		return "Overlay"
-	}
-	return "Unknown part-type"
-}
-
-// hashtypeStr returns a string representation of a  hash type
-func hashtypeStr(htype sif.Hashtype) string {
-	switch htype {
-	case sif.HashSHA256:
-		return "SHA256"
-	case sif.HashSHA384:
-		return "SHA384"
-	case sif.HashSHA512:
-		return "SHA512"
-	case sif.HashBLAKE2S:
-		return "BLAKE2S"
-	case sif.HashBLAKE2B:
-		return "BLAKE2B"
-	}
-	return "Unknown hash-type"
 }
 
 // cmdList displays a list of all active descriptors from a SIF file to stdout
@@ -155,43 +50,7 @@ func cmdList(args []string) error {
 
 	fmt.Println("Descriptor list:")
 
-	fmt.Printf("%-4s %-8s %-8s %-26s %s\n", "ID", "|GROUP", "|LINK", "|SIF POSITION (start-end)", "|TYPE")
-	fmt.Println("------------------------------------------------------------------------------")
-
-	for _, v := range fimg.DescrArr {
-		if v.Used == false {
-			continue
-		} else {
-			fmt.Printf("%-4d ", v.ID)
-			if v.Groupid == sif.DescrUnusedGroup {
-				fmt.Printf("|%-7s ", "NONE")
-			} else {
-				fmt.Printf("|%-7d ", v.Groupid&^sif.DescrGroupMask)
-			}
-			if v.Link == sif.DescrUnusedLink {
-				fmt.Printf("|%-7s ", "NONE")
-			} else {
-				fmt.Printf("|%-7d ", v.Link)
-			}
-
-			fposbuf := fmt.Sprintf("|%d-%d ", v.Fileoff, v.Fileoff+v.Filelen)
-			fmt.Printf("%-26s ", fposbuf)
-
-			switch v.Datatype {
-			case sif.DataPartition:
-				f, _ := v.GetFsType()
-				p, _ := v.GetPartType()
-				a, _ := v.GetArch()
-				fmt.Printf("|%s (%s/%s/%s)", datatypeStr(v.Datatype), fstypeStr(f), parttypeStr(p), sif.GetGoArch(string(a[:sif.HdrArchLen-1])))
-			case sif.DataSignature:
-				h, _ := v.GetHashType()
-				fmt.Printf("|%s (%s)", datatypeStr(v.Datatype), hashtypeStr(h))
-			default:
-				fmt.Printf("|%s", datatypeStr(v.Datatype))
-			}
-			fmt.Println("")
-		}
-	}
+	fmt.Print(fimg.FmtDescrList())
 
 	return nil
 }
@@ -213,51 +72,9 @@ func cmdInfo(args []string) error {
 	}
 	defer fimg.UnloadContainer()
 
-	for i, v := range fimg.DescrArr {
-		if v.Used == false {
-			continue
-		} else if v.ID == uint32(id) {
-			fmt.Println("Descr slot#:", i)
-			fmt.Println("  Datatype: ", datatypeStr(v.Datatype))
-			fmt.Println("  ID:       ", v.ID)
-			fmt.Println("  Used:     ", v.Used)
-			if v.Groupid == sif.DescrUnusedGroup {
-				fmt.Println("  Groupid:  ", "NONE")
-			} else {
-				fmt.Println("  Groupid:  ", v.Groupid&^sif.DescrGroupMask)
-			}
-			if v.Link == sif.DescrUnusedLink {
-				fmt.Println("  Link:     ", "NONE")
-			} else {
-				fmt.Println("  Link:     ", v.Link)
-			}
-			fmt.Println("  Fileoff:  ", v.Fileoff)
-			fmt.Println("  Filelen:  ", v.Filelen)
-			fmt.Println("  Ctime:    ", time.Unix(v.Ctime, 0))
-			fmt.Println("  Mtime:    ", time.Unix(v.Mtime, 0))
-			fmt.Println("  UID:      ", v.UID)
-			fmt.Println("  Gid:      ", v.Gid)
-			fmt.Println("  Name:     ", string(v.Name[:]))
-			switch v.Datatype {
-			case sif.DataPartition:
-				f, _ := v.GetFsType()
-				p, _ := v.GetPartType()
-				a, _ := v.GetArch()
-				fmt.Println("  Fstype:   ", fstypeStr(f))
-				fmt.Println("  Parttype: ", parttypeStr(p))
-				fmt.Println("  Arch:     ", sif.GetGoArch(string(a[:sif.HdrArchLen-1])))
-			case sif.DataSignature:
-				h, _ := v.GetHashType()
-				e, _ := v.GetEntityString()
-				fmt.Println("  Hashtype: ", hashtypeStr(h))
-				fmt.Println("  Entity:   ", e)
-			}
+	fmt.Print(fimg.FmtDescrInfo(uint32(id)))
 
-			return nil
-		}
-	}
-
-	return fmt.Errorf("descriptor not in range or currently unused")
+	return nil
 }
 
 // cmdDump extracts and output a data object from a SIF file to stdout

--- a/pkg/sif/fmt.go
+++ b/pkg/sif/fmt.go
@@ -1,0 +1,216 @@
+// Copyright (c) 2018, Divya Cote <divya.cote@gmail.com> All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package sif
+
+import (
+	"fmt"
+	"time"
+)
+
+// readableSize returns the size in human readable format
+func readableSize(size uint64) string {
+	var divs int
+	var conversion string
+
+	for ; size != 0; size >>= 10 {
+		if size < 1024 {
+			break
+		}
+		divs++
+	}
+
+	switch divs {
+	case 0:
+		conversion = fmt.Sprintf("%d", size)
+	case 1:
+		conversion = fmt.Sprintf("%dKB", size)
+	case 2:
+		conversion = fmt.Sprintf("%dMB", size)
+	case 3:
+		conversion = fmt.Sprintf("%dGB", size)
+	case 4:
+		conversion = fmt.Sprintf("%dTB", size)
+	}
+	return conversion
+}
+
+// FmtHeader formats the output of a SIF file global header
+func (fimg *FileImage) FmtHeader() string {
+	s := fmt.Sprintln("Launch:  ", string(fimg.Header.Launch[:]))
+	s += fmt.Sprintln("Magic:   ", string(fimg.Header.Magic[:]))
+	s += fmt.Sprintln("Version: ", string(fimg.Header.Version[:]))
+	s += fmt.Sprintln("Arch:    ", GetGoArch(string(fimg.Header.Arch[:HdrArchLen-1])))
+	s += fmt.Sprintln("ID:      ", fimg.Header.ID)
+	s += fmt.Sprintln("Ctime:   ", time.Unix(fimg.Header.Ctime, 0))
+	s += fmt.Sprintln("Mtime:   ", time.Unix(fimg.Header.Mtime, 0))
+	s += fmt.Sprintln("Dfree:   ", fimg.Header.Dfree)
+	s += fmt.Sprintln("Dtotal:  ", fimg.Header.Dtotal)
+	s += fmt.Sprintln("Descoff: ", fimg.Header.Descroff)
+	s += fmt.Sprintln("Descrlen:", readableSize(uint64(fimg.Header.Descrlen)))
+	s += fmt.Sprintln("Dataoff: ", fimg.Header.Dataoff)
+	s += fmt.Sprintln("Datalen: ", readableSize(uint64(fimg.Header.Datalen)))
+
+	return s
+}
+
+// datatypeStr returns a string representation of a datatype
+func datatypeStr(dtype Datatype) string {
+	switch dtype {
+	case DataDeffile:
+		return "Def.FILE"
+	case DataEnvVar:
+		return "Env.Vars"
+	case DataLabels:
+		return "JSON.Labels"
+	case DataPartition:
+		return "FS"
+	case DataSignature:
+		return "Signature"
+	case DataGenericJSON:
+		return "JSON.Generic"
+	}
+	return "Unknown data-type"
+}
+
+// fstypeStr returns a string representation of a file system type
+func fstypeStr(ftype Fstype) string {
+	switch ftype {
+	case FsSquash:
+		return "Squashfs"
+	case FsExt3:
+		return "Ext3"
+	case FsImmuObj:
+		return "Archive"
+	case FsRaw:
+		return "Raw"
+	}
+	return "Unknown fs-type"
+}
+
+// parttypeStr returns a string representation of a partition type
+func parttypeStr(ptype Parttype) string {
+	switch ptype {
+	case PartSystem:
+		return "System"
+	case PartPrimSys:
+		return "*System"
+	case PartData:
+		return "Data"
+	case PartOverlay:
+		return "Overlay"
+	}
+	return "Unknown part-type"
+}
+
+// hashtypeStr returns a string representation of a  hash type
+func hashtypeStr(htype Hashtype) string {
+	switch htype {
+	case HashSHA256:
+		return "SHA256"
+	case HashSHA384:
+		return "SHA384"
+	case HashSHA512:
+		return "SHA512"
+	case HashBLAKE2S:
+		return "BLAKE2S"
+	case HashBLAKE2B:
+		return "BLAKE2B"
+	}
+	return "Unknown hash-type"
+}
+
+// FmtDescrList formats the output of a list of all active descriptors from a SIF file
+func (fimg *FileImage) FmtDescrList() string {
+	s := fmt.Sprintf("%-4s %-8s %-8s %-26s %s\n", "ID", "|GROUP", "|LINK", "|SIF POSITION (start-end)", "|TYPE")
+	s += fmt.Sprintln("------------------------------------------------------------------------------")
+
+	for _, v := range fimg.DescrArr {
+		if v.Used == false {
+			continue
+		} else {
+			s += fmt.Sprintf("%-4d ", v.ID)
+			if v.Groupid == DescrUnusedGroup {
+				s += fmt.Sprintf("|%-7s ", "NONE")
+			} else {
+				s += fmt.Sprintf("|%-7d ", v.Groupid&^DescrGroupMask)
+			}
+			if v.Link == DescrUnusedLink {
+				s += fmt.Sprintf("|%-7s ", "NONE")
+			} else {
+				s += fmt.Sprintf("|%-7d ", v.Link)
+			}
+
+			fposbuf := fmt.Sprintf("|%d-%d ", v.Fileoff, v.Fileoff+v.Filelen)
+			s += fmt.Sprintf("%-26s ", fposbuf)
+
+			switch v.Datatype {
+			case DataPartition:
+				f, _ := v.GetFsType()
+				p, _ := v.GetPartType()
+				a, _ := v.GetArch()
+				s += fmt.Sprintf("|%s (%s/%s/%s)\n", datatypeStr(v.Datatype), fstypeStr(f), parttypeStr(p), GetGoArch(string(a[:HdrArchLen-1])))
+			case DataSignature:
+				h, _ := v.GetHashType()
+				s += fmt.Sprintf("|%s (%s)\n", datatypeStr(v.Datatype), hashtypeStr(h))
+			default:
+				s += fmt.Sprintf("|%s\n", datatypeStr(v.Datatype))
+			}
+		}
+	}
+
+	return s
+}
+
+// FmtDescrInfo formats the ouput of detailed info about a descriptor from a SIF file
+func (fimg *FileImage) FmtDescrInfo(id uint32) string {
+	var s string
+
+	for i, v := range fimg.DescrArr {
+		if v.Used == false {
+			continue
+		} else if v.ID == uint32(id) {
+			s = fmt.Sprintln("Descr slot#:", i)
+			s += fmt.Sprintln("  Datatype: ", datatypeStr(v.Datatype))
+			s += fmt.Sprintln("  ID:       ", v.ID)
+			s += fmt.Sprintln("  Used:     ", v.Used)
+			if v.Groupid == DescrUnusedGroup {
+				s += fmt.Sprintln("  Groupid:  ", "NONE")
+			} else {
+				s += fmt.Sprintln("  Groupid:  ", v.Groupid&^DescrGroupMask)
+			}
+			if v.Link == DescrUnusedLink {
+				s += fmt.Sprintln("  Link:     ", "NONE")
+			} else {
+				s += fmt.Sprintln("  Link:     ", v.Link)
+			}
+			s += fmt.Sprintln("  Fileoff:  ", v.Fileoff)
+			s += fmt.Sprintln("  Filelen:  ", v.Filelen)
+			s += fmt.Sprintln("  Ctime:    ", time.Unix(v.Ctime, 0))
+			s += fmt.Sprintln("  Mtime:    ", time.Unix(v.Mtime, 0))
+			s += fmt.Sprintln("  UID:      ", v.UID)
+			s += fmt.Sprintln("  Gid:      ", v.Gid)
+			s += fmt.Sprintln("  Name:     ", string(v.Name[:]))
+			switch v.Datatype {
+			case DataPartition:
+				f, _ := v.GetFsType()
+				p, _ := v.GetPartType()
+				a, _ := v.GetArch()
+				s += fmt.Sprintln("  Fstype:   ", fstypeStr(f))
+				s += fmt.Sprintln("  Parttype: ", parttypeStr(p))
+				s += fmt.Sprintln("  Arch:     ", GetGoArch(string(a[:HdrArchLen-1])))
+			case DataSignature:
+				h, _ := v.GetHashType()
+				e, _ := v.GetEntityString()
+				s += fmt.Sprintln("  Hashtype: ", hashtypeStr(h))
+				s += fmt.Sprint("  Entity:   ", e)
+			}
+
+			return s
+		}
+	}
+
+	return ""
+}

--- a/pkg/sif/fmt_test.go
+++ b/pkg/sif/fmt_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package sif
+
+import (
+	"testing"
+)
+
+func TestFmtHeader(t *testing.T) {
+	fimg, err := LoadContainer("testdata/testcontainer2.sif", true)
+	if err != nil {
+		t.Error(`LoadContainer("testdata/testcontainer2.sif", true):`, err)
+	}
+	defer fimg.UnloadContainer()
+
+	t.Log(fimg.FmtHeader())
+}
+
+func TestFmtDescrList(t *testing.T) {
+	fimg, err := LoadContainer("testdata/testcontainer2.sif", true)
+	if err != nil {
+		t.Error(`LoadContainer("testdata/testcontainer2.sif", true):`, err)
+	}
+	defer fimg.UnloadContainer()
+
+	t.Log(fimg.FmtDescrList())
+}
+
+func TestFmtDescrInfo(t *testing.T) {
+	fimg, err := LoadContainer("testdata/testcontainer2.sif", true)
+	if err != nil {
+		t.Error(`LoadContainer("testdata/testcontainer2.sif", true):`, err)
+	}
+	defer fimg.UnloadContainer()
+
+	t.Log(fimg.FmtDescrInfo(1))
+	t.Log(fimg.FmtDescrInfo(2))
+	t.Log(fimg.FmtDescrInfo(3))
+	t.Log(fimg.FmtDescrInfo(4))
+}

--- a/pkg/sif/lookup.go
+++ b/pkg/sif/lookup.go
@@ -19,25 +19,6 @@ import (
 // Methods on (fimg *FIleImage)
 //
 
-// OutputHeader generates a string which displays each fields of the global Header
-func (fimg *FileImage) OutputHeader() string {
-	str := fmt.Sprintf("%s %s\n%s %s\n%s %s\n%s %s\n%s %v\n%s %s\n%s %s\n%s %d\n%s %d\n%s %d\n%s %d\n%s %d\n%s %d",
-		"Launch:  ", string(fimg.Header.Launch[:]),
-		"Magic:   ", string(fimg.Header.Magic[:]),
-		"Version: ", string(fimg.Header.Version[:]),
-		"Arch:    ", string(fimg.Header.Arch[:]),
-		"ID:      ", fimg.Header.ID,
-		"Ctime:   ", time.Unix(fimg.Header.Ctime, 0),
-		"Mtime:   ", time.Unix(fimg.Header.Mtime, 0),
-		"Dfree:   ", fimg.Header.Dfree,
-		"Dtotal:  ", fimg.Header.Dtotal,
-		"Descoff: ", fimg.Header.Descroff,
-		"Descrlen:", fimg.Header.Descrlen,
-		"Dataoff: ", fimg.Header.Dataoff,
-		"Datalen: ", fimg.Header.Datalen)
-	return str
-}
-
 // GetSIFArch returns the SIF arch code from go runtime arch code
 func GetSIFArch(goarch string) (sifarch string) {
 	var ok bool
@@ -253,25 +234,6 @@ func (fimg *FileImage) GetFromDescr(descr Descriptor) ([]*Descriptor, []int, err
 //
 // Methods on (descr *Descriptor)
 //
-
-// OutputDescriptor generates a string which displays each fields of a descriptor
-func (descr *Descriptor) OutputDescriptor() string {
-	str := fmt.Sprintf("%s 0x%x\n%s %v\n%s %v\n%s 0x%x\n%s %d\n%s %d\n%s %d\n%s %s\n%s %s\n%s %d\n%s %d\n%s %s\n%s %v",
-		"Datatype:", descr.Datatype,
-		"ID:      ", descr.ID,
-		"Used:    ", descr.Used,
-		"Groupid: ", descr.Groupid,
-		"Link:    ", descr.Link,
-		"Fileoff: ", descr.Fileoff,
-		"Filelen: ", descr.Filelen,
-		"Ctime:   ", time.Unix(descr.Ctime, 0),
-		"Mtime:   ", time.Unix(descr.Mtime, 0),
-		"UID:     ", descr.UID,
-		"Gid:     ", descr.Gid,
-		"Name:    ", string(descr.Name[:]),
-		"Extra: ", descr.Extra)
-	return str
-}
 
 // GetName returns the name tag associated with the descriptor. Analogous to file name.
 func (descr *Descriptor) GetName() string {

--- a/pkg/sif/lookup.go
+++ b/pkg/sif/lookup.go
@@ -12,7 +12,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"strings"
-	"time"
 )
 
 //


### PR DESCRIPTION
Formatting the output of the global header, the descriptor list and the
descriptor info is now done in the sif package for general use instead of
being found in the siftool directly.