### PR TITLE
Bump github.com/satori/go.uuid Module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/sylabs/sif
 go 1.15
 
 require (
-	github.com/satori/go.uuid v1.2.0
+	github.com/satori/go.uuid v1.2.1-0.20180404165556-75cca531ea76
 	github.com/spf13/cobra v1.1.3
 	golang.org/x/crypto v0.0.0-20210503195802-e9a32991a82e
 )

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/satori/go.uuid v1.2.1-0.20180404165556-75cca531ea76 h1:ofyVTM1w4iyKwaQIlRR6Ip06mXXx5Cnz7a4mTGYq1hE=
+github.com/satori/go.uuid v1.2.1-0.20180404165556-75cca531ea76/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/internal/app/siftool/modif.go
+++ b/internal/app/siftool/modif.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // Copyright (c) 2018, Divya Cote <divya.cote@gmail.com> All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
@@ -19,19 +19,20 @@ import (
 
 // New creates a new empty SIF file.
 func New(file string) error {
-	cinfo := sif.CreateInfo{
-		Pathname:   file,
-		Launchstr:  sif.HdrLaunch,
-		Sifversion: sif.HdrVersion,
-		ID:         uuid.NewV4(),
-	}
-
-	_, err := sif.CreateContainer(cinfo)
+	id, err := uuid.NewV4()
 	if err != nil {
 		return err
 	}
 
-	return nil
+	cinfo := sif.CreateInfo{
+		Pathname:   file,
+		Launchstr:  sif.HdrLaunch,
+		Sifversion: sif.HdrVersion,
+		ID:         id,
+	}
+
+	_, err = sif.CreateContainer(cinfo)
+	return err
 }
 
 // AddOptions contains the options when adding a section to a SIF file.

--- a/pkg/integrity/testdata/gen_sifs.go
+++ b/pkg/integrity/testdata/gen_sifs.go
@@ -1,3 +1,8 @@
+// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
+// distributed with the sources of this project regarding your rights to use or distribute this
+// software.
+
 package main
 
 import (
@@ -13,15 +18,20 @@ import (
 )
 
 func createImage(path string, dis []sif.DescriptorInput) error {
+	id, err := uuid.NewV4()
+	if err != nil {
+		return err
+	}
+
 	ci := sif.CreateInfo{
 		Pathname:   path,
 		Launchstr:  sif.HdrLaunch,
 		Sifversion: sif.HdrVersion,
-		ID:         uuid.NewV4(),
+		ID:         id,
 		InputDescr: dis,
 	}
 
-	_, err := sif.CreateContainer(ci)
+	_, err = sif.CreateContainer(ci)
 	return err
 }
 

--- a/pkg/sif/create_test.go
+++ b/pkg/sif/create_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -60,12 +60,17 @@ func TestDataStructs(t *testing.T) {
 }
 
 func TestCreateContainer(t *testing.T) {
+	id, err := uuid.NewV4()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// general info for the new SIF file creation
 	cinfo := CreateInfo{
 		Pathname:   "testdata/testcontainer.sif",
 		Launchstr:  HdrLaunch,
 		Sifversion: HdrVersion,
-		ID:         uuid.NewV4(),
+		ID:         id,
 	}
 
 	// test container creation without any input descriptors


### PR DESCRIPTION
As pointed out in https://github.com/sylabs/sif/issues/7#issuecomment-833889421, the latest tagged version of `github.com/satori/go.uuid` (1.2.0) contains the deficiency described in https://github.com/satori/go.uuid/issues/73.

Ultimately, we need to move to a maintained UUID Go module as described in https://github.com/sylabs/sif/issues/7#issuecomment-832808170. But this will necessitate a major version bump, and we may want to consider other breaking changes while we're at that.

In the meantime, advancing `github.com/satori/go.uuid` to the commit on `master` where this issue was addressed (https://github.com/satori/go.uuid/commit/75cca531ea763666bc46e531da3b4c3b95f64557).