### PR TITLE
Add DataCryptoMessage Descriptor

### DIFF
--- a/pkg/sif/create.go
+++ b/pkg/sif/create.go
@@ -466,6 +466,20 @@ func (di *DescriptorInput) SetSignExtra(hash Hashtype, entity string) error {
 	return nil
 }
 
+// SetCryptoMsgExtra serializes the message format and type info into a binary buffer
+func (di *DescriptorInput) SetCryptoMsgExtra(format Formattype, message Messagetype) error {
+	extra := CryptoMessage{
+		Formattype:  format,
+		Messagetype: message,
+	}
+
+	// serialize the message data for integration with the base descriptor input
+	if err := binary.Write(&di.Extra, binary.LittleEndian, extra); err != nil {
+		return err
+	}
+	return nil
+}
+
 // SetName sets the byte array field "Name" to the value of string "name"
 func (d *Descriptor) SetName(name string) {
 	copy(d.Name[:], []byte(name))

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -130,13 +130,14 @@ type Datatype int32
 
 // List of supported SIF data types
 const (
-	DataDeffile     Datatype = iota + 0x4001 // definition file data object
-	DataEnvVar                               // environment variables data object
-	DataLabels                               // JSON labels data object
-	DataPartition                            // file system data object
-	DataSignature                            // signing/verification data object
-	DataGenericJSON                          // generic JSON meta-data
-	DataGeneric                              // generic / raw data
+	DataDeffile       Datatype = iota + 0x4001 // definition file data object
+	DataEnvVar                                 // environment variables data object
+	DataLabels                                 // JSON labels data object
+	DataPartition                              // file system data object
+	DataSignature                              // signing/verification data object
+	DataGenericJSON                            // generic JSON meta-data
+	DataGeneric                                // generic / raw data
+	DataCryptoMessage                          // cryptographic message data object
 )
 
 // Fstype represents the different SIF file system types found in partition data objects
@@ -172,6 +173,27 @@ const (
 	HashSHA512
 	HashBLAKE2S
 	HashBLAKE2B
+)
+
+// Formattype represents the different formats used to store cryptographic message objects
+type Formattype int32
+
+// List of supported cryptographic message formats
+const (
+	FormatOpenPGP Formattype = iota + 1
+	FormatPEM
+)
+
+// Messagetype represents the different messages stored within cryptographic message objects
+type Messagetype int32
+
+// List of supported cryptographic message formats
+const (
+	// openPGP formatted messages
+	MessageClearSignature Messagetype = 0x100
+
+	// PEM formatted messages
+	MessageRSAOAEP Messagetype = 0x200
 )
 
 // SIF data object deletation strategies
@@ -230,6 +252,12 @@ type GenericJSON struct {
 
 // Generic represents the SIF generic data object descriptor
 type Generic struct {
+}
+
+// CryptoMessage represents the SIF crypto message object descriptor
+type CryptoMessage struct {
+	Formattype  Formattype
+	Messagetype Messagetype
 }
 
 // Header describes a loaded SIF file


### PR DESCRIPTION
This descriptor is intended to store cryptographic messages within sif
files. This includes, but is not limited to clear signed openPGP
messages as well as encrypted RSA-OAEP messages.

Signed-off-by: Ian Kaneshiro <iankane@umich.edu>

Notes for reviewers:
- Message types do not use `iota` for enumeration to allow logical grouping of additional constants over time
- I am thinking about adding an `Extra [remainingExtraSpace]bytes` field to the struct so that for select uses of the descriptor(aka an openPGP signature) we can store fingerprint and entity information in the descriptor portion in a reasonable way and would like feedback on the idea here.