### PR TITLE
Handle C strings more consistently

### DIFF
--- a/pkg/sif/fmt.go
+++ b/pkg/sif/fmt.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
 // Copyright (c) 2018, Divya Cote <divya.cote@gmail.com> All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
@@ -39,10 +40,10 @@ func readableSize(size uint64) string {
 
 // FmtHeader formats the output of a SIF file global header
 func (fimg *FileImage) FmtHeader() string {
-	s := fmt.Sprintln("Launch:  ", string(fimg.Header.Launch[:]))
-	s += fmt.Sprintln("Magic:   ", string(fimg.Header.Magic[:]))
-	s += fmt.Sprintln("Version: ", string(fimg.Header.Version[:]))
-	s += fmt.Sprintln("Arch:    ", GetGoArch(string(fimg.Header.Arch[:HdrArchLen-1])))
+	s := fmt.Sprintln("Launch:  ", cstrToString(fimg.Header.Launch[:]))
+	s += fmt.Sprintln("Magic:   ", cstrToString(fimg.Header.Magic[:]))
+	s += fmt.Sprintln("Version: ", cstrToString(fimg.Header.Version[:]))
+	s += fmt.Sprintln("Arch:    ", GetGoArch(cstrToString(fimg.Header.Arch[:])))
 	s += fmt.Sprintln("ID:      ", fimg.Header.ID)
 	s += fmt.Sprintln("Ctime:   ", time.Unix(fimg.Header.Ctime, 0))
 	s += fmt.Sprintln("Mtime:   ", time.Unix(fimg.Header.Mtime, 0))
@@ -157,7 +158,7 @@ func (fimg *FileImage) FmtDescrList() string {
 				f, _ := v.GetFsType()
 				p, _ := v.GetPartType()
 				a, _ := v.GetArch()
-				s += fmt.Sprintf("|%s (%s/%s/%s)\n", datatypeStr(v.Datatype), fstypeStr(f), parttypeStr(p), GetGoArch(string(a[:HdrArchLen-1])))
+				s += fmt.Sprintf("|%s (%s/%s/%s)\n", datatypeStr(v.Datatype), fstypeStr(f), parttypeStr(p), GetGoArch(cstrToString(a[:])))
 			case DataSignature:
 				h, _ := v.GetHashType()
 				s += fmt.Sprintf("|%s (%s)\n", datatypeStr(v.Datatype), hashtypeStr(h))
@@ -210,7 +211,7 @@ func (fimg *FileImage) FmtDescrInfo(id uint32) string {
 				a, _ := v.GetArch()
 				s += fmt.Sprintln("  Fstype:   ", fstypeStr(f))
 				s += fmt.Sprintln("  Parttype: ", parttypeStr(p))
-				s += fmt.Sprintln("  Arch:     ", GetGoArch(string(a[:HdrArchLen-1])))
+				s += fmt.Sprintln("  Arch:     ", GetGoArch(cstrToString(a[:])))
 			case DataSignature:
 				h, _ := v.GetHashType()
 				e, _ := v.GetEntityString()

--- a/pkg/sif/load.go
+++ b/pkg/sif/load.go
@@ -51,10 +51,10 @@ func readDescriptors(fimg *FileImage) error {
 // `runnable' checks is current container can run on host.
 func isValidSif(fimg *FileImage) error {
 	// check various header fields
-	if string(fimg.Header.Magic[:HdrMagicLen-1]) != HdrMagic {
+	if cstrToString(fimg.Header.Magic[:]) != HdrMagic {
 		return fmt.Errorf("invalid SIF file: Magic |%s| want |%s|", fimg.Header.Magic, HdrMagic)
 	}
-	if string(fimg.Header.Version[:HdrVersionLen-1]) > HdrVersion {
+	if cstrToString(fimg.Header.Version[:]) > HdrVersion {
 		return fmt.Errorf("invalid SIF file: Version %s want <= %s", fimg.Header.Version, HdrVersion)
 	}
 
@@ -206,4 +206,12 @@ func (fimg *FileImage) UnloadContainer() (err error) {
 		}
 	}
 	return
+}
+
+func cstrToString(str []byte) string {
+	n := len(str)
+	if m := n - 1; str[m] == 0 {
+		n = m
+	}
+	return string(str[:n])
 }

--- a/pkg/sif/lookup_test.go
+++ b/pkg/sif/lookup_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -332,7 +332,7 @@ func TestGetArch(t *testing.T) {
 		t.Error("parts[0].GetArch()", err)
 	}
 
-	if string(arch[:HdrArchLen-1]) != HdrArchAMD64 {
+	if cstrToString(arch[:]) != HdrArchAMD64 {
 		t.Logf("|%s|%s|\n", arch[:HdrArchLen-1], HdrArchAMD64)
 		t.Error("part.GetArch() should have returned 'HdrArchAMD64':", err)
 	}


### PR DESCRIPTION
The SIF binary contains C strings (bytes terminated by \000) and there
are not handled consistently when they are output.

Since there's nothing in the actual code that is doing this (other than
having an array initialized to zeroes and not writing anything to the
last element), be a little bit lenient when loading data from the file:
examine the last byte and if it's \000, ignore it.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>