### PR TITLE
Deprecate Formatting Functions

### DIFF
--- a/internal/app/siftool/info.go
+++ b/internal/app/siftool/info.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // Copyright (c) 2018, Divya Cote <divya.cote@gmail.com> All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
@@ -30,6 +30,7 @@ func Header(file string) error {
 		}
 	}()
 
+	//nolint:staticcheck // In use until v2 API to avoid code duplication
 	fmt.Print(fimg.FmtHeader())
 
 	return nil
@@ -54,6 +55,7 @@ func List(file string) error {
 
 	fmt.Println("Descriptor list:")
 
+	//nolint:staticcheck // In use until v2 API to avoid code duplication
 	fmt.Print(fimg.FmtDescrList())
 
 	return nil
@@ -71,6 +73,7 @@ func Info(descr uint64, file string) error {
 		}
 	}()
 
+	//nolint:staticcheck // In use until v2 API to avoid code duplication
 	fmt.Print(fimg.FmtDescrInfo(uint32(descr)))
 
 	return nil

--- a/pkg/sif/fmt.go
+++ b/pkg/sif/fmt.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // Copyright (c) 2018, Divya Cote <divya.cote@gmail.com> All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
@@ -10,29 +10,6 @@ import (
 	"fmt"
 	"time"
 )
