### PR TITLE
Add interface to express operations to perform on SIF file handles

### DIFF
--- a/pkg/sif/load_test.go
+++ b/pkg/sif/load_test.go
@@ -7,9 +7,11 @@ package sif
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 )
 
 func TestLoadContainer(t *testing.T) {
@@ -27,6 +29,165 @@ func TestLoadContainerFp(t *testing.T) {
 	fp, err := os.Open("testdata/testcontainer2.sif")
 	if err != nil {
 		t.Error("error opening testdata/testcontainer2.sif:", err)
+	}
+
+	fimg, err := LoadContainerFp(fp, true)
+	if err != nil {
+		t.Error("LoadContainerFp(fp, true):", err)
+	}
+
+	if err = fimg.UnloadContainer(); err != nil {
+		t.Error("fimg.UnloadContainer():", err)
+	}
+}
+
+type mockFileInfo struct {
+	name string
+	size int64
+	time time.Time
+}
+
+func (m *mockFileInfo) Name() string {
+	return m.name
+}
+
+func (m *mockFileInfo) Size() int64 {
+	return m.size
+}
+
+func (m *mockFileInfo) Mode() os.FileMode {
+	return 0644
+}
+
+func (m *mockFileInfo) ModTime() time.Time {
+	return m.time
+}
+
+func (m *mockFileInfo) IsDir() bool {
+	return false
+}
+
+func (m *mockFileInfo) Sys() interface{} {
+	return nil
+}
+
+type mockSifReadWriter struct {
+	buf    []byte
+	name   string
+	pos    int64
+	closed bool
+}
+
+func (m *mockSifReadWriter) Name() string {
+	return m.name
+}
+
+func (m *mockSifReadWriter) Close() error {
+	m.closed = true
+	return nil
+}
+
+func (m *mockSifReadWriter) Fd() uintptr {
+	return ^uintptr(0)
+}
+
+func (m *mockSifReadWriter) Read(b []byte) (n int, err error) {
+	if m.closed {
+		return 0, os.ErrInvalid
+	}
+
+	if m.pos >= int64(len(m.buf)) {
+		return 0, io.EOF
+	}
+
+	n = copy(b, m.buf[m.pos:])
+
+	m.pos += int64(n)
+
+	return n, err
+}
+
+func (m *mockSifReadWriter) Seek(offset int64, whence int) (ret int64, err error) {
+	if m.closed {
+		return 0, os.ErrInvalid
+	}
+
+	sz := int64(len(m.buf))
+
+	switch whence {
+	case 0:
+		ret = offset
+
+	case 1:
+		ret = offset + m.pos
+
+	case 2:
+		ret = offset + sz
+
+	default:
+		return 0, os.ErrInvalid
+	}
+
+	if ret < 0 {
+		ret = 0
+	} else if ret > sz {
+		ret = sz
+	}
+
+	m.pos = ret
+
+	return ret, err
+}
+
+func (m *mockSifReadWriter) Stat() (os.FileInfo, error) {
+	return &mockFileInfo{name: m.name, size: int64(len(m.buf)), time: time.Unix(0, 0)}, nil
+}
+
+func (m *mockSifReadWriter) Sync() error {
+	return nil
+}
+
+func (m *mockSifReadWriter) Truncate(size int64) error {
+	m.pos = 0
+	return nil
+}
+
+func (m *mockSifReadWriter) Write(b []byte) (n int, err error) {
+	if m.closed {
+		return 0, os.ErrInvalid
+	}
+
+	if len(b) > cap(m.buf[m.pos:]) {
+		buf := make([]byte, 0, m.pos+int64(len(b)))
+		copy(buf, m.buf)
+		m.buf = buf
+	}
+
+	n = copy(m.buf[m.pos:], b)
+
+	m.pos += int64(n)
+
+	return n, err
+}
+
+func TestLoadContainerFpMock(t *testing.T) {
+	// This test is using mockSifReadWriter to verify that the code
+	// is not making assumptions regading the behavior of the
+	// ReadWriter it's getting, as mockSifReadWriter implements a
+	// very dumb buffer. This specific test could be exteded to test
+	// for more error conditions as it would be possible to report
+	// errors from cases where it would be otherwise hard to do so
+	// (e.g. Seek, Read, Sync or Truncate reporting errors).
+
+	// Load a valid SIF file to test the happy path.
+	content, err := ioutil.ReadFile("testdata/testcontainer2.sif")
+	if err != nil {
+		t.Error(`ioutil.ReadFile("testdata/testcontainer2.sif"):`, err)
+	}
+
+	fp := &mockSifReadWriter{
+		buf:  content,
+		name: "mockSifReadWriter",
 	}
 
 	fimg, err := LoadContainerFp(fp, true)

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -18,8 +18,9 @@ package sif
 
 import (
 	"bytes"
-	"github.com/satori/go.uuid"
 	"os"
+
+	uuid "github.com/satori/go.uuid"
 )
 
 // Layout of a SIF file (example)
@@ -254,10 +255,24 @@ type Header struct {
 // SIF file. Those data structures are internal.
 //
 
+// ReadWriter describes the operations needed to support reading and
+// writing SIF files
+type ReadWriter interface {
+	Name() string
+	Close() error
+	Fd() uintptr
+	Read(b []byte) (n int, err error)
+	Seek(offset int64, whence int) (ret int64, err error)
+	Stat() (os.FileInfo, error)
+	Sync() error
+	Truncate(size int64) error
+	Write(b []byte) (n int, err error)
+}
+
 // FileImage describes the representation of a SIF file in memory
 type FileImage struct {
 	Header     Header        // the loaded SIF global header
-	Fp         *os.File      // file pointer of opened SIF file
+	Fp         ReadWriter    // file pointer of opened SIF file
 	Filesize   int64         // file size of the opened SIF file
 	Filedata   []byte        // the content of the opened file
 	Amodebuf   bool          // access mode: mmap = false, buffered = true


### PR DESCRIPTION
The SifReadWriter expresses the operations required to support reading
and writing SIF files. This facilitates testing other code using the sif
package without having to create actual files in the filesystem.

Remove some code redundancy by having LoadContainer call LoadContainerFp
for the common code.

Add a test that exercises the load logic using a mock to validate that
the code is working only thru the SifReadWriter interface.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>