### PR TITLE
Revert HdrVersion to "01"

### DIFF
--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -91,7 +91,7 @@ import (
 const (
 	HdrLaunch       = "#!/usr/bin/env run-singularity\n"
 	HdrMagic        = "SIF_MAGIC" // SIF identification
-	HdrVersion      = "02"        // SIF SPEC VERSION
+	HdrVersion      = "01"        // SIF SPEC VERSION
 	HdrArchUnknown  = "00"        // Undefined/Unsupported arch
 	HdrArch386      = "01"        // 386 (i[3-6]86) arch code
 	HdrArchAMD64    = "02"        // AMD64 arch code


### PR DESCRIPTION
In f68560db HdrVersion was changed to "02" to account for the
introduction of the "data generic" datatype.

Since the binary layout of the header is not actually changing, only the
value stored in one of the fields, revert HdrVersion to "01". Tools like
singularity and siftool will simply report an unknown datatype if they
run into an image with this type of content. They will still be able to
deal with it (at least at a high level).

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>