### PR TITLE
Report Code Coverage Metrics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
             - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Run Tests
-          command: go test -coverprofile cover.out -race -timeout 60s ./...
+          command: go test -coverprofile cover.out -race ./...
       - codecov/upload:
           file: cover.out
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
-version: 2
+version: 2.1
+
+orbs:
+  codecov: codecov/codecov@1.0.4
 
 defaults: &defaults
   working_directory: /src
@@ -88,7 +91,9 @@ jobs:
             - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Run Tests
-          command: go test -cover -race -timeout 60s ./...
+          command: go test -coverprofile cover.out -race -timeout 60s ./...
+      - codecov/upload:
+          file: cover.out
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,23 +9,6 @@ defaults: &defaults
     - image: golang:1.12
 
 jobs:
-  build:
-    <<: *defaults
-    steps:
-      - checkout
-      - run:
-          name: Build Source
-          command: ./build.sh
-      - run:
-          name: Install golangci-lint
-          command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
-      - run:
-          name: Check for Lint
-          command: golangci-lint run ./...
-      - run:
-          name: Run Tests
-          command: go test -cover -race -timeout 60s ./...
-
   lint_markdown:
     <<: *defaults
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
           command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
       - run:
           name: Check for Lint
-          command: golangci-lint run ./...
+          command: golangci-lint run
 
   unit_test:
     <<: *defaults

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![GoDoc](https://godoc.org/github.com/sylabs/sif?status.svg)](https://godoc.org/github.com/sylabs/sif)
 [![Build Status](https://circleci.com/gh/sylabs/sif.svg?style=shield)](https://circleci.com/gh/sylabs/workflows/sif)
+[![Code Coverage](https://codecov.io/gh/sylabs/sif/branch/master/graph/badge.svg)](https://codecov.io/gh/sylabs/sif)
 [![Go Report Card](https://goreportcard.com/badge/github.com/sylabs/sif)](https://goreportcard.com/report/github.com/sylabs/sif)
 
 SIF is an open source implementation of the Singularity Container Image Format


### PR DESCRIPTION
Report code coverage metrics. Add badge with code coverage summary. Remove redundant build job (#31). Use default timeout for `go test` in CircleCI config, and remove unnecessary path specifier to `golangci-lint `.

Closes #31, closes #34