### PR TITLE
Update Linter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
       - image: golang:1.14
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.27
+      - image: golangci/golangci-lint:v1.39
 
 jobs:
   lint_markdown:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ executors:
   golang:
     docker:
       - image: golang:1.14
+  golangci-lint:
+    docker:
+      - image: golangci/golangci-lint:v1.27
 
 jobs:
   lint_markdown:
@@ -42,12 +45,9 @@ jobs:
           command: ./build.sh
 
   lint_source:
-    executor: golang
+    executor: golangci-lint
     steps:
       - checkout
-      - run:
-          name: Install golangci-lint
-          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
       - run:
           name: Check for Lint
           command: golangci-lint run

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,7 +22,6 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - lll
     - misspell
     - nolintlint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - dogsled
     - dupl
     - errcheck
+    - exportloopref
     - gochecknoinits
     - gocritic
     - godot
@@ -27,7 +28,6 @@ linters:
     - nolintlint
     - prealloc
     - rowserrcheck
-    - scopelint
     - staticcheck
     - structcheck
     - typecheck

--- a/pkg/sif/load_test.go
+++ b/pkg/sif/load_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -224,7 +224,7 @@ func TestLoadContainerInvalidMagic(t *testing.T) {
 	// ... and edit the magic to make it invalid. Instead of
 	// exploring all kinds of invalid, simply mess with the last
 	// byte, as this would catch off-by-one errors in the code.
-	copy(content[HdrLaunchLen:HdrLaunchLen+HdrMagicLen], []byte("SIF_MAGIX"))
+	copy(content[HdrLaunchLen:HdrLaunchLen+HdrMagicLen], "SIF_MAGIX")
 
 	fp := &mockSifReadWriter{
 		buf:  content,

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -189,10 +189,10 @@ type Messagetype int32
 
 // List of supported cryptographic message formats.
 const (
-	// openPGP formatted messages
+	// openPGP formatted messages.
 	MessageClearSignature Messagetype = 0x100
 
-	// PEM formatted messages
+	// PEM formatted messages.
 	MessageRSAOAEP Messagetype = 0x200
 )
 


### PR DESCRIPTION
Use official `golangci/golangci-lint` image in CI config. Bump `golangci-lint` from 1.27 to 1.39. Address `gocritic` and `godot` lint. Remove deprecated `interfacer` linter. Replace deprecated `scopelint` linter with `exportloopref`.