### PR TITLE
Badges and Associated Fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,20 @@ jobs:
           name: Check for Lint
           command: golangci-lint run ./...
 
+  lint_markdown:
+    <<: *defaults
+    docker:
+      - image: node:11
+    steps:
+      - attach_workspace:
+          at: /
+      - run:
+          name: Install markdownlint
+          command: npm install -g markdownlint-cli
+      - run:
+          name: Check for Lint
+          command: markdownlint -i vendor .
+
   unit_test:
     <<: *defaults
     steps:
@@ -122,6 +136,9 @@ workflows:
           requires:
             - get_source
       - lint_source:
+          requires:
+            - get_source
+      - lint_markdown:
           requires:
             - get_source
       - unit_test:

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+    "default": true,
+    "MD013": false
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,7 @@ works, incorporate into other computer software, distribute, and sublicense
 such enhancements or derivative works thereof, in binary and source code
 form.
 
-
-# Contributing
+## Contributing
 
 When contributing to SIF, it is important to properly communicate the
 gist of the contribution. If it is a simple code or editorial fix, simply
@@ -23,9 +22,10 @@ with the project leader or developers.
 Please note we have a code of conduct, described below. Please follow it in
 all your interactions with the project members and users.
 
-## Pull Requests (PRs)
+### Pull Requests (PRs)
 
-### Process
+#### Process
+
 1. Essential bug fix PRs should be sent to both master and release branches.
 2. Small bug fix and feature enhancement PRs should be sent to master only.
 3. Follow the existing code style precedent, especially for C. For Golang, you
@@ -45,7 +45,8 @@ all your interactions with the project members and users.
    requirements are met.
 10. Documentation must be provided if necessary (next section)
 
-### Documentation
+#### Documentation
+
 1. If you are changing any of the following:
 
    - renamed commands
@@ -55,9 +56,9 @@ all your interactions with the project members and users.
    - migration guidance (how to convert images?)
    - changed behaviour (recipe sections work differently)
 
-# Code of Conduct
+## Code of Conduct
 
-## Our Pledge
+### Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
@@ -66,29 +67,29 @@ size, disability, ethnicity, gender identity and expression, level of experience
 nationality, personal appearance, race, religion, or sexual identity and
 orientation.
 
-## Our Standards
+### Our Standards
 
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
+- The use of sexualized language or imagery and unwelcome sexual attention or
   advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
   address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
-### Our Responsibilities
+#### Our Responsibilities
 
 Project maintainers are responsible for clarifying the standards of acceptable
 behavior and are expected to take appropriate and fair corrective action in
@@ -100,7 +101,7 @@ that are not aligned to this Code of Conduct, or to ban temporarily or
 permanently any contributor for other behaviors that they deem inappropriate,
 threatening, offensive, or harmful.
 
-## Scope
+### Scope
 
 This Code of Conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community. Examples of
@@ -109,7 +110,7 @@ address, posting via an official social media account, or acting as an appointed
 representative at an online or offline event. Representation of a project may be
 further defined and clarified by project maintainers.
 
-## Enforcement
+### Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the project leaders (info@sylabs.io). All
@@ -120,10 +121,10 @@ an incident. Further details of specific enforcement policies may be posted
 separately.
 
 Project maintainers, contributors and users who do not follow or enforce the
-Code of Conduct in good faith may face temporary or permanent repercussions 
+Code of Conduct in good faith may face temporary or permanent repercussions
 with their involvement in the project as determined by the project's leader(s).
 
