### PR TITLE
Extend helpers and siftool for CryptoMessage type

### DIFF
--- a/internal/app/siftool/modif.go
+++ b/internal/app/siftool/modif.go
@@ -69,6 +69,8 @@ func Add(containerFile, dataFile string, opts AddOptions) error {
 		d = sif.DataGenericJSON
 	case 7:
 		d = sif.DataGeneric
+	case 8:
+		d = sif.DataCryptoMessage
 	default:
 		log.Printf("error: -datatype flag is required with a valid range\n\n")
 		return fmt.Errorf("usage")

--- a/pkg/sif/fmt.go
+++ b/pkg/sif/fmt.go
@@ -74,6 +74,8 @@ func datatypeStr(dtype Datatype) string {
 		return "JSON.Generic"
 	case DataGeneric:
 		return "Generic/Raw"
+	case DataCryptoMessage:
+		return "Cryptographic Message"
 	}
 	return "Unknown data-type"
 }
@@ -127,6 +129,28 @@ func hashtypeStr(htype Hashtype) string {
 	return "Unknown hash-type"
 }
 
+// formattypeStr returns a string representation of a format type
+func formattypeStr(ftype Formattype) string {
+	switch ftype {
+	case FormatOpenPGP:
+		return "OpenPGP"
+	case FormatPEM:
+		return "PEM"
+	}
+	return "Unknown format-type"
+}
+
+// messagetypeStr returns a string representation of a message type
+func messagetypeStr(mtype Messagetype) string {
+	switch mtype {
+	case MessageClearSignature:
+		return "Clear Signature"
+	case MessageRSAOAEP:
+		return "RSA-OAEP"
+	}
+	return "Unknown message-type"
+}
+
 // FmtDescrList formats the output of a list of all active descriptors from a SIF file
 func (fimg *FileImage) FmtDescrList() string {
 	s := fmt.Sprintf("%-4s %-8s %-8s %-26s %s\n", "ID", "|GROUP", "|LINK", "|SIF POSITION (start-end)", "|TYPE")
@@ -164,6 +188,10 @@ func (fimg *FileImage) FmtDescrList() string {
 			case DataSignature:
 				h, _ := v.GetHashType()
 				s += fmt.Sprintf("|%s (%s)\n", datatypeStr(v.Datatype), hashtypeStr(h))
+			case DataCryptoMessage:
+				f, _ := v.GetFormatType()
+				m, _ := v.GetMessageType()
+				s += fmt.Sprintf("|%s (%s/%s)\n", datatypeStr(v.Datatype), formattypeStr(f), messagetypeStr(m))
 			default:
 				s += fmt.Sprintf("|%s\n", datatypeStr(v.Datatype))
 			}
@@ -219,6 +247,11 @@ func (fimg *FileImage) FmtDescrInfo(id uint32) string {
 				e, _ := v.GetEntityString()
 				s += fmt.Sprintln("  Hashtype: ", hashtypeStr(h))
 				s += fmt.Sprintln("  Entity:   ", e)
+			case DataCryptoMessage:
+				f, _ := v.GetFormatType()
+				m, _ := v.GetMessageType()
+				s += fmt.Sprintln("  Fmttype:  ", formattypeStr(f))
+				s += fmt.Sprintln("  Msgtype:  ", messagetypeStr(m))
 			}
 
 			return s

--- a/pkg/sif/lookup.go
+++ b/pkg/sif/lookup.go
@@ -375,6 +375,36 @@ func (descr *Descriptor) GetEntityString() (string, error) {
 	return fmt.Sprintf("%0X", fingerprint[:20]), nil
 }
 
+// GetFormatType extracts the Formattype field from the Extra field of a Cryptographic Message Descriptor
+func (descr *Descriptor) GetFormatType() (Formattype, error) {
+	if descr.Datatype != DataCryptoMessage {
+		return -1, fmt.Errorf("expected DataCryptoMessage, got %v", descr.Datatype)
+	}
+
+	var cinfo CryptoMessage
+	b := bytes.NewReader(descr.Extra[:])
+	if err := binary.Read(b, binary.LittleEndian, &cinfo); err != nil {
+		return -1, fmt.Errorf("while extracting Crypto extra info: %s", err)
+	}
+
+	return cinfo.Formattype, nil
+}
+
+// GetMessageType extracts the Messagetype field from the Extra field of a Cryptographic Message Descriptor
+func (descr *Descriptor) GetMessageType() (Messagetype, error) {
+	if descr.Datatype != DataCryptoMessage {
+		return -1, fmt.Errorf("expected DataCryptoMessage, got %v", descr.Datatype)
+	}
+
+	var cinfo CryptoMessage
+	b := bytes.NewReader(descr.Extra[:])
+	if err := binary.Read(b, binary.LittleEndian, &cinfo); err != nil {
+		return -1, fmt.Errorf("while extracting Crypto extra info: %s", err)
+	}
+
+	return cinfo.Messagetype, nil
+}
+
 // GetPartPrimSys returns the primary system partition if present. There should
 // be only one primary system partition in a SIF file.
 func (fimg *FileImage) GetPartPrimSys() (*Descriptor, int, error) {


### PR DESCRIPTION
This adds helpers to deserialize the data stored within the Extra field.
And updates siftool to give useful information about this new type.

Signed-off-by: Ian Kaneshiro <iankane@umich.edu>