### PR TITLE
Clean up init.go, rename to log.go

### DIFF
--- a/pkg/sif/log.go
+++ b/pkg/sif/log.go
@@ -16,6 +16,3 @@ var (
 	sifLoggerBuf bytes.Buffer
 	siflog       = log.New(&sifLoggerBuf, "", log.Ldate|log.Ltime|log.Lshortfile)
 )
-
-func init() {
-}


### PR DESCRIPTION
Remove the empty init function and rename the file to log.go, since all
it contains is logging functionality.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>