### PR TITLE
CI Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,10 +116,7 @@ jobs:
             - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Run Tests
-          command: go test -coverprofile cover.out -race -timeout 60s ./...
-      - store_artifacts:
-          path: cover.out
-          destination: cover.out
+          command: go test -cover -race -timeout 60s ./...
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,6 @@ jobs:
       - run:
           name: Populate Go Mod Cache
           command: go mod download
-      - run:
-          name: Go Mod Verify
-          command: go mod verify
       - save_cache:
           key: go-mod-{{ checksum "go.sum" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,20 @@ jobs:
           name: Run Tests
           command: go test -cover -race -timeout 60s ./...
 
-  get_source:
+  lint_markdown:
+    <<: *defaults
+    docker:
+      - image: node:11
+    steps:
+      - checkout
+      - run:
+          name: Install markdownlint
+          command: npm install -g markdownlint-cli
+      - run:
+          name: Check for Lint
+          command: markdownlint -i vendor .
+
+  cache_go_mod:
     <<: *defaults
     steps:
       - checkout
@@ -38,28 +51,22 @@ jobs:
             - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Populate Go Mod Cache
-          command: |-
-            if [ ! -d /go/pkg/mod ]; then
-              go mod download
-            fi
-      - save_cache:
-          key: go-mod-{{ checksum "go.sum" }}
-          paths:
-            - /go/pkg/mod
+          command: go mod download
       - run:
           name: Go Mod Verify
           command: go mod verify
-      - persist_to_workspace:
-          root: /
+      - save_cache:
+          key: go-mod-{{ checksum "go.sum" }}
           paths:
-            - go/pkg/mod
-            - src
+            - '/go/pkg/mod'
 
   build_source:
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: /
+      - checkout
+      - restore_cache:
+          keys:
+            - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Build Source
           command: ./build.sh
@@ -67,8 +74,10 @@ jobs:
   check_formatting:
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: /
+      - checkout
+      - restore_cache:
+          keys:
+            - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Check Formatting
           command: test -z $(go fmt ./...)
@@ -76,8 +85,10 @@ jobs:
   vet_source:
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: /
+      - checkout
+      - restore_cache:
+          keys:
+            - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Vet Source
           command: go vet -all ./...
@@ -85,8 +96,10 @@ jobs:
   lint_source:
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: /
+      - checkout
+      - restore_cache:
+          keys:
+            - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Install golangci-lint
           command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
@@ -94,25 +107,13 @@ jobs:
           name: Check for Lint
           command: golangci-lint run ./...
 
-  lint_markdown:
-    <<: *defaults
-    docker:
-      - image: node:11
-    steps:
-      - attach_workspace:
-          at: /
-      - run:
-          name: Install markdownlint
-          command: npm install -g markdownlint-cli
-      - run:
-          name: Check for Lint
-          command: markdownlint -i vendor .
-
   unit_test:
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: /
+      - checkout
+      - restore_cache:
+          keys:
+            - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Run Tests
           command: go test -coverprofile cover.out -race -timeout 60s ./...
@@ -125,22 +126,20 @@ workflows:
 
   build_and_test:
     jobs:
-      - get_source
+      - lint_markdown
+      - cache_go_mod
       - build_source:
           requires:
-            - get_source
+            - cache_go_mod
       - check_formatting:
           requires:
-            - get_source
+            - cache_go_mod
       - vet_source:
           requires:
-            - get_source
+            - cache_go_mod
       - lint_source:
           requires:
-            - get_source
-      - lint_markdown:
-          requires:
-            - get_source
+            - cache_go_mod
       - unit_test:
           requires:
-            - get_source
+            - cache_go_mod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: /src
   docker:
-    - image: golang:1.11.6-stretch
+    - image: golang:1.12
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
   lint_markdown:
     <<: *defaults
     docker:
-      - image: node:11
+      - image: node:11-slim
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           command: go vet -all ./...
       - run:
           name: Install golangci-lint
-          command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
+          command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
       - run:
           name: Check for Lint
           command: golangci-lint run ./...
@@ -89,7 +89,7 @@ jobs:
           at: /
       - run:
           name: Install golangci-lint
-          command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
+          command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
       - run:
           name: Check for Lint
           command: golangci-lint run ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,6 @@ jobs:
           name: Build Source
           command: ./build.sh
       - run:
-          name: Check Formatting
-          command: test -z $(go fmt ./...)
-      - run:
           name: Install golangci-lint
           command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
       - run:
@@ -68,17 +65,6 @@ jobs:
           name: Build Source
           command: ./build.sh
 
-  check_formatting:
-    <<: *defaults
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - go-mod-{{ checksum "go.sum" }}
-      - run:
-          name: Check Formatting
-          command: test -z $(go fmt ./...)
-
   lint_source:
     <<: *defaults
     steps:
@@ -112,9 +98,6 @@ workflows:
       - lint_markdown
       - cache_go_mod
       - build_source:
-          requires:
-            - cache_go_mod
-      - check_formatting:
           requires:
             - cache_go_mod
       - lint_source:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,6 @@ jobs:
           name: Check Formatting
           command: test -z $(go fmt ./...)
       - run:
-          name: Vet Source
-          command: go vet -all ./...
-      - run:
           name: Install golangci-lint
           command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
       - run:
@@ -82,17 +79,6 @@ jobs:
           name: Check Formatting
           command: test -z $(go fmt ./...)
 
-  vet_source:
-    <<: *defaults
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - go-mod-{{ checksum "go.sum" }}
-      - run:
-          name: Vet Source
-          command: go vet -all ./...
-
   lint_source:
     <<: *defaults
     steps:
@@ -129,9 +115,6 @@ workflows:
           requires:
             - cache_go_mod
       - check_formatting:
-          requires:
-            - cache_go_mod
-      - vet_source:
           requires:
             - cache_go_mod
       - lint_source:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,9 @@ jobs:
           keys:
             - go-mod-{{ checksum "go.sum" }}
       - run:
+          name: Verify go.mod
+          command: go list -mod=readonly ./... >/dev/null
+      - run:
           name: Populate Go Mod Cache
           command: go mod download
       - save_cache:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - gosimple
     - govet
     - ineffassign
+    - misspell
     - staticcheck
     - structcheck
     - typecheck
@@ -17,3 +18,5 @@ linters:
 linters-settings:
   gofmt:
     simplify: true
+  misspell:
+    locale: US

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,14 @@
+linters:
+  disable-all: true
+  enable-all: false
+  enable:
+    - deadcode
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ linters:
   enable:
     - deadcode
     - errcheck
+    - gofmt
     - gosimple
     - govet
     - ineffassign
@@ -12,3 +13,7 @@ linters:
     - typecheck
     - unused
     - varcheck
+
+linters-settings:
+  gofmt:
+    simplify: true

--- a/internal/app/siftool/modif.go
+++ b/internal/app/siftool/modif.go
@@ -17,7 +17,7 @@ import (
 	"github.com/sylabs/sif/pkg/sif"
 )
 
-// New creates a new emtpy SIF file
+// New creates a new empty SIF file
 func New(file string) error {
 	cinfo := sif.CreateInfo{
 		Pathname:   file,
@@ -34,7 +34,7 @@ func New(file string) error {
 	return nil
 }
 
-// AddOptions contains the options when adding a sectiont to a SIF file
+// AddOptions contains the options when adding a section to a SIF file
 type AddOptions struct {
 	Datatype   *int64
 	Parttype   *int64


### PR DESCRIPTION
Add `go list -mod=readonly` to `cache_go_mod` job to verify `go.mod` is in sync with source code. 

Replace workspace usage with `checkout`/`restore_cache` as recommended on the [CircleCI blog](https://circleci.com/blog/deep-diving-into-circleci-workspaces/).

Advance Go version to 1.12. Use `node:11-slim` (148MB) instead of `node:11` (904MB) for `lint_markdown` job. Update `golangci-lint` to v1.16. Remove `cover.out` artifact, since we aren't using it.

Closes #28 