-## Attribution
+### Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
 available at [http://contributor-covenant.org/version/1/4][version]

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,5 @@
+# LICENSE
+
 Copyright (c) 2018, Sylabs Inc. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -13,22 +13,22 @@ stored in a single file.
 Unless otherwise noted, the SIF source files are distributed under the BSD-style
 license found in the LICENSE.md file.
 
-### Download and Install From Source
+## Download and Install From Source
 
 To get the sif package to use directly from your programs:
 
-```Shell Session
-$ go get -u github.com/sylabs/sif/pkg/sif
+```sh
+go get -u github.com/sylabs/sif/pkg/sif
 ```
 
 To get the siftool CLI program installed to $GOPATH/bin to manipulate SIF container files:
 
-```Shell Session
-$ mkdir -p $GOPATH/src/github.com/sylabs
-$ cd $GOPATH/src/github.com/sylabs
-$ git clone https://github.com/sylabs/sif
-$ cd sif
-$ ./build.sh
+```sh
+mkdir -p $GOPATH/src/github.com/sylabs
+cd $GOPATH/src/github.com/sylabs
+git clone https://github.com/sylabs/sif
+cd sif
+./build.sh
 ```
 
 ### Contributing
@@ -36,4 +36,4 @@ $ ./build.sh
 SIF and Singularity is the work of many contributors. We appreciate your help!
 
 To contribute, please read the contribution guidelines:
-	[CONTRIBUTING.md](./CONTRIBUTING.md)
+    [CONTRIBUTING.md](./CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![GoDoc](https://godoc.org/github.com/sylabs/sif?status.svg)](https://godoc.org/github.com/sylabs/sif)
 <a href="https://circleci.com/gh/sylabs/sif"><img src="https://circleci.com/gh/sylabs/sif.svg?style=shield&circle-token=7e762a71efecb4da6cd6981e90cf4cc9c5e4291e"/></a>
+[![Go Report Card](https://goreportcard.com/badge/github.com/sylabs/sif)](https://goreportcard.com/report/github.com/sylabs/sif)
 
 SIF is an open source implementation of the Singularity Container Image Format
 that makes it easy to create complete and encapsulated container enviroments

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # The Singularity Image Format (SIF)
 
 <a href="https://circleci.com/gh/sylabs/sif"><img src="https://circleci.com/gh/sylabs/sif.svg?style=shield&circle-token=7e762a71efecb4da6cd6981e90cf4cc9c5e4291e"/></a>
-<a href="https://app.zenhub.com/workspace/o/sylabs/sif/boards"><img src="https://raw.githubusercontent.com/ZenHubIO/support/master/zenhub-badge.png"></a>
 
 SIF is an open source implementation of the Singularity Container Image Format
 that makes it easy to create complete and encapsulated container enviroments

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # The Singularity Image Format (SIF)
 
+[![GoDoc](https://godoc.org/github.com/sylabs/sif?status.svg)](https://godoc.org/github.com/sylabs/sif)
 <a href="https://circleci.com/gh/sylabs/sif"><img src="https://circleci.com/gh/sylabs/sif.svg?style=shield&circle-token=7e762a71efecb4da6cd6981e90cf4cc9c5e4291e"/></a>
 
 SIF is an open source implementation of the Singularity Container Image Format

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # The Singularity Image Format (SIF)
 
 [![GoDoc](https://godoc.org/github.com/sylabs/sif?status.svg)](https://godoc.org/github.com/sylabs/sif)
-<a href="https://circleci.com/gh/sylabs/sif"><img src="https://circleci.com/gh/sylabs/sif.svg?style=shield&circle-token=7e762a71efecb4da6cd6981e90cf4cc9c5e4291e"/></a>
+[![Build Status](https://circleci.com/gh/sylabs/sif.svg?style=shield)](https://circleci.com/gh/sylabs/workflows/sif)
 [![Go Report Card](https://goreportcard.com/badge/github.com/sylabs/sif)](https://goreportcard.com/report/github.com/sylabs/sif)
 
 SIF is an open source implementation of the Singularity Container Image Format

--- a/pkg/sif/create.go
+++ b/pkg/sif/create.go
@@ -378,7 +378,7 @@ func compactAtDescr(fimg *FileImage, descr *Descriptor) error {
 }
 
 // DeleteObject removes data from a SIF file referred to by id. The descriptor for the
-// data object is free'd and can be reused later. There's currenly 2 clean mode specified
+// data object is free'd and can be reused later. There's currently 2 clean mode specified
 // by flags: DelZero, to zero out the data region for security and DelCompact to
 // remove and shink the file compacting the unused area.
 func (fimg *FileImage) DeleteObject(id uint32, flags int) error {

--- a/pkg/sif/create_test.go
+++ b/pkg/sif/create_test.go
@@ -104,7 +104,7 @@ func TestCreateContainer(t *testing.T) {
 		Groupid:   DescrDefaultGroup,
 		Link:      DescrUnusedLink,
 		Fname:     "testdata/busybox.squash",
-		Alignment: 1048576, // Test an aggresive alignment requirement
+		Alignment: 1048576, // Test an aggressive alignment requirement
 	}
 	// open up the data object file for this descriptor
 	partHandle, err := os.Open(parinput.Fname)

--- a/pkg/sif/fmt.go
+++ b/pkg/sif/fmt.go
@@ -171,7 +171,7 @@ func (fimg *FileImage) FmtDescrList() string {
 	return s
 }
 
-// FmtDescrInfo formats the ouput of detailed info about a descriptor from a SIF file
+// FmtDescrInfo formats the output of detailed info about a descriptor from a SIF file
 func (fimg *FileImage) FmtDescrInfo(id uint32) string {
 	var s string
 

--- a/pkg/sif/lookup_test.go
+++ b/pkg/sif/lookup_test.go
@@ -144,7 +144,7 @@ func TestFromDescr(t *testing.T) {
 		t.Error("fimg.GetFromDescr(descr): should have found descriptor:", err)
 	}
 
-	// Simple lookup of a descriptor of type EnvVar (non-existant)
+	// Simple lookup of a descriptor of type EnvVar (non-existent)
 	descr = Descriptor{
 		Datatype: DataEnvVar,
 	}
@@ -153,7 +153,7 @@ func TestFromDescr(t *testing.T) {
 		t.Error("fimg.GetFromDescr(descr): should not have found descriptor:", err)
 	}
 
-	// Simple lookup of a descriptor of type Generic (non-existant)
+	// Simple lookup of a descriptor of type Generic (non-existent)
 	descr = Descriptor{
 		Datatype: DataGeneric,
 	}


### PR DESCRIPTION
Remove broken ZenHub badge. Add GoDoc and Go Report Card badges. Fix misspelled words. Add `markdownlint` in CI, and fix associated lint.