### PR TITLE
Add GetReader

### DIFF
--- a/pkg/integrity/metadata.go
+++ b/pkg/integrity/metadata.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -204,7 +204,7 @@ func (om objectMetadata) matches(f *sif.FileImage, od *sif.Descriptor) error {
 		return &DescriptorIntegrityError{ID: od.ID}
 	}
 
-	if ok, err := om.ObjectDigest.matches(od.GetReadSeeker(f)); err != nil {
+	if ok, err := om.ObjectDigest.matches(od.GetReader(f)); err != nil {
 		return err
 	} else if !ok {
 		return &ObjectIntegrityError{ID: od.ID}
@@ -242,7 +242,7 @@ func getImageMetadata(f *sif.FileImage, minID uint32, ods []*sif.Descriptor, h c
 			return imageMetadata{}, errMinimumIDInvalid
 		}
 
-		om, err := getObjectMetadata(od.ID-minID, *od, od.GetReadSeeker(f), h)
+		om, err := getObjectMetadata(od.ID-minID, *od, od.GetReader(f), h)
 		if err != nil {
 			return imageMetadata{}, err
 		}

--- a/pkg/integrity/select.go
+++ b/pkg/integrity/select.go
@@ -153,7 +153,7 @@ func getGroupSignatures(f *sif.FileImage, groupID uint32, legacy bool) ([]*sif.D
 	sigs := make([]*sif.Descriptor, 0, len(ods))
 	for _, od := range ods {
 		b := make([]byte, od.Filelen)
-		if _, err := io.ReadFull(od.GetReadSeeker(f), b); err != nil {
+		if _, err := io.ReadFull(od.GetReader(f), b); err != nil {
 			return nil, err
 		}
 

--- a/pkg/integrity/verify.go
+++ b/pkg/integrity/verify.go
@@ -128,7 +128,7 @@ func (v *groupVerifier) fingerprints() ([][20]byte, error) {
 // data object fails, a ObjectIntegrityError is returned.
 func (v *groupVerifier) verifySignature(sig *sif.Descriptor, kr openpgp.KeyRing) (imageMetadata, []uint32, *openpgp.Entity, error) { // nolint:lll
 	b := make([]byte, sig.Filelen)
-	if _, err := io.ReadFull(sig.GetReadSeeker(v.f), b); err != nil {
+	if _, err := io.ReadFull(sig.GetReader(v.f), b); err != nil {
 		return imageMetadata{}, nil, nil, err
 	}
 
@@ -241,7 +241,7 @@ func (v *legacyGroupVerifier) fingerprints() ([][20]byte, error) {
 // If verification of a data object fails, a ObjectIntegrityError is returned.
 func (v *legacyGroupVerifier) verifySignature(sig *sif.Descriptor, kr openpgp.KeyRing) (*openpgp.Entity, error) {
 	b := make([]byte, sig.Filelen)
-	if _, err := io.ReadFull(sig.GetReadSeeker(v.f), b); err != nil {
+	if _, err := io.ReadFull(sig.GetReader(v.f), b); err != nil {
 		return nil, err
 	}
 
@@ -275,7 +275,7 @@ func (v *legacyGroupVerifier) verifySignature(sig *sif.Descriptor, kr openpgp.Ke
 	// Get reader covering all non-signature objects.
 	rs := make([]io.Reader, 0, len(v.ods))
 	for _, od := range v.ods {
-		rs = append(rs, od.GetReadSeeker(v.f))
+		rs = append(rs, od.GetReader(v.f))
 	}
 	r := io.MultiReader(rs...)
 
@@ -355,7 +355,7 @@ func (v *legacyObjectVerifier) fingerprints() ([][20]byte, error) {
 // If verification of a data object fails, a ObjectIntegrityError is returned.
 func (v *legacyObjectVerifier) verifySignature(sig *sif.Descriptor, kr openpgp.KeyRing) (*openpgp.Entity, error) {
 	b := make([]byte, sig.Filelen)
-	if _, err := io.ReadFull(sig.GetReadSeeker(v.f), b); err != nil {
+	if _, err := io.ReadFull(sig.GetReader(v.f), b); err != nil {
 		return nil, err
 	}
 
@@ -387,7 +387,7 @@ func (v *legacyObjectVerifier) verifySignature(sig *sif.Descriptor, kr openpgp.K
 	}
 
 	// Verify object integrity.
-	if ok, err := d.matches(v.od.GetReadSeeker(v.f)); err != nil {
+	if ok, err := d.matches(v.od.GetReader(v.f)); err != nil {
 		return e, err
 	} else if !ok {
 		return e, &ObjectIntegrityError{ID: v.od.ID}

--- a/pkg/sif/lookup.go
+++ b/pkg/sif/lookup.go
@@ -263,7 +263,16 @@ func (d *Descriptor) GetData(fimg *FileImage) []byte {
 
 // GetReadSeeker returns a io.ReadSeeker that reads the data object associated with descriptor d
 // from image fimg.
+//
+// Deprecated: GetReadSeeker will be removed in a future release. Use GetData or GetReader to read
+// the data object.
 func (d *Descriptor) GetReadSeeker(fimg *FileImage) io.ReadSeeker {
+	return io.NewSectionReader(fimg.Fp, d.Fileoff, d.Filelen)
+}
+
+// GetReader returns a io.Reader that reads the data object associated with descriptor d from image
+// fimg.
+func (d *Descriptor) GetReader(fimg *FileImage) io.Reader {
 	return io.NewSectionReader(fimg.Fp, d.Fileoff, d.Filelen)
 }
 


### PR DESCRIPTION
Add `GetReader` and deprecate `GetReadSeeker`. Replace usage of `GetReadSeeker` with `GetReader` in `integrity` package.

Closes #14 