### PR TITLE
Return nil if header is corrupted

### DIFF
--- a/pkg/sif/lookup.go
+++ b/pkg/sif/lookup.go
@@ -254,7 +254,7 @@ func (descr *Descriptor) GetData(fimg *FileImage) []byte {
 		return data
 	}
 
-	if int64(len(fimg.Filedata)) < descr.Fileoff+descr.Filelen {
+	if descr.Fileoff+descr.Filelen > int64(len(fimg.Filedata)) {
 		// corrupted header
 		return nil
 	}

--- a/pkg/sif/lookup.go
+++ b/pkg/sif/lookup.go
@@ -255,7 +255,8 @@ func (descr *Descriptor) GetData(fimg *FileImage) []byte {
 	}
 
 	if descr.Fileoff+descr.Filelen > int64(len(fimg.Filedata)) {
-		// corrupted header
+		// there's not enough data in the file to account for the indicated
+		// payload. Is the header corrupted?
 		return nil
 	}
 

--- a/pkg/sif/lookup.go
+++ b/pkg/sif/lookup.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -252,6 +252,11 @@ func (descr *Descriptor) GetData(fimg *FileImage) []byte {
 			return nil
 		}
 		return data
+	}
+
+	if int64(len(fimg.Filedata)) < descr.Fileoff+descr.Filelen {
+		// corrupted header
+		return nil
 	}
 
 	return fimg.Filedata[descr.Fileoff : descr.Fileoff+descr.Filelen]


### PR DESCRIPTION
If your verifying a container thats corrupted/without a sif header, it will panic. Not any more! This will add a check to ensure the that there is data to return, before returning it.

Related to: https://github.com/sylabs/singularity/pull/3615

<br>