### PR TITLE
Trim zero bytes when format SIF, update tests

### DIFF
--- a/pkg/sif/fmt.go
+++ b/pkg/sif/fmt.go
@@ -40,10 +40,10 @@ func readableSize(size uint64) string {
 
 // FmtHeader formats the output of a SIF file global header.
 func (fimg *FileImage) FmtHeader() string {
-	s := fmt.Sprintln("Launch:  ", cstrToString(fimg.Header.Launch[:]))
-	s += fmt.Sprintln("Magic:   ", cstrToString(fimg.Header.Magic[:]))
-	s += fmt.Sprintln("Version: ", cstrToString(fimg.Header.Version[:]))
-	s += fmt.Sprintln("Arch:    ", GetGoArch(cstrToString(fimg.Header.Arch[:])))
+	s := fmt.Sprintln("Launch:  ", trimZeroBytes(fimg.Header.Launch[:]))
+	s += fmt.Sprintln("Magic:   ", trimZeroBytes(fimg.Header.Magic[:]))
+	s += fmt.Sprintln("Version: ", trimZeroBytes(fimg.Header.Version[:]))
+	s += fmt.Sprintln("Arch:    ", GetGoArch(trimZeroBytes(fimg.Header.Arch[:])))
 	s += fmt.Sprintln("ID:      ", fimg.Header.ID)
 	s += fmt.Sprintln("Ctime:   ", time.Unix(fimg.Header.Ctime, 0))
 	s += fmt.Sprintln("Mtime:   ", time.Unix(fimg.Header.Mtime, 0))
@@ -184,7 +184,7 @@ func (fimg *FileImage) FmtDescrList() string {
 				f, _ := v.GetFsType()
 				p, _ := v.GetPartType()
 				a, _ := v.GetArch()
-				s += fmt.Sprintf("|%s (%s/%s/%s)\n", datatypeStr(v.Datatype), fstypeStr(f), parttypeStr(p), GetGoArch(cstrToString(a[:])))
+				s += fmt.Sprintf("|%s (%s/%s/%s)\n", datatypeStr(v.Datatype), fstypeStr(f), parttypeStr(p), GetGoArch(trimZeroBytes(a[:])))
 			case DataSignature:
 				h, _ := v.GetHashType()
 				s += fmt.Sprintf("|%s (%s)\n", datatypeStr(v.Datatype), hashtypeStr(h))
@@ -233,7 +233,7 @@ func (fimg *FileImage) FmtDescrInfo(id uint32) string {
 			s += fmt.Sprintln("  Mtime:    ", time.Unix(v.Mtime, 0))
 			s += fmt.Sprintln("  UID:      ", v.UID)
 			s += fmt.Sprintln("  Gid:      ", v.Gid)
-			s += fmt.Sprintln("  Name:     ", string(v.Name[:]))
+			s += fmt.Sprintln("  Name:     ", trimZeroBytes(v.Name[:]))
 			switch v.Datatype {
 			case DataPartition:
 				f, _ := v.GetFsType()
@@ -241,7 +241,7 @@ func (fimg *FileImage) FmtDescrInfo(id uint32) string {
 				a, _ := v.GetArch()
 				s += fmt.Sprintln("  Fstype:   ", fstypeStr(f))
 				s += fmt.Sprintln("  Parttype: ", parttypeStr(p))
-				s += fmt.Sprintln("  Arch:     ", GetGoArch(cstrToString(a[:])))
+				s += fmt.Sprintln("  Arch:     ", GetGoArch(trimZeroBytes(a[:])))
 			case DataSignature:
 				h, _ := v.GetHashType()
 				e, _ := v.GetEntityString()

--- a/pkg/sif/fmt_test.go
+++ b/pkg/sif/fmt_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 )
 
-func TestFmtHeader(t *testing.T) {
+func TestFileImage_FmtHeader(t *testing.T) {
 	fimg, err := LoadContainer("testdata/testcontainer2.sif", true)
 	if err != nil {
-		t.Error(`LoadContainer("testdata/testcontainer2.sif", true):`, err)
+		t.Fatalf(`Could not load test container: %v`, err)
 	}
 	defer func() {
 		if err := fimg.UnloadContainer(); err != nil {
@@ -20,13 +20,32 @@ func TestFmtHeader(t *testing.T) {
 		}
 	}()
 
-	t.Log(fimg.FmtHeader())
+	const expectHeader = `Launch:   #!/usr/bin/env run-singularity
+
+Magic:    SIF_MAGIC
+Version:  00
+Arch:     amd64
+ID:       293e8b11-dbd0-47e6-b0b9-390772c12be8
+Ctime:    2018-08-14 07:45:59 +0000 UTC
+Mtime:    2018-08-14 07:47:36 +0000 UTC
+Dfree:    45
+Dtotal:   48
+Descoff:  4096
+Descrlen: 27KB
+Dataoff:  32768
+Datalen:  1MB
+`
+
+	actual := fimg.FmtHeader()
+	if expectHeader != actual {
+		t.Errorf("Expected header:\n%q\nBut got:\n%q", expectHeader, actual)
+	}
 }
 
-func TestFmtDescrList(t *testing.T) {
+func TestFileImage_FmtDescrList(t *testing.T) {
 	fimg, err := LoadContainer("testdata/testcontainer2.sif", true)
 	if err != nil {
-		t.Error(`LoadContainer("testdata/testcontainer2.sif", true):`, err)
+		t.Fatalf(`Could not load test container: %v`, err)
 	}
 	defer func() {
 		if err := fimg.UnloadContainer(); err != nil {
@@ -34,13 +53,23 @@ func TestFmtDescrList(t *testing.T) {
 		}
 	}()
 
-	t.Log(fimg.FmtDescrList())
+	const expectList = `ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
+------------------------------------------------------------------------------
+1    |1       |NONE    |32768-32830               |Def.FILE
+2    |1       |NONE    |1048576-1753088           |FS (Squashfs/*System/amd64)
+3    |1       |2       |1753088-1754043           |Signature (SHA384)
+`
+
+	actual := fimg.FmtDescrList()
+	if expectList != actual {
+		t.Errorf("Expected list:\n%q\nBut got:\n%q", expectList, actual)
+	}
 }
 
-func TestFmtDescrInfo(t *testing.T) {
+func TestFileImage_FmtDescrInfo(t *testing.T) {
 	fimg, err := LoadContainer("testdata/testcontainer2.sif", true)
 	if err != nil {
-		t.Error(`LoadContainer("testdata/testcontainer2.sif", true):`, err)
+		t.Fatalf(`Could not load test container: %v`, err)
 	}
 	defer func() {
 		if err := fimg.UnloadContainer(); err != nil {
@@ -48,8 +77,65 @@ func TestFmtDescrInfo(t *testing.T) {
 		}
 	}()
 
-	t.Log(fimg.FmtDescrInfo(1))
-	t.Log(fimg.FmtDescrInfo(2))
-	t.Log(fimg.FmtDescrInfo(3))
-	t.Log(fimg.FmtDescrInfo(4))
+	expect := []string{
+		`Descr slot#: 0
+  Datatype:  Def.FILE
+  ID:        1
+  Used:      true
+  Groupid:   1
+  Link:      NONE
+  Fileoff:   32768
+  Filelen:   62
+  Ctime:     2018-08-14 07:45:59 +0000 UTC
+  Mtime:     2018-08-14 07:45:59 +0000 UTC
+  UID:       1002
+  Gid:       1002
+  Name:      busybox.deffile
+`,
+		`Descr slot#: 1
+  Datatype:  FS
+  ID:        2
+  Used:      true
+  Groupid:   1
+  Link:      NONE
+  Fileoff:   1048576
+  Filelen:   704512
+  Ctime:     2018-08-14 07:45:59 +0000 UTC
+  Mtime:     2018-08-14 07:45:59 +0000 UTC
+  UID:       1002
+  Gid:       1002
+  Name:      busybox.squash
+  Fstype:    Squashfs
+  Parttype:  *System
+  Arch:      amd64
+`,
+		`Descr slot#: 2
+  Datatype:  Signature
+  ID:        3
+  Used:      true
+  Groupid:   1
+  Link:      2
+  Fileoff:   1753088
+  Filelen:   955
+  Ctime:     2018-08-14 07:47:36 +0000 UTC
+  Mtime:     2018-08-14 07:47:36 +0000 UTC
+  UID:       1002
+  Gid:       1002
+  Name:      part-signature
+  Hashtype:  SHA384
+  Entity:    9F2B6C36D999A3E91CB3104720671590C12D4222
+`,
+		``,
+	}
+
+	for i := 0; i < len(expect); i++ {
+		actual := fimg.FmtDescrInfo(uint32(i + 1))
+		if len(expect[i]) != len(actual) {
+			t.Errorf("Expected info len: %d, but got: %d", len(expect[i]), len(actual))
+
+		}
+		if expect[i] != actual {
+			t.Errorf("Expected info:\n%q\nBut got:\n%q", expect[i], actual)
+		}
+	}
 }

--- a/pkg/sif/load.go
+++ b/pkg/sif/load.go
@@ -221,10 +221,7 @@ func (fimg *FileImage) UnloadContainer() (err error) {
 }
 
 func trimZeroBytes(str []byte) string {
-	n := len(str) - 1
-	for ; str[n] == 0; n-- {
-	}
-	return string(str[:n+1])
+	return string(bytes.TrimRight(str, "\x00"))
 }
 
 func modeToStr(mode int) string {

--- a/pkg/sif/load.go
+++ b/pkg/sif/load.go
@@ -52,10 +52,10 @@ func readDescriptors(fimg *FileImage) error {
 // `runnable' checks is current container can run on host.
 func isValidSif(fimg *FileImage) error {
 	// check various header fields
-	if cstrToString(fimg.Header.Magic[:]) != HdrMagic {
+	if trimZeroBytes(fimg.Header.Magic[:]) != HdrMagic {
 		return fmt.Errorf("invalid SIF file: Magic |%s| want |%s|", fimg.Header.Magic, HdrMagic)
 	}
-	if cstrToString(fimg.Header.Version[:]) > HdrVersion {
+	if trimZeroBytes(fimg.Header.Version[:]) > HdrVersion {
 		return fmt.Errorf("invalid SIF file: Version %s want <= %s", fimg.Header.Version, HdrVersion)
 	}
 
@@ -220,12 +220,11 @@ func (fimg *FileImage) UnloadContainer() (err error) {
 	return
 }
 
-func cstrToString(str []byte) string {
-	n := len(str)
-	if m := n - 1; str[m] == 0 {
-		n = m
+func trimZeroBytes(str []byte) string {
+	n := len(str) - 1
+	for ; str[n] == 0; n-- {
 	}
-	return string(str[:n])
+	return string(str[:n+1])
 }
 
 func modeToStr(mode int) string {

--- a/pkg/sif/load_test.go
+++ b/pkg/sif/load_test.go
@@ -257,3 +257,36 @@ func TestLoadContainerReader(t *testing.T) {
 		t.Error(`fimg.UnloadContainer():`, err)
 	}
 }
+
+func TestTrimZeroBytes(t *testing.T) {
+	tt := []struct {
+		name   string
+		in     []byte
+		expect string
+	}{
+		{
+			name:   "no zero",
+			in:     []byte("hello!"),
+			expect: "hello!",
+		},
+		{
+			name:   "c string",
+			in:     []byte("hello!\x00"),
+			expect: "hello!",
+		},
+		{
+			name:   "many zeroes",
+			in:     []byte("hello!\x00\x00\x00\x00\x00\x00\x00"),
+			expect: "hello!",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := trimZeroBytes(tc.in)
+			if tc.expect != actual {
+				t.Fatalf("Expected %q, but got %q", tc.expect, actual)
+			}
+		})
+	}
+}

--- a/pkg/sif/load_test.go
+++ b/pkg/sif/load_test.go
@@ -270,13 +270,23 @@ func TestTrimZeroBytes(t *testing.T) {
 			expect: "hello!",
 		},
 		{
-			name:   "c string",
+			name:   "c string x00",
 			in:     []byte("hello!\x00"),
 			expect: "hello!",
 		},
 		{
-			name:   "many zeroes",
+			name:   "c string 000",
+			in:     []byte("hello!\000"),
+			expect: "hello!",
+		},
+		{
+			name:   "many zeroes x00",
 			in:     []byte("hello!\x00\x00\x00\x00\x00\x00\x00"),
+			expect: "hello!",
+		},
+		{
+			name:   "many zeroes 000",
+			in:     []byte("hello!\000\000\000\000\000\000\000"),
 			expect: "hello!",
 		},
 	}

--- a/pkg/sif/lookup_test.go
+++ b/pkg/sif/lookup_test.go
@@ -393,7 +393,7 @@ func TestGetArch(t *testing.T) {
 		t.Error("parts[0].GetArch()", err)
 	}
 
-	if cstrToString(arch[:]) != HdrArchAMD64 {
+	if trimZeroBytes(arch[:]) != HdrArchAMD64 {
 		t.Logf("|%s|%s|\n", arch[:HdrArchLen-1], HdrArchAMD64)
 		t.Error("part.GetArch() should have returned 'HdrArchAMD64':", err)
 	}


### PR DESCRIPTION
Update fmt tests so that they actually compare fmt result.

Also trim trailing zero bytes when printing descriptor name (they are not printed but they affect tests and the resulting string).