### PR TITLE
Update CI Badges/Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # The Singularity Image Format (SIF)
 
-[![GoDoc](https://godoc.org/github.com/sylabs/sif?status.svg)](https://godoc.org/github.com/sylabs/sif)
-[![Build Status](https://circleci.com/gh/hpcng/sif.svg?style=shield)](https://circleci.com/gh/hpcng/workflows/sif)
-[![Code Coverage](https://codecov.io/gh/hpcng/sif/branch/master/graph/badge.svg)](https://codecov.io/gh/hpcng/sif)
-[![Go Report Card](https://goreportcard.com/badge/github.com/hpcng/sif)](https://goreportcard.com/report/github.com/hpcng/sif)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/sylabs/sif?status.svg)](https://pkg.go.dev/github.com/sylabs/sif)
+[![Build Status](https://circleci.com/gh/sylabs/sif.svg?style=shield)](https://circleci.com/gh/sylabs/workflows/sif)
+[![Code Coverage](https://codecov.io/gh/sylabs/sif/branch/master/graph/badge.svg)](https://app.codecov.io/gh/sylabs/sif)
+[![Go Report Card](https://goreportcard.com/badge/github.com/sylabs/sif)](https://goreportcard.com/report/github.com/sylabs/sif)
 
 SIF is an open source implementation of the Singularity Container Image Format
 that makes it easy to create complete and encapsulated container enviroments


### PR DESCRIPTION
Replace `godoc` link with `pkg.go.dev`, as the former has been deprecated ([ref](https://blog.golang.org/godoc.org-redirect)). Update CI badges/links with `sylabs` org.