### PR TITLE
Go 1.14 and CI Updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
   lint_markdown:
     <<: *defaults
     docker:
-      - image: node:11-slim
+      - image: node:12-slim
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 defaults: &defaults
   working_directory: /src
   docker:
-    - image: golang:1.13
+    - image: golang:1.14
 
 jobs:
   lint_markdown:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
       - checkout
       - run:
           name: Install golangci-lint
-          command: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.18.0
+          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.7
       - run:
           name: Check for Lint
           command: golangci-lint run

--- a/pkg/sif/load.go
+++ b/pkg/sif/load.go
@@ -54,10 +54,10 @@ func readDescriptors(fimg *FileImage) error {
 func isValidSif(fimg *FileImage) error {
 	// check various header fields
 	if trimZeroBytes(fimg.Header.Magic[:]) != HdrMagic {
-		return fmt.Errorf("invalid SIF file: Magic |%s| want |%s|", fimg.Header.Magic, HdrMagic)
+		return fmt.Errorf("invalid SIF file: Magic |%s| want |%s|", trimZeroBytes(fimg.Header.Magic[:]), HdrMagic)
 	}
 	if trimZeroBytes(fimg.Header.Version[:]) > HdrVersion {
-		return fmt.Errorf("invalid SIF file: Version %s want <= %s", fimg.Header.Version, HdrVersion)
+		return fmt.Errorf("invalid SIF file: Version %s want <= %s", trimZeroBytes(fimg.Header.Version[:]), HdrVersion)
 	}
 
 	return nil


### PR DESCRIPTION
Update CI to test with Go 1.14 (while maintaining 1.13 in go.mod, as per the [Go Version Compatibility section of the README](https://github.com/sylabs/sif#go-version-compatibility)).

Update `golangci-lint` to v1.23.7 and, `node` to v12 in CircleCI configuration. Fix a couple of new printf format issues:

```
pkg/sif/load.go:57:20: SA5009: Printf format %s has arg #1 of wrong type [10]byte (staticcheck)
                return fmt.Errorf("invalid SIF file: Magic |%s| want |%s|", fimg.Header.Magic, HdrMagic)
                                 ^
pkg/sif/load.go:60:20: SA5009: Printf format %s has arg #1 of wrong type [3]byte (staticcheck)
                return fmt.Errorf("invalid SIF file: Version %s want <= %s", fimg.Header.Version, HdrVersion)
```