### PR TITLE
CI Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@1.1
+  codecov: codecov/codecov@1.2
 
 executors:
   node:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,10 +31,11 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Check go.mod and go.sum are tidy
-          command: |-
-            go mod tidy
-            git diff --exit-code -- go.mod go.sum
+          name: Go Mod Tidy
+          command: go mod tidy
+      - run:
+          name: Check Module Tidiness
+          command: git diff --exit-code -- go.mod go.sum
 
   build-source:
     executor: golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
       - image: golangci/golangci-lint:v1.40-alpine
 
 jobs:
-  lint_markdown:
+  lint-markdown:
     executor: node
     steps:
       - checkout
@@ -26,7 +26,7 @@ jobs:
           name: Check for Lint
           command: markdownlint .
 
-  check_go_mod:
+  check-go-mod:
     executor: golang
     steps:
       - checkout
@@ -36,7 +36,7 @@ jobs:
             go mod tidy
             git diff --exit-code -- go.mod go.sum
 
-  build_source:
+  build-source:
     executor: golang
     steps:
       - checkout
@@ -44,7 +44,7 @@ jobs:
           name: Build Source
           command: ./build.sh
 
-  lint_source:
+  lint-source:
     executor: golangci-lint
     steps:
       - checkout
@@ -52,7 +52,7 @@ jobs:
           name: Check for Lint
           command: golangci-lint run
 
-  unit_test:
+  unit-test:
     executor: golang
     steps:
       - checkout
@@ -67,8 +67,8 @@ workflows:
 
   build_and_test:
     jobs:
-      - lint_markdown
-      - check_go_mod
-      - build_source
-      - lint_source
-      - unit_test
+      - lint-markdown
+      - check-go-mod
+      - build-source
+      - lint-source
+      - unit-test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,6 @@ linters:
     - godox
     - gofmt
     - goimports
-    - golint
     - gomodguard
     - goprintffuncname
     - gosec
@@ -26,6 +25,7 @@ linters:
     - misspell
     - nolintlint
     - prealloc
+    - revive
     - rowserrcheck
     - staticcheck
     - structcheck

--- a/internal/app/siftool/modif.go
+++ b/internal/app/siftool/modif.go
@@ -168,11 +168,7 @@ func Add(containerFile, dataFile string, opts AddOptions) error {
 	}()
 
 	// add new data object to SIF file
-	if err = fimg.AddObject(input); err != nil {
-		return err
-	}
-
-	return nil
+	return fimg.AddObject(input)
 }
 
 // Del deletes a specified object descriptor and data from the SIF file.
@@ -191,11 +187,7 @@ func Del(descr uint64, file string) error {
 		if !v.Used {
 			continue
 		} else if v.ID == uint32(descr) {
-			if err := fimg.DeleteObject(uint32(descr), 0); err != nil {
-				return err
-			}
-
-			return nil
+			return fimg.DeleteObject(uint32(descr), 0)
 		}
 	}
 
@@ -218,11 +210,7 @@ func Setprim(descr uint64, file string) error {
 		if !v.Used {
 			continue
 		} else if v.ID == uint32(descr) {
-			if err := fimg.SetPrimPart(uint32(descr)); err != nil {
-				return err
-			}
-
-			return nil
+			return fimg.SetPrimPart(uint32(descr))
 		}
 	}
 

--- a/pkg/sif/create.go
+++ b/pkg/sif/create.go
@@ -443,10 +443,7 @@ func (di *DescriptorInput) SetPartExtra(fs Fstype, part Parttype, arch string) e
 	copy(extra.Arch[:], arch)
 
 	// serialize the partition data for integration with the base descriptor input
-	if err := binary.Write(&di.Extra, binary.LittleEndian, extra); err != nil {
-		return err
-	}
-	return nil
+	return binary.Write(&di.Extra, binary.LittleEndian, extra)
 }
 
 // SetSignExtra serializes the hash type and the entity info into a binary buffer.
@@ -462,10 +459,7 @@ func (di *DescriptorInput) SetSignExtra(hash Hashtype, entity string) error {
 	copy(extra.Entity[:], h)
 
 	// serialize the signature data for integration with the base descriptor input
-	if err := binary.Write(&di.Extra, binary.LittleEndian, extra); err != nil {
-		return err
-	}
-	return nil
+	return binary.Write(&di.Extra, binary.LittleEndian, extra)
 }
 
 // SetCryptoMsgExtra serializes the message format and type info into a binary buffer.
@@ -476,10 +470,7 @@ func (di *DescriptorInput) SetCryptoMsgExtra(format Formattype, message Messaget
 	}
 
 	// serialize the message data for integration with the base descriptor input
-	if err := binary.Write(&di.Extra, binary.LittleEndian, extra); err != nil {
-		return err
-	}
-	return nil
+	return binary.Write(&di.Extra, binary.LittleEndian, extra)
 }
 
 // SetName sets the byte array field "Name" to the value of string "name".


### PR DESCRIPTION
Update Codecov Orb to latest version. Use consistent naming convention (hyphens) in CI config. Replace deprecated `golint` linter with `revive`. Address lint found by `revive` linter.