### PR TITLE
Update go.mod to go1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sylabs/sif
 
-go 1.12
+go 1.13
 
 require (
 	github.com/kr/pretty v0.1.0 // indirect


### PR DESCRIPTION
This PR re-updates the `go.mod` go version to `1.13`, since we are using
1.13 in Singularity.