### PR TITLE
Verify Go 1.13 Compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 defaults: &defaults
   working_directory: /src
   docker:
-    - image: golang:1.12
+    - image: golang:1.13
 
 jobs:
   lint_markdown:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@1.0.4
+  codecov: codecov/codecov@1.0.5
 
 defaults: &defaults
   working_directory: /src

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
             - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Install golangci-lint
-          command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
+          command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.18.0
       - run:
           name: Check for Lint
           command: golangci-lint run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,20 +22,10 @@ jobs:
           name: Check for Lint
           command: markdownlint -i vendor .
 
-  cache_go_mod:
+  check_vendor:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - go-mod-{{ checksum "go.sum" }}
-      - run:
-          name: Populate Go Mod Cache
-          command: go mod download
-      - save_cache:
-          key: go-mod-{{ checksum "go.sum" }}
-          paths:
-            - '/go/pkg/mod'
       - run:
           name: Check vendor/ module is up-to-date
           command: scripts/check-vendor
@@ -44,9 +34,6 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Build Source
           command: ./build.sh
@@ -55,9 +42,6 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Install golangci-lint
           command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.18.0
@@ -69,9 +53,6 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - go-mod-{{ checksum "go.sum" }}
       - run:
           name: Run Tests
           command: go test -coverprofile cover.out -race ./...
@@ -84,13 +65,7 @@ workflows:
   build_and_test:
     jobs:
       - lint_markdown
-      - cache_go_mod
-      - build_source:
-          requires:
-            - cache_go_mod
-      - lint_source:
-          requires:
-            - cache_go_mod
-      - unit_test:
-          requires:
-            - cache_go_mod
+      - check_vendor
+      - build_source
+      - lint_source
+      - unit_test

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ cd sif
 ./build.sh
 ```
 
+## Go Version Compatibility
+
+This module aims to maintain support for the two most recent stable versions of Go.
+
 ### Contributing
 
 SIF and Singularity is the work of many contributors. We appreciate your help!

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sylabs/sif
 
-go 1.11
+go 1.13
 
 require (
 	github.com/kr/pretty v0.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sylabs/sif
 
-go 1.13
+go 1.12
 
 require (
 	github.com/kr/pretty v0.1.0 // indirect


### PR DESCRIPTION
Use Go v1.13 in CI. Update `codecov` Orb to v1.0.5, and `golangci-lint` to v1.18.0.

Remove `cache_go_mod` job, and associated `save_cache`/`restore_cache` steps from all jobs, using the Go module proxy instead. Move existing `scripts/check-vendor` step to a new `check_vendor` job.

Closes #51 