### PR TITLE
Update Go Version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:16-slim
   golang:
     docker:
-      - image: golang:1.14
+      - image: golang:1.16
   golangci-lint:
     docker:
       - image: golangci/golangci-lint:v1.39

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sylabs/sif
 
-go 1.13
+go 1.15
 
 require (
 	github.com/satori/go.uuid v1.2.0


### PR DESCRIPTION
Bump Go language version to 1.15 as per the stated [Go version compatibility](https://github.com/sylabs/sif#go-version-compatibility). Use latest Go version (1.16) in CI.