### PR TITLE
Bump golangci-lint to 1.40

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
       - image: golang:1.16
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.39
+      - image: golangci/golangci-lint:v1.40-alpine
 
 jobs:
   lint_markdown:


### PR DESCRIPTION
Update `golangci-lint` to 1.40.x.