-
-// String will return a string corresponding to the Datatype.
-func (d Datatype) String() string {
-	switch d {
-	case DataDeffile:
-		return "Def.FILE"
-	case DataEnvVar:
-		return "Env.Vars"
-	case DataLabels:
-		return "JSON.Labels"
-	case DataPartition:
-		return "FS"
-	case DataSignature:
-		return "Signature"
-	case DataGenericJSON:
-		return "JSON.Generic"
-	case DataGeneric:
-		return "Generic/Raw"
-	case DataCryptoMessage:
-		return "Cryptographic Message"
-	}
-	return "Unknown"
-}
 
 // readableSize returns the size in human readable format.
 func readableSize(size uint64) string {
@@ -78,77 +55,6 @@ func (fimg *FileImage) FmtHeader() string {
 	s += fmt.Sprintln("Datalen: ", readableSize(uint64(fimg.Header.Datalen)))
 
 	return s
-}
-
-// fstypeStr returns a string representation of a file system type.
-func fstypeStr(ftype Fstype) string {
-	switch ftype {
-	case FsSquash:
-		return "Squashfs"
-	case FsExt3:
-		return "Ext3"
-	case FsImmuObj:
-		return "Archive"
-	case FsRaw:
-		return "Raw"
-	case FsEncryptedSquashfs:
-		return "Encrypted squashfs"
-	}
-	return "Unknown fs-type"
-}
-
-// parttypeStr returns a string representation of a partition type.
-func parttypeStr(ptype Parttype) string {
-	switch ptype {
-	case PartSystem:
-		return "System"
-	case PartPrimSys:
-		return "*System"
-	case PartData:
-		return "Data"
-	case PartOverlay:
-		return "Overlay"
-	}
-	return "Unknown part-type"
-}
-
-// hashtypeStr returns a string representation of a  hash type.
-func hashtypeStr(htype Hashtype) string {
-	switch htype {
-	case HashSHA256:
-		return "SHA256"
-	case HashSHA384:
-		return "SHA384"
-	case HashSHA512:
-		return "SHA512"
-	case HashBLAKE2S:
-		return "BLAKE2S"
-	case HashBLAKE2B:
-		return "BLAKE2B"
-	}
-	return "Unknown hash-type"
-}
-
-// formattypeStr returns a string representation of a format type.
-func formattypeStr(ftype Formattype) string {
-	switch ftype {
-	case FormatOpenPGP:
-		return "OpenPGP"
-	case FormatPEM:
-		return "PEM"
-	}
-	return "Unknown format-type"
-}
-
-// messagetypeStr returns a string representation of a message type.
-func messagetypeStr(mtype Messagetype) string {
-	switch mtype {
-	case MessageClearSignature:
-		return "Clear Signature"
-	case MessageRSAOAEP:
-		return "RSA-OAEP"
-	}
-	return "Unknown message-type"
 }
 
 // FmtDescrList formats the output of a list of all active descriptors from a SIF file.

--- a/pkg/sif/fmt.go
+++ b/pkg/sif/fmt.go
@@ -39,6 +39,8 @@ func readableSize(size uint64) string {
 }
 
 // FmtHeader formats the output of a SIF file global header.
+//
+// Deprecated: FmtHeader will be removed in a future release.
 func (fimg *FileImage) FmtHeader() string {
 	s := fmt.Sprintln("Launch:  ", trimZeroBytes(fimg.Header.Launch[:]))
 	s += fmt.Sprintln("Magic:   ", trimZeroBytes(fimg.Header.Magic[:]))
@@ -58,6 +60,8 @@ func (fimg *FileImage) FmtHeader() string {
 }
 
 // FmtDescrList formats the output of a list of all active descriptors from a SIF file.
+//
+// Deprecated: FmtDescrList will be removed in a future release.
 func (fimg *FileImage) FmtDescrList() string {
 	s := fmt.Sprintf("%-4s %-8s %-8s %-26s %s\n", "ID", "|GROUP", "|LINK", "|SIF POSITION (start-end)", "|TYPE")
 	s += fmt.Sprintln("------------------------------------------------------------------------------")
@@ -108,6 +112,8 @@ func (fimg *FileImage) FmtDescrList() string {
 }
 
 // FmtDescrInfo formats the output of detailed info about a descriptor from a SIF file.
+//
+// Deprecated: FmtDescrInfo will be removed in a future release.
 func (fimg *FileImage) FmtDescrInfo(id uint32) string {
 	var s string
 

--- a/pkg/sif/fmt.go
+++ b/pkg/sif/fmt.go
@@ -90,14 +90,14 @@ func (fimg *FileImage) FmtDescrList() string {
 				f, _ := v.GetFsType()
 				p, _ := v.GetPartType()
 				a, _ := v.GetArch()
-				s += fmt.Sprintf("|%s (%s/%s/%s)\n", v.Datatype, fstypeStr(f), parttypeStr(p), GetGoArch(trimZeroBytes(a[:])))
+				s += fmt.Sprintf("|%s (%s/%s/%s)\n", v.Datatype, f, p, GetGoArch(trimZeroBytes(a[:])))
 			case DataSignature:
 				h, _ := v.GetHashType()
-				s += fmt.Sprintf("|%s (%s)\n", v.Datatype, hashtypeStr(h))
+				s += fmt.Sprintf("|%s (%s)\n", v.Datatype, h)
 			case DataCryptoMessage:
 				f, _ := v.GetFormatType()
 				m, _ := v.GetMessageType()
-				s += fmt.Sprintf("|%s (%s/%s)\n", v.Datatype, formattypeStr(f), messagetypeStr(m))
+				s += fmt.Sprintf("|%s (%s/%s)\n", v.Datatype, f, m)
 			default:
 				s += fmt.Sprintf("|%s\n", v.Datatype)
 			}
@@ -145,19 +145,19 @@ func (fimg *FileImage) FmtDescrInfo(id uint32) string {
 				f, _ := v.GetFsType()
 				p, _ := v.GetPartType()
 				a, _ := v.GetArch()
-				s += fmt.Sprintln("  Fstype:   ", fstypeStr(f))
-				s += fmt.Sprintln("  Parttype: ", parttypeStr(p))
+				s += fmt.Sprintln("  Fstype:   ", f)
+				s += fmt.Sprintln("  Parttype: ", p)
 				s += fmt.Sprintln("  Arch:     ", GetGoArch(trimZeroBytes(a[:])))
 			case DataSignature:
 				h, _ := v.GetHashType()
 				e, _ := v.GetEntityString()
-				s += fmt.Sprintln("  Hashtype: ", hashtypeStr(h))
+				s += fmt.Sprintln("  Hashtype: ", h)
 				s += fmt.Sprintln("  Entity:   ", e)
 			case DataCryptoMessage:
 				f, _ := v.GetFormatType()
 				m, _ := v.GetMessageType()
-				s += fmt.Sprintln("  Fmttype:  ", formattypeStr(f))
-				s += fmt.Sprintln("  Msgtype:  ", messagetypeStr(m))
+				s += fmt.Sprintln("  Fmttype:  ", f)
+				s += fmt.Sprintln("  Msgtype:  ", m)
 			}
 
 			return s

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -140,9 +140,9 @@ const (
 	DataCryptoMessage                          // cryptographic message data object
 )
 
-// String will return a string corresponding to the Datatype.
-func (d Datatype) String() string {
-	switch d {
+// String returns a human-readable representation of t.
+func (t Datatype) String() string {
+	switch t {
 	case DataDeffile:
 		return "Def.FILE"
 	case DataEnvVar:
@@ -175,9 +175,9 @@ const (
 	FsEncryptedSquashfs                   // Encrypted Squashfs file system, RDONLY
 )
 
-// fstypeStr returns a string representation of a file system type.
-func fstypeStr(ftype Fstype) string {
-	switch ftype {
+// String returns a human-readable representation of t.
+func (t Fstype) String() string {
+	switch t {
 	case FsSquash:
 		return "Squashfs"
 	case FsExt3:
@@ -189,7 +189,7 @@ func fstypeStr(ftype Fstype) string {
 	case FsEncryptedSquashfs:
 		return "Encrypted squashfs"
 	}
-	return "Unknown fs-type"
+	return "Unknown"
 }
 
 // Parttype represents the different SIF container partition types (system and data).
@@ -203,9 +203,9 @@ const (
 	PartOverlay                     // partition hosts an overlay
 )
 
-// parttypeStr returns a string representation of a partition type.
-func parttypeStr(ptype Parttype) string {
-	switch ptype {
+// String returns a human-readable representation of t.
+func (t Parttype) String() string {
+	switch t {
 	case PartSystem:
 		return "System"
 	case PartPrimSys:
@@ -215,7 +215,7 @@ func parttypeStr(ptype Parttype) string {
 	case PartOverlay:
 		return "Overlay"
 	}
-	return "Unknown part-type"
+	return "Unknown"
 }
 
 // Hashtype represents the different SIF hashing function types used to fingerprint data objects.
@@ -230,9 +230,9 @@ const (
 	HashBLAKE2B
 )
 
-// hashtypeStr returns a string representation of a  hash type.
-func hashtypeStr(htype Hashtype) string {
-	switch htype {
+// String returns a human-readable representation of t.
+func (t Hashtype) String() string {
+	switch t {
 	case HashSHA256:
 		return "SHA256"
 	case HashSHA384:
@@ -244,7 +244,7 @@ func hashtypeStr(htype Hashtype) string {
 	case HashBLAKE2B:
 		return "BLAKE2B"
 	}
-	return "Unknown hash-type"
+	return "Unknown"
 }
 
 // Formattype represents the different formats used to store cryptographic message objects.
@@ -256,15 +256,15 @@ const (
 	FormatPEM
 )
 
-// formattypeStr returns a string representation of a format type.
-func formattypeStr(ftype Formattype) string {
-	switch ftype {
+// String returns a human-readable representation of t.
+func (t Formattype) String() string {
+	switch t {
 	case FormatOpenPGP:
 		return "OpenPGP"
 	case FormatPEM:
 		return "PEM"
 	}
-	return "Unknown format-type"
+	return "Unknown"
 }
 
 // Messagetype represents the different messages stored within cryptographic message objects.
@@ -279,15 +279,15 @@ const (
 	MessageRSAOAEP Messagetype = 0x200
 )
 
-// messagetypeStr returns a string representation of a message type.
-func messagetypeStr(mtype Messagetype) string {
-	switch mtype {
+// String returns a human-readable representation of t.
+func (t Messagetype) String() string {
+	switch t {
 	case MessageClearSignature:
 		return "Clear Signature"
 	case MessageRSAOAEP:
 		return "RSA-OAEP"
 	}
-	return "Unknown message-type"
+	return "Unknown"
 }
 
 // SIF data object deletion strategies.

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -140,6 +140,29 @@ const (
 	DataCryptoMessage                          // cryptographic message data object
 )
 
+// String will return a string corresponding to the Datatype.
+func (d Datatype) String() string {
+	switch d {
+	case DataDeffile:
+		return "Def.FILE"
+	case DataEnvVar:
+		return "Env.Vars"
+	case DataLabels:
+		return "JSON.Labels"
+	case DataPartition:
+		return "FS"
+	case DataSignature:
+		return "Signature"
+	case DataGenericJSON:
+		return "JSON.Generic"
+	case DataGeneric:
+		return "Generic/Raw"
+	case DataCryptoMessage:
+		return "Cryptographic Message"
+	}
+	return "Unknown"
+}
+
 // Fstype represents the different SIF file system types found in partition data objects.
 type Fstype int32
 
@@ -152,6 +175,23 @@ const (
 	FsEncryptedSquashfs                   // Encrypted Squashfs file system, RDONLY
 )
 
+// fstypeStr returns a string representation of a file system type.
+func fstypeStr(ftype Fstype) string {
+	switch ftype {
+	case FsSquash:
+		return "Squashfs"
+	case FsExt3:
+		return "Ext3"
+	case FsImmuObj:
+		return "Archive"
+	case FsRaw:
+		return "Raw"
+	case FsEncryptedSquashfs:
+		return "Encrypted squashfs"
+	}
+	return "Unknown fs-type"
+}
+
 // Parttype represents the different SIF container partition types (system and data).
 type Parttype int32
 
@@ -162,6 +202,21 @@ const (
 	PartData                        // partition hosts data only
 	PartOverlay                     // partition hosts an overlay
 )
+
+// parttypeStr returns a string representation of a partition type.
+func parttypeStr(ptype Parttype) string {
+	switch ptype {
+	case PartSystem:
+		return "System"
+	case PartPrimSys:
+		return "*System"
+	case PartData:
+		return "Data"
+	case PartOverlay:
+		return "Overlay"
+	}
+	return "Unknown part-type"
+}
 
 // Hashtype represents the different SIF hashing function types used to fingerprint data objects.
 type Hashtype int32
@@ -175,6 +230,23 @@ const (
 	HashBLAKE2B
 )
 
+// hashtypeStr returns a string representation of a  hash type.
+func hashtypeStr(htype Hashtype) string {
+	switch htype {
+	case HashSHA256:
+		return "SHA256"
+	case HashSHA384:
+		return "SHA384"
+	case HashSHA512:
+		return "SHA512"
+	case HashBLAKE2S:
+		return "BLAKE2S"
+	case HashBLAKE2B:
+		return "BLAKE2B"
+	}
+	return "Unknown hash-type"
+}
+
 // Formattype represents the different formats used to store cryptographic message objects.
 type Formattype int32
 
@@ -183,6 +255,17 @@ const (
 	FormatOpenPGP Formattype = iota + 1
 	FormatPEM
 )
+
+// formattypeStr returns a string representation of a format type.
+func formattypeStr(ftype Formattype) string {
+	switch ftype {
+	case FormatOpenPGP:
+		return "OpenPGP"
+	case FormatPEM:
+		return "PEM"
+	}
+	return "Unknown format-type"
+}
 
 // Messagetype represents the different messages stored within cryptographic message objects.
 type Messagetype int32
@@ -195,6 +278,17 @@ const (
 	// PEM formatted messages.
 	MessageRSAOAEP Messagetype = 0x200
 )
+
+// messagetypeStr returns a string representation of a message type.
+func messagetypeStr(mtype Messagetype) string {
+	switch mtype {
+	case MessageClearSignature:
+		return "Clear Signature"
+	case MessageRSAOAEP:
+		return "RSA-OAEP"
+	}
+	return "Unknown message-type"
+}
 
 // SIF data object deletion strategies.
 const (

--- a/pkg/sif/testdata/TestFileImage_FmtDescrInfo/One.golden
+++ b/pkg/sif/testdata/TestFileImage_FmtDescrInfo/One.golden
@@ -1,0 +1,13 @@
+Descr slot#: 0
+  Datatype:  Def.FILE
+  ID:        1
+  Used:      true
+  Groupid:   1
+  Link:      NONE
+  Fileoff:   32768
+  Filelen:   62
+  Ctime:     2018-08-14 07:45:59 +0000 UTC
+  Mtime:     2018-08-14 07:45:59 +0000 UTC
+  UID:       1002
+  Gid:       1002
+  Name:      busybox.deffile

--- a/pkg/sif/testdata/TestFileImage_FmtDescrInfo/Three.golden
+++ b/pkg/sif/testdata/TestFileImage_FmtDescrInfo/Three.golden
@@ -1,0 +1,15 @@
+Descr slot#: 2
+  Datatype:  Signature
+  ID:        3
+  Used:      true
+  Groupid:   1
+  Link:      2
+  Fileoff:   1753088
+  Filelen:   955
+  Ctime:     2018-08-14 07:47:36 +0000 UTC
+  Mtime:     2018-08-14 07:47:36 +0000 UTC
+  UID:       1002
+  Gid:       1002
+  Name:      part-signature
+  Hashtype:  SHA384
+  Entity:    9F2B6C36D999A3E91CB3104720671590C12D4222

--- a/pkg/sif/testdata/TestFileImage_FmtDescrInfo/Two.golden
+++ b/pkg/sif/testdata/TestFileImage_FmtDescrInfo/Two.golden
@@ -1,0 +1,16 @@
+Descr slot#: 1
+  Datatype:  FS
+  ID:        2
+  Used:      true
+  Groupid:   1
+  Link:      NONE
+  Fileoff:   1048576
+  Filelen:   704512
+  Ctime:     2018-08-14 07:45:59 +0000 UTC
+  Mtime:     2018-08-14 07:45:59 +0000 UTC
+  UID:       1002
+  Gid:       1002
+  Name:      busybox.squash
+  Fstype:    Squashfs
+  Parttype:  *System
+  Arch:      amd64

--- a/pkg/sif/testdata/TestFileImage_FmtDescrList/output.golden
+++ b/pkg/sif/testdata/TestFileImage_FmtDescrList/output.golden
@@ -1,0 +1,5 @@
+ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
+------------------------------------------------------------------------------
+1    |1       |NONE    |32768-32830               |Def.FILE
+2    |1       |NONE    |1048576-1753088           |FS (Squashfs/*System/amd64)
+3    |1       |2       |1753088-1754043           |Signature (SHA384)

--- a/pkg/sif/testdata/TestFileImage_FmtHeader/output.golden
+++ b/pkg/sif/testdata/TestFileImage_FmtHeader/output.golden
@@ -1,0 +1,14 @@
+Launch:   #!/usr/bin/env run-singularity
+
+Magic:    SIF_MAGIC
+Version:  00
+Arch:     amd64
+ID:       293e8b11-dbd0-47e6-b0b9-390772c12be8
+Ctime:    2018-08-14 07:45:59 +0000 UTC
+Mtime:    2018-08-14 07:47:36 +0000 UTC
+Dfree:    45
+Dtotal:   48
+Descoff:  4096
+Descrlen: 27KB
+Dataoff:  32768
+Datalen:  1MB


### PR DESCRIPTION
Deprecate [`FmtDescrInfo`](https://pkg.go.dev/github.com/sylabs/sif@v1.3.0/pkg/sif#FileImage.FmtDescrInfo), [`FmtDescrList`](https://pkg.go.dev/github.com/sylabs/sif@v1.3.0/pkg/sif#FileImage.FmtDescrList), and [`FmtHeader`](https://pkg.go.dev/github.com/sylabs/sif@v1.3.0/pkg/sif#FileImage.FmtHeader) in preparation for removal from v2 API (#22).

Expose `func String()` for `Fstype`, `Parttype`, `Hashtype`, `Formattype`, `Messagetype` types. Use `goldie` in formatting unit tests.