### PR TITLE
Remove mmap Usage

### DIFF
--- a/pkg/integrity/select.go
+++ b/pkg/integrity/select.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"sort"
 
 	"github.com/sylabs/sif/pkg/sif"
@@ -151,10 +152,16 @@ func getGroupSignatures(f *sif.FileImage, groupID uint32, legacy bool) ([]*sif.D
 	// Filter signatures based on legacy flag.
 	sigs := make([]*sif.Descriptor, 0, len(ods))
 	for _, od := range ods {
-		isLegacy, err := isLegacySignature(od.GetData(f))
+		b := make([]byte, od.Filelen)
+		if _, err := io.ReadFull(od.GetReadSeeker(f), b); err != nil {
+			return nil, err
+		}
+
+		isLegacy, err := isLegacySignature(b)
 		if err != nil {
 			return nil, err
 		}
+
 		if isLegacy == legacy {
 			sigs = append(sigs, od)
 		}

--- a/pkg/integrity/verify.go
+++ b/pkg/integrity/verify.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -127,9 +127,14 @@ func (v *groupVerifier) fingerprints() ([][20]byte, error) {
 // of a data object descriptor fails, a DescriptorIntegrityError is returned. If verification of a
 // data object fails, a ObjectIntegrityError is returned.
 func (v *groupVerifier) verifySignature(sig *sif.Descriptor, kr openpgp.KeyRing) (imageMetadata, []uint32, *openpgp.Entity, error) { // nolint:lll
+	b := make([]byte, sig.Filelen)
+	if _, err := io.ReadFull(sig.GetReadSeeker(v.f), b); err != nil {
+		return imageMetadata{}, nil, nil, err
+	}
+
 	// Verify signature and decode image metadata.
 	var im imageMetadata
-	e, _, err := verifyAndDecodeJSON(sig.GetData(v.f), &im, kr)
+	e, _, err := verifyAndDecodeJSON(b, &im, kr)
 	if err != nil {
 		return im, nil, e, &SignatureNotValidError{ID: sig.ID, Err: err}
 	}
@@ -235,8 +240,13 @@ func (v *legacyGroupVerifier) fingerprints() ([][20]byte, error) {
 //
 // If verification of a data object fails, a ObjectIntegrityError is returned.
 func (v *legacyGroupVerifier) verifySignature(sig *sif.Descriptor, kr openpgp.KeyRing) (*openpgp.Entity, error) {
+	b := make([]byte, sig.Filelen)
+	if _, err := io.ReadFull(sig.GetReadSeeker(v.f), b); err != nil {
+		return nil, err
+	}
+
 	// Verify signature and decode plaintext.
-	e, b, _, err := verifyAndDecode(sig.GetData(v.f), kr)
+	e, b, _, err := verifyAndDecode(b, kr)
 	if err != nil {
 		return e, &SignatureNotValidError{ID: sig.ID, Err: err}
 	}
@@ -344,8 +354,13 @@ func (v *legacyObjectVerifier) fingerprints() ([][20]byte, error) {
 //
 // If verification of a data object fails, a ObjectIntegrityError is returned.
 func (v *legacyObjectVerifier) verifySignature(sig *sif.Descriptor, kr openpgp.KeyRing) (*openpgp.Entity, error) {
+	b := make([]byte, sig.Filelen)
+	if _, err := io.ReadFull(sig.GetReadSeeker(v.f), b); err != nil {
+		return nil, err
+	}
+
 	// Verify signature and decode plaintext.
-	e, b, _, err := verifyAndDecode(sig.GetData(v.f), kr)
+	e, b, _, err := verifyAndDecode(b, kr)
 	if err != nil {
 		return e, &SignatureNotValidError{ID: sig.ID, Err: err}
 	}

--- a/pkg/sif/load.go
+++ b/pkg/sif/load.go
@@ -98,6 +98,8 @@ func LoadContainerFp(fp ReadWriter, rdonly bool) (fimg FileImage, err error) {
 	}
 	fimg.Filesize = info.Size()
 
+	fimg.Amodebuf = true // for backwards compat, true == !mmap
+
 	// read global header from SIF file
 	if err = readHeader(fp, &fimg); err != nil {
 		return
@@ -120,6 +122,8 @@ func LoadContainerFp(fp ReadWriter, rdonly bool) (fimg FileImage, err error) {
 // and extract various components like the global header, descriptors and even
 // perhaps data, depending on how much is read from the source.
 func LoadContainerReader(b *bytes.Reader) (fimg FileImage, err error) {
+	fimg.Amodebuf = true // for backwards compat, true == !mmap
+
 	// read global header from SIF file
 	if err = readHeader(b, &fimg); err != nil {
 		return

--- a/pkg/sif/load.go
+++ b/pkg/sif/load.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -12,31 +12,28 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"log"
 	"os"
-	"syscall"
 )
 
-// Read the global header from the container file.
-func readHeader(fimg *FileImage) error {
-	if err := binary.Read(fimg.Reader, binary.LittleEndian, &fimg.Header); err != nil {
+// Read the global header from r.
+func readHeader(r io.Reader, fimg *FileImage) error {
+	if err := binary.Read(r, binary.LittleEndian, &fimg.Header); err != nil {
 		return fmt.Errorf("reading global header from container file: %s", err)
 	}
 
 	return nil
 }
 
-// Read the used descriptors and populate an in-memory representation of those in node list.
-func readDescriptors(fimg *FileImage) error {
+// Read the used descriptors from r and populate an in-memory representation of those in node list.
+func readDescriptors(r io.ReadSeeker, fimg *FileImage) error {
 	// start by positioning us to the start of descriptors
-	_, err := fimg.Reader.Seek(fimg.Header.Descroff, 0)
-	if err != nil {
+	if _, err := r.Seek(fimg.Header.Descroff, io.SeekStart); err != nil {
 		return fmt.Errorf("seek() setting to descriptors start: %s", err)
 	}
 
 	// Initialize descriptor array (slice) and read them all from file
 	fimg.DescrArr = make([]Descriptor, fimg.Header.Dtotal)
-	if err := binary.Read(fimg.Reader, binary.LittleEndian, &fimg.DescrArr); err != nil {
+	if err := binary.Read(r, binary.LittleEndian, &fimg.DescrArr); err != nil {
 		fimg.DescrArr = nil
 		return fmt.Errorf("reading descriptor array from container file: %s", err)
 	}
@@ -60,82 +57,6 @@ func isValidSif(fimg *FileImage) error {
 		return fmt.Errorf("invalid SIF file: Version %s want <= %s", trimZeroBytes(fimg.Header.Version[:]), HdrVersion)
 	}
 
-	return nil
-}
-
-// mapFile takes a file pointer and returns a slice of bytes representing the file data.
-func (fimg *FileImage) mapFile(rdonly bool) error {
-	info, err := fimg.Fp.Stat()
-	if err != nil {
-		return fmt.Errorf("while trying to size SIF file to mmap")
-	}
-
-	switch info.Mode() & os.ModeType {
-	case 0:
-		// regular file
-		fimg.Filesize = info.Size()
-	case os.ModeDevice:
-		// block device
-		fimg.Amodebuf = true
-		fimg.Filesize, err = fimg.Fp.Seek(0, io.SeekEnd)
-		if err != nil {
-			return fmt.Errorf("while getting block device size: %s", err)
-		}
-	default:
-		return fmt.Errorf("%s is neither a file nor a block device", fimg.Fp.Name())
-	}
-
-	fimg.Filedata = nil
-
-	if !fimg.Amodebuf {
-		prot := syscall.PROT_READ
-		flags := syscall.MAP_PRIVATE
-
-		if !rdonly {
-			prot = syscall.PROT_WRITE
-			flags = syscall.MAP_SHARED
-		}
-
-		size := nextAligned(fimg.Filesize, syscall.Getpagesize())
-		if int64(int(size)) < fimg.Filesize {
-			return fmt.Errorf("file is too big to be mapped")
-		}
-
-		fimg.Filedata, err = syscall.Mmap(int(fimg.Fp.Fd()), 0, int(size), prot, flags)
-		if err != nil {
-			// mmap failed, use sequential read() instead for top of file
-			log.Printf("mmap on %s failed (%s), reading buffer sequentially...", err, fimg.Fp.Name())
-			fimg.Amodebuf = true
-		}
-	}
-
-	if fimg.Filedata == nil {
-		fimg.Filedata = make([]byte, DataStartOffset)
-
-		// start by positioning us to the start of the file
-		_, err := fimg.Fp.Seek(0, io.SeekStart)
-		if err != nil {
-			return fmt.Errorf("seek() setting to start of file: %s", err)
-		}
-
-		if n, err := fimg.Fp.Read(fimg.Filedata); n != DataStartOffset {
-			return fmt.Errorf("short read while reading top of file: %v", err)
-		}
-	}
-
-	// create and associate a new bytes.Reader on top of mmap'ed or buffered data from file
-	fimg.Reader = bytes.NewReader(fimg.Filedata)
-
-	return nil
-}
-
-func (fimg *FileImage) unmapFile() error {
-	if fimg.Amodebuf {
-		return nil
-	}
-	if err := syscall.Munmap(fimg.Filedata); err != nil {
-		return fmt.Errorf("while calling unmapping SIF file")
-	}
 	return nil
 }
 
@@ -171,21 +92,14 @@ func LoadContainerFp(fp ReadWriter, rdonly bool) (fimg FileImage, err error) {
 	}
 	fimg.Fp = fp
 
-	defer func() {
-		if err != nil {
-			if err := fimg.unmapFile(); err != nil {
-				log.Printf("could not unmap SIF: %v", err)
-			}
-		}
-	}()
-
-	// get a memory map of the SIF file
-	if err = fimg.mapFile(rdonly); err != nil {
-		return
+	info, err := fimg.Fp.Stat()
+	if err != nil {
+		return fimg, err
 	}
+	fimg.Filesize = info.Size()
 
 	// read global header from SIF file
-	if err = readHeader(&fimg); err != nil {
+	if err = readHeader(fp, &fimg); err != nil {
 		return
 	}
 
@@ -195,7 +109,7 @@ func LoadContainerFp(fp ReadWriter, rdonly bool) (fimg FileImage, err error) {
 	}
 
 	// read descriptor array from SIF file
-	if err = readDescriptors(&fimg); err != nil {
+	if err = readDescriptors(fp, &fimg); err != nil {
 		return
 	}
 
@@ -206,10 +120,8 @@ func LoadContainerFp(fp ReadWriter, rdonly bool) (fimg FileImage, err error) {
 // and extract various components like the global header, descriptors and even
 // perhaps data, depending on how much is read from the source.
 func LoadContainerReader(b *bytes.Reader) (fimg FileImage, err error) {
-	fimg.Reader = b
-
 	// read global header from SIF file
-	if err = readHeader(&fimg); err != nil {
+	if err = readHeader(b, &fimg); err != nil {
 		return
 	}
 
@@ -220,7 +132,7 @@ func LoadContainerReader(b *bytes.Reader) (fimg FileImage, err error) {
 
 	// in the case where the reader buffer doesn't include descriptor data, we
 	// don't return an error and DescrArr will be set to nil
-	if readErr := readDescriptors(&fimg); readErr != nil {
+	if readErr := readDescriptors(b, &fimg); readErr != nil {
 		fmt.Println("Error reading descriptors: ", readErr)
 	}
 
@@ -231,9 +143,6 @@ func LoadContainerReader(b *bytes.Reader) (fimg FileImage, err error) {
 func (fimg *FileImage) UnloadContainer() (err error) {
 	// if SIF data comes from file, not a slice buffer (see LoadContainer() variants)
 	if fimg.Fp != nil {
-		if err = fimg.unmapFile(); err != nil {
-			return
-		}
 		if err = fimg.Fp.Close(); err != nil {
 			return fmt.Errorf("closing SIF file failed, corrupted: don't use: %s", err)
 		}

--- a/pkg/sif/load_test.go
+++ b/pkg/sif/load_test.go
@@ -26,18 +26,38 @@ func TestLoadContainer(t *testing.T) {
 }
 
 func TestLoadContainerFp(t *testing.T) {
-	fp, err := os.Open("testdata/testcontainer2.sif")
-	if err != nil {
-		t.Error("error opening testdata/testcontainer2.sif:", err)
+	tests := []struct {
+		name   string
+		offset int64
+	}{
+		{
+			name: "NoSeek",
+		},
+		{
+			name:   "Seek",
+			offset: 1,
+		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fp, err := os.Open("testdata/testcontainer2.sif")
+			if err != nil {
+				t.Fatal("error opening testdata/testcontainer2.sif:", err)
+			}
 
-	fimg, err := LoadContainerFp(fp, true)
-	if err != nil {
-		t.Error("LoadContainerFp(fp, true):", err)
-	}
+			if _, err := fp.Seek(tt.offset, io.SeekStart); err != nil {
+				t.Fatal(err)
+			}
 
-	if err = fimg.UnloadContainer(); err != nil {
-		t.Error("fimg.UnloadContainer():", err)
+			fimg, err := LoadContainerFp(fp, true)
+			if err != nil {
+				t.Error("LoadContainerFp(fp, true):", err)
+			}
+
+			if err = fimg.UnloadContainer(); err != nil {
+				t.Error("fimg.UnloadContainer():", err)
+			}
+		})
 	}
 }
 
@@ -251,7 +271,7 @@ func TestLoadContainerReader(t *testing.T) {
 	r := bytes.NewReader(content[:31768])
 	fimg, err := LoadContainerReader(r)
 	if err != nil || fimg.DescrArr != nil {
-		t.Error(`LoadContainerBuffer(buf):`, err)
+		t.Error(`LoadContainerReader(buf):`, err)
 	}
 
 	if err = fimg.UnloadContainer(); err != nil {
@@ -262,7 +282,7 @@ func TestLoadContainerReader(t *testing.T) {
 	r = bytes.NewReader(content[:32768])
 	fimg, err = LoadContainerReader(r)
 	if err != nil {
-		t.Error(`LoadContainerBuffer(buf):`, err)
+		t.Error(`LoadContainerReader(buf):`, err)
 	}
 
 	if err = fimg.UnloadContainer(); err != nil {

--- a/pkg/sif/lookup.go
+++ b/pkg/sif/lookup.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -252,32 +252,19 @@ func (fimg *FileImage) GetFromDescr(descr Descriptor) ([]*Descriptor, []int, err
 	return descrs, indexes, nil
 }
 
-// GetData return a memory mapped byte slice mirroring the data object in a SIF file.
+// GetData returns the data object associated with descriptor d from image fimg, or nil on error.
 func (d *Descriptor) GetData(fimg *FileImage) []byte {
-	if fimg.Amodebuf {
-		data := make([]byte, d.Filelen)
-		if _, err := io.ReadFull(d.GetReadSeeker(fimg), data); err != nil {
-			return nil
-		}
-		return data
-	}
-
-	if d.Fileoff+d.Filelen > int64(len(fimg.Filedata)) {
-		// there's not enough data in the file to account for the indicated
-		// payload. Is the header corrupted?
+	b := make([]byte, d.Filelen)
+	if _, err := io.ReadFull(d.GetReadSeeker(fimg), b); err != nil {
 		return nil
 	}
-
-	return fimg.Filedata[d.Fileoff : d.Fileoff+d.Filelen]
+	return b
 }
 
 // GetReadSeeker returns a io.ReadSeeker that reads the data object associated with descriptor d
 // from image fimg.
 func (d *Descriptor) GetReadSeeker(fimg *FileImage) io.ReadSeeker {
-	if fimg.Amodebuf {
-		return io.NewSectionReader(fimg.Fp, d.Fileoff, d.Filelen)
-	}
-	return io.NewSectionReader(fimg.Reader, d.Fileoff, d.Filelen)
+	return io.NewSectionReader(fimg.Fp, d.Fileoff, d.Filelen)
 }
 
 // GetName returns the name tag associated with the descriptor. Analogous to file name.

--- a/pkg/sif/lookup_test.go
+++ b/pkg/sif/lookup_test.go
@@ -7,7 +7,7 @@ package sif
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"path/filepath"
 	"testing"
 )
@@ -325,8 +325,8 @@ func TestGetReadSeeker(t *testing.T) {
 			}
 
 			// Read data via ReadSeeker and validate data.
-			b, err := ioutil.ReadAll(descr.GetReadSeeker(tt.fimg))
-			if err != nil {
+			b := make([]byte, descr.Filelen)
+			if _, err := io.ReadFull(descr.GetReadSeeker(tt.fimg), b); err != nil {
 				t.Fatalf("failed to read: %v", err)
 			}
 			if got, want := string(b[5:10]), "BEGIN"; got != want {

--- a/pkg/sif/lookup_test.go
+++ b/pkg/sif/lookup_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -262,25 +262,11 @@ func TestFromDescr(t *testing.T) {
 }
 
 func TestGetData(t *testing.T) {
-	mmapImage, err := LoadContainer(filepath.Join("testdata", "testcontainer2.sif"), true)
-	if err != nil {
-		t.Fatalf("failed to load container: %v", err)
-	}
-	defer func() {
-		if err := mmapImage.UnloadContainer(); err != nil {
-			t.Error(err)
-		}
-	}()
-
-	// It's a little tough to test the code path for buffered I/O. Cheat a little by forcing
-	// Amodebuf to true, which simulates that.
 	bufferedImage, err := LoadContainer(filepath.Join("testdata", "testcontainer2.sif"), true)
 	if err != nil {
 		t.Fatalf("failed to load container: %v", err)
 	}
-	bufferedImage.Amodebuf = true // apply hack to fake buffered I/O
 	defer func() {
-		bufferedImage.Amodebuf = false // undo hack to fake buffered I/O (ensures munmap called)
 		if err := bufferedImage.UnloadContainer(); err != nil {
 			t.Error(err)
 		}
@@ -290,7 +276,6 @@ func TestGetData(t *testing.T) {
 		name string
 		fimg *FileImage
 	}{
-		{"Mmap", &mmapImage},
 		{"Buffered", &bufferedImage},
 	}
 
@@ -313,25 +298,11 @@ func TestGetData(t *testing.T) {
 }
 
 func TestGetReadSeeker(t *testing.T) {
-	mmapImage, err := LoadContainer(filepath.Join("testdata", "testcontainer2.sif"), true)
-	if err != nil {
-		t.Fatalf("failed to load container: %v", err)
-	}
-	defer func() {
-		if err := mmapImage.UnloadContainer(); err != nil {
-			t.Error(err)
-		}
-	}()
-
-	// It's a little tough to test the code path for buffered I/O. Cheat a little by forcing
-	// Amodebuf to true, which simulates that.
 	bufferedImage, err := LoadContainer(filepath.Join("testdata", "testcontainer2.sif"), true)
 	if err != nil {
 		t.Fatalf("failed to load container: %v", err)
 	}
-	bufferedImage.Amodebuf = true // apply hack to fake buffered I/O
 	defer func() {
-		bufferedImage.Amodebuf = false // undo hack to fake buffered I/O (ensures munmap called)
 		if err := bufferedImage.UnloadContainer(); err != nil {
 			t.Error(err)
 		}
@@ -341,7 +312,6 @@ func TestGetReadSeeker(t *testing.T) {
 		name string
 		fimg *FileImage
 	}{
-		{"Mmap", &mmapImage},
 		{"Buffered", &bufferedImage},
 	}
 

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -304,9 +304,9 @@ type FileImage struct {
 	Header     Header        // the loaded SIF global header
 	Fp         ReadWriter    // file pointer of opened SIF file
 	Filesize   int64         // file size of the opened SIF file
-	Filedata   []byte        // the content of the opened file
-	Amodebuf   bool          // access mode: mmap = false, buffered = true
-	Reader     *bytes.Reader // reader on top of Mapdata
+	Filedata   []byte        // Deprecated: Filedata exists for historical compatibility and should not be used.
+	Amodebuf   bool          // Deprecated: Amodebuf exists for historical compatibility and should not be used.
+	Reader     *bytes.Reader // Deprecated: Reader exists for historical compatibility and should not be used.
 	DescrArr   []Descriptor  // slice of loaded descriptors from SIF file
 	PrimPartID uint32        // ID of primary system partition if present
 }


### PR DESCRIPTION
Address occasional `SIGBUS` when accessing SIF file stored on a non-local filesystem by removing `mmap` usage.

Clarify `GetData` behaviour on error. Replace `GetData` usage with `GetReadSeeker` in `integrity` package.

Fixes #11 