### PR TITLE
Add script to verify that vendor dir is up-to-date

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,15 +44,15 @@ jobs:
           keys:
             - go-mod-{{ checksum "go.sum" }}
       - run:
-          name: Verify go.mod
-          command: go list -mod=readonly ./... >/dev/null
-      - run:
           name: Populate Go Mod Cache
           command: go mod download
       - save_cache:
           key: go-mod-{{ checksum "go.sum" }}
           paths:
             - '/go/pkg/mod'
+      - run:
+          name: Check vendor/ module is up-to-date
+          command: scripts/check-vendor
 
   build_source:
     <<: *defaults

--- a/scripts/check-vendor
+++ b/scripts/check-vendor
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+set -e
+
+if test ! -e go.mod ; then
+	echo "E: $PWD/go.mod not found. Abort."
+	exit 1
+fi
+
+export GO111MODULE=on
+
+if ! git diff-index --quiet HEAD ; then
+	echo "E: Workspace is unexpectly dirty. Abort."
+	exit 2
+fi
+
+if ! go mod download ; then
+	echo "E: Failed to download Go modules. Abort"
+	exit 3
+fi
+
+if ! go mod verify > /dev/null ; then
+	echo "E: Invalid Go module state. Abort."
+	exit 4
+fi
+
+if ! go mod vendor ; then
+	echo "E: Failed to update vendor/ directory. Abort."
+	exit 5
+fi
+
+# the go mod vendor command above might have opened files in vendor, and
+# this tells git that things _might_ have been modified so it should
+# check that.
+git update-index --refresh
+
+if ! git diff-index --raw --exit-code HEAD ; then
+	echo "E: Workspace became dirty after runnig 'go mod vendor'. Abort."
+	exit 6
+fi
+
+echo "I: Vendor directory OK."
+exit 0


### PR DESCRIPTION
Add scripts/check-vendor to check that the vendor/ directory is
up-to-date wrt go.mod and that the vendor/ directory has not been
modified wrt to what should be there.

Add call to scripts/check-vendor in .circleci/config.yml so that we
verify that vendor/ and/or go.mod has not been updated without updating
the other, too.

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>