### PR TITLE
Refactor siftool Package

### DIFF
--- a/cmd/siftool/info.go
+++ b/cmd/siftool/info.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2021, Sylabs Inc. All rights reserved.
 // Copyright (c) 2018, Divya Cote <divya.cote@gmail.com> All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
@@ -41,7 +42,7 @@ func cmdInfo(args []string) error {
 		return fmt.Errorf("while converting input descriptor id: %s", err)
 	}
 
-	return siftool.Info(id, args[1])
+	return siftool.Info(args[1], uint32(id))
 }
 
 // cmdDump extracts and output a data object from a SIF file to stdout.
@@ -55,5 +56,5 @@ func cmdDump(args []string) error {
 		return fmt.Errorf("while converting input descriptor id: %s", err)
 	}
 
-	return siftool.Dump(id, args[1])
+	return siftool.Dump(args[1], uint32(id))
 }

--- a/cmd/siftool/modif.go
+++ b/cmd/siftool/modif.go
@@ -6,8 +6,10 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/sylabs/sif/internal/app/siftool"
@@ -15,14 +17,14 @@ import (
 )
 
 var (
-	datatype   = flag.Int64("datatype", -1, "")
-	parttype   = flag.Int64("parttype", -1, "")
-	partfs     = flag.Int64("partfs", -1, "")
-	partarch   = flag.Int64("partarch", -1, "")
-	signhash   = flag.Int64("signhash", -1, "")
+	datatype   = flag.Int("datatype", 0, "")
+	parttype   = flag.Int("parttype", 0, "")
+	partfs     = flag.Int("partfs", 0, "")
+	partarch   = flag.Int("partarch", 0, "")
+	signhash   = flag.Int("signhash", 0, "")
 	signentity = flag.String("signentity", "", "")
-	groupid    = flag.Int64("groupid", sif.DescrUnusedGroup, "")
-	link       = flag.Int64("link", sif.DescrUnusedLink, "")
+	groupid    = flag.Int("groupid", 0, "")
+	link       = flag.Int("link", 0, "")
 	alignment  = flag.Int("alignment", 0, "")
 	filename   = flag.String("filename", "", "")
 )
@@ -41,19 +43,92 @@ func cmdAdd(args []string) error {
 	}
 
 	opts := siftool.AddOptions{
-		Datatype:   datatype,
-		Parttype:   parttype,
-		Partfs:     partfs,
-		Partarch:   partarch,
-		Signhash:   signhash,
-		Signentity: signentity,
-		Groupid:    groupid,
-		Link:       link,
-		Alignment:  alignment,
-		Filename:   filename,
+		Groupid:   uint32(*groupid),
+		Link:      uint32(*link),
+		Alignment: *alignment,
+		Filename:  *filename,
+		Fp:        os.Stdin,
 	}
 
-	return siftool.Add(args[0], args[1], opts)
+	switch *datatype {
+	case 1:
+		opts.Datatype = sif.DataDeffile
+	case 2:
+		opts.Datatype = sif.DataEnvVar
+	case 3:
+		opts.Datatype = sif.DataLabels
+	case 4:
+		opts.Datatype = sif.DataPartition
+	case 5:
+		opts.Datatype = sif.DataSignature
+	case 6:
+		opts.Datatype = sif.DataGenericJSON
+	case 7:
+		opts.Datatype = sif.DataGeneric
+	case 8:
+		opts.Datatype = sif.DataCryptoMessage
+	default:
+		return errors.New("-datatype flag is required with a valid range")
+	}
+
+	if opts.Datatype == sif.DataPartition {
+		if *partfs == 0 || *parttype == 0 || *partarch == 0 {
+			return errors.New("with partition datatype, -partfs, -parttype and -partarch must be passed")
+		}
+
+		opts.Parttype = sif.Parttype(*parttype)
+		opts.Partfs = sif.Fstype(*partfs)
+
+		switch *partarch {
+		case 1:
+			opts.Partarch = sif.HdrArch386
+		case 2:
+			opts.Partarch = sif.HdrArchAMD64
+		case 3:
+			opts.Partarch = sif.HdrArchARM
+		case 4:
+			opts.Partarch = sif.HdrArchARM64
+		case 5:
+			opts.Partarch = sif.HdrArchPPC64
+		case 6:
+			opts.Partarch = sif.HdrArchPPC64le
+		case 7:
+			opts.Partarch = sif.HdrArchMIPS
+		case 8:
+			opts.Partarch = sif.HdrArchMIPSle
+		case 9:
+			opts.Partarch = sif.HdrArchMIPS64
+		case 10:
+			opts.Partarch = sif.HdrArchMIPS64le
+		case 11:
+			opts.Partarch = sif.HdrArchS390x
+		default:
+			return errors.New("-partarch flag is required with a valid range")
+		}
+	} else if opts.Datatype == sif.DataSignature {
+		if *signhash == 0 || *signentity == "" {
+			return errors.New("with signature datatype, -signhash and -signentity must be passed")
+		}
+
+		opts.Signhash = sif.Hashtype(*signhash)
+		opts.Signentity = *signentity
+	}
+
+	if dataFile := args[1]; dataFile != "-" {
+		fp, err := os.Open(dataFile)
+		if err != nil {
+			return err
+		}
+		defer fp.Close()
+
+		opts.Fp = fp
+
+		if opts.Filename == "" {
+			opts.Filename = dataFile
+		}
+	}
+
+	return siftool.Add(args[0], opts)
 }
 
 func cmdDel(args []string) error {
@@ -66,7 +141,7 @@ func cmdDel(args []string) error {
 		return fmt.Errorf("while converting input descriptor id: %s", err)
 	}
 
-	return siftool.Del(id, args[1])
+	return siftool.Del(args[1], uint32(id))
 }
 
 func cmdSetPrim(args []string) error {
@@ -79,5 +154,5 @@ func cmdSetPrim(args []string) error {
 		return fmt.Errorf("while converting input descriptor id: %s", err)
 	}
 
-	return siftool.Setprim(id, args[0])
+	return siftool.Setprim(args[0], uint32(id))
 }

--- a/cmd/siftool/siftool.go
+++ b/cmd/siftool/siftool.go
@@ -107,8 +107,8 @@ func main() {
 	-signentity   the entity that signs (with -datatype 5-Signature)
 	              [NEEDED, no default]:
 	                example: 433FE984155206BD962725E20E8713472A879943
-	-groupid      set groupid [default: DescrUnusedGroup]
-	-link         set link pointer [default: DescrUnusedLink]
+	-groupid      set groupid [default: 0]
+	-link         set link pointer [default: 0]
 	-alignment    set alignment constraint [default: aligned on page size]
 	-filename     set logical filename/handle [default: input filename]
 `},

--- a/internal/app/siftool/file.go
+++ b/internal/app/siftool/file.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package siftool
+
+import (
+	"github.com/sylabs/sif/pkg/sif"
+)
+
+// withFileImage calls fn with a FileImage loaded from path.
+func withFileImage(path string, writable bool, fn func(*sif.FileImage) error) (err error) {
+	f, err := sif.LoadContainer(path, !writable)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if uerr := f.UnloadContainer(); uerr != nil && err == nil {
+			err = uerr
+		}
+	}()
+
+	return fn(&f)
+}

--- a/internal/app/siftool/info.go
+++ b/internal/app/siftool/info.go
@@ -19,8 +19,8 @@ import (
 )
 
 // Header displays a SIF file global header.
-func Header(file string) error {
-	fimg, err := sif.LoadContainer(file, true)
+func Header(path string) error {
+	fimg, err := sif.LoadContainer(path, true)
 	if err != nil {
 		return err
 	}
@@ -37,8 +37,8 @@ func Header(file string) error {
 }
 
 // List displays a list of all active descriptors from a SIF file.
-func List(file string) error {
-	fimg, err := sif.LoadContainer(file, true)
+func List(path string) error {
+	fimg, err := sif.LoadContainer(path, true)
 	if err != nil {
 		return err
 	}
@@ -62,8 +62,8 @@ func List(file string) error {
 }
 
 // Info displays detailed info about a descriptor from a SIF file.
-func Info(descr uint64, file string) error {
-	fimg, err := sif.LoadContainer(file, true)
+func Info(path string, id uint32) error {
+	fimg, err := sif.LoadContainer(path, true)
 	if err != nil {
 		return err
 	}
@@ -74,14 +74,14 @@ func Info(descr uint64, file string) error {
 	}()
 
 	//nolint:staticcheck // In use until v2 API to avoid code duplication
-	fmt.Print(fimg.FmtDescrInfo(uint32(descr)))
+	fmt.Print(fimg.FmtDescrInfo(id))
 
 	return nil
 }
 
 // Dump extracts and outputs a data object from a SIF file.
-func Dump(descr uint64, file string) error {
-	fimg, err := sif.LoadContainer(file, true)
+func Dump(path string, id uint32) error {
+	fimg, err := sif.LoadContainer(path, true)
 	if err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func Dump(descr uint64, file string) error {
 		if !v.Used {
 			continue
 		}
-		if v.ID == uint32(descr) {
+		if v.ID == id {
 			if _, err := fimg.Fp.Seek(v.Fileoff, 0); err != nil {
 				return fmt.Errorf("while seeking to data object: %s", err)
 			}

--- a/internal/app/siftool/modif.go
+++ b/internal/app/siftool/modif.go
@@ -9,7 +9,6 @@
 package siftool
 
 import (
-	"fmt"
 	"io"
 	"log"
 
@@ -98,15 +97,7 @@ func Del(path string, id uint32) error {
 		}
 	}()
 
-	for _, v := range fimg.DescrArr {
-		if !v.Used {
-			continue
-		} else if v.ID == id {
-			return fimg.DeleteObject(id, 0)
-		}
-	}
-
-	return fmt.Errorf("descriptor not in range or currently unused")
+	return fimg.DeleteObject(id, 0)
 }
 
 // Setprim sets the primary system partition of the SIF file.
@@ -121,13 +112,5 @@ func Setprim(path string, id uint32) error {
 		}
 	}()
 
-	for _, v := range fimg.DescrArr {
-		if !v.Used {
-			continue
-		} else if v.ID == id {
-			return fimg.SetPrimPart(id)
-		}
-	}
-
-	return fmt.Errorf("descriptor not in range or currently unused")
+	return fimg.SetPrimPart(id)
 }

--- a/internal/app/siftool/modif.go
+++ b/internal/app/siftool/modif.go
@@ -10,7 +10,6 @@ package siftool
 
 import (
 	"io"
-	"log"
 
 	uuid "github.com/satori/go.uuid"
 	"github.com/sylabs/sif/pkg/sif"
@@ -70,47 +69,21 @@ func Add(path string, opts AddOptions) error {
 		}
 	}
 
-	// load SIF image file
-	fimg, err := sif.LoadContainer(path, false)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := fimg.UnloadContainer(); err != nil {
-			log.Printf("Error unloading container: %v", err)
-		}
-	}()
-
-	// add new data object to SIF file
-	return fimg.AddObject(input)
+	return withFileImage(path, true, func(f *sif.FileImage) error {
+		return f.AddObject(input)
+	})
 }
 
 // Del deletes a specified object descriptor and data from the SIF file.
 func Del(path string, id uint32) error {
-	fimg, err := sif.LoadContainer(path, false)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := fimg.UnloadContainer(); err != nil {
-			log.Printf("Error unloading container: %v", err)
-		}
-	}()
-
-	return fimg.DeleteObject(id, 0)
+	return withFileImage(path, true, func(f *sif.FileImage) error {
+		return f.DeleteObject(id, 0)
+	})
 }
 
 // Setprim sets the primary system partition of the SIF file.
 func Setprim(path string, id uint32) error {
-	fimg, err := sif.LoadContainer(path, false)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := fimg.UnloadContainer(); err != nil {
-			log.Printf("Error unloading container: %v", err)
-		}
-	}()
-
-	return fimg.SetPrimPart(id)
+	return withFileImage(path, true, func(f *sif.FileImage) error {
+		return f.SetPrimPart(id)
+	})
 }

--- a/internal/app/siftool/modif.go
+++ b/internal/app/siftool/modif.go
@@ -10,22 +10,22 @@ package siftool
 
 import (
 	"fmt"
+	"io"
 	"log"
-	"os"
 
 	uuid "github.com/satori/go.uuid"
 	"github.com/sylabs/sif/pkg/sif"
 )
 
 // New creates a new empty SIF file.
-func New(file string) error {
+func New(path string) error {
 	id, err := uuid.NewV4()
 	if err != nil {
 		return err
 	}
 
 	cinfo := sif.CreateInfo{
-		Pathname:   file,
+		Pathname:   path,
 		Launchstr:  sif.HdrLaunch,
 		Sifversion: sif.HdrVersion,
 		ID:         id,
@@ -37,127 +37,42 @@ func New(file string) error {
 
 // AddOptions contains the options when adding a section to a SIF file.
 type AddOptions struct {
-	Datatype   *int64
-	Parttype   *int64
-	Partfs     *int64
-	Partarch   *int64
-	Signhash   *int64
-	Signentity *string
-	Groupid    *int64
-	Link       *int64
-	Alignment  *int
-	Filename   *string
+	Datatype   sif.Datatype
+	Parttype   sif.Parttype
+	Partfs     sif.Fstype
+	Partarch   string
+	Signhash   sif.Hashtype
+	Signentity string
+	Groupid    uint32
+	Link       uint32
+	Alignment  int
+	Filename   string
+	Fp         io.Reader
 }
 
 // Add adds a data object to a SIF file.
-func Add(containerFile, dataFile string, opts AddOptions) error {
-	var err error
-	var d sif.Datatype
-	var a string
-
-	switch *opts.Datatype {
-	case 1:
-		d = sif.DataDeffile
-	case 2:
-		d = sif.DataEnvVar
-	case 3:
-		d = sif.DataLabels
-	case 4:
-		d = sif.DataPartition
-	case 5:
-		d = sif.DataSignature
-	case 6:
-		d = sif.DataGenericJSON
-	case 7:
-		d = sif.DataGeneric
-	case 8:
-		d = sif.DataCryptoMessage
-	default:
-		log.Printf("error: -datatype flag is required with a valid range\n\n")
-		return fmt.Errorf("usage")
-	}
-
-	if *opts.Filename == "" {
-		*opts.Filename = dataFile
-	}
-
-	// data we need to create a new descriptor
+func Add(path string, opts AddOptions) error {
 	input := sif.DescriptorInput{
-		Datatype:  d,
-		Groupid:   sif.DescrGroupMask | uint32(*opts.Groupid),
-		Link:      uint32(*opts.Link),
-		Alignment: *opts.Alignment,
-		Fname:     *opts.Filename,
+		Datatype:  opts.Datatype,
+		Groupid:   sif.DescrGroupMask | opts.Groupid,
+		Link:      opts.Link,
+		Alignment: opts.Alignment,
+		Fname:     opts.Filename,
+		Fp:        opts.Fp,
 	}
 
-	if dataFile == "-" {
-		input.Fp = os.Stdin
-	} else {
-		// open up the data object file for this descriptor
-		fp, err := os.Open(dataFile)
-		if err != nil {
+	if opts.Datatype == sif.DataPartition {
+		if err := input.SetPartExtra(opts.Partfs, opts.Parttype, opts.Partarch); err != nil {
 			return err
 		}
-		defer fp.Close()
-
-		input.Fp = fp
-
-		fi, err := fp.Stat()
-		if err != nil {
-			return err
-		}
-		input.Size = fi.Size()
-	}
-
-	if d == sif.DataPartition {
-		if sif.Fstype(*opts.Partfs) == -1 || sif.Parttype(*opts.Parttype) == -1 || *opts.Partarch == -1 {
-			return fmt.Errorf("with partition datatype, -partfs, -parttype and -partarch must be passed")
-		}
-
-		switch *opts.Partarch {
-		case 1:
-			a = sif.HdrArch386
-		case 2:
-			a = sif.HdrArchAMD64
-		case 3:
-			a = sif.HdrArchARM
-		case 4:
-			a = sif.HdrArchARM64
-		case 5:
-			a = sif.HdrArchPPC64
-		case 6:
-			a = sif.HdrArchPPC64le
-		case 7:
-			a = sif.HdrArchMIPS
-		case 8:
-			a = sif.HdrArchMIPSle
-		case 9:
-			a = sif.HdrArchMIPS64
-		case 10:
-			a = sif.HdrArchMIPS64le
-		case 11:
-			a = sif.HdrArchS390x
-		default:
-			log.Printf("error: -partarch flag is required with a valid range\n\n")
-			return fmt.Errorf("usage")
-		}
-
-		err := input.SetPartExtra(sif.Fstype(*opts.Partfs), sif.Parttype(*opts.Parttype), a)
-		if err != nil {
-			return err
-		}
-	} else if d == sif.DataSignature {
-		if sif.Hashtype(*opts.Signhash) == -1 || *opts.Signentity == "" {
-			return fmt.Errorf("with signature datatype, -signhash and -signentity must be passed")
-		}
-
-		if err := input.SetSignExtra(sif.Hashtype(*opts.Signhash), *opts.Signentity); err != nil {
+	} else if opts.Datatype == sif.DataSignature {
+		if err := input.SetSignExtra(opts.Signhash, opts.Signentity); err != nil {
 			return err
 		}
 	}
 
 	// load SIF image file
-	fimg, err := sif.LoadContainer(containerFile, false)
+	fimg, err := sif.LoadContainer(path, false)
 	if err != nil {
 		return err
 	}
@@ -172,8 +87,8 @@ func Add(containerFile, dataFile string, opts AddOptions) error {
 }
 
 // Del deletes a specified object descriptor and data from the SIF file.
-func Del(descr uint64, file string) error {
-	fimg, err := sif.LoadContainer(file, false)
+func Del(path string, id uint32) error {
+	fimg, err := sif.LoadContainer(path, false)
 	if err != nil {
 		return err
 	}
@@ -186,8 +101,8 @@ func Del(descr uint64, file string) error {
 	for _, v := range fimg.DescrArr {
 		if !v.Used {
 			continue
-		} else if v.ID == uint32(descr) {
-			return fimg.DeleteObject(uint32(descr), 0)
+		} else if v.ID == id {
+			return fimg.DeleteObject(id, 0)
 		}
 	}
 
@@ -195,8 +110,8 @@ func Del(descr uint64, file string) error {
 }
 
 // Setprim sets the primary system partition of the SIF file.
-func Setprim(descr uint64, file string) error {
-	fimg, err := sif.LoadContainer(file, false)
+func Setprim(path string, id uint32) error {
+	fimg, err := sif.LoadContainer(path, false)
 	if err != nil {
 		return err
 	}
@@ -209,8 +124,8 @@ func Setprim(descr uint64, file string) error {
 	for _, v := range fimg.DescrArr {
 		if !v.Used {
 			continue
-		} else if v.ID == uint32(descr) {
-			return fimg.SetPrimPart(uint32(descr))
+		} else if v.ID == id {
+			return fimg.SetPrimPart(id)
 		}
 	}
 

--- a/pkg/siftool/add.go
+++ b/pkg/siftool/add.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -8,6 +8,9 @@
 package siftool
 
 import (
+	"errors"
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/sylabs/sif/internal/app/siftool"
 	"github.com/sylabs/sif/pkg/sif"
@@ -16,67 +19,130 @@ import (
 // Add implements 'siftool add' sub-command.
 func Add() *cobra.Command {
 	ret := &cobra.Command{
-		Use:   "add [OPTIONS] <containerfile> <dataobjectfile>",
+		Use:   "add <containerfile> <dataobjectfile>",
 		Short: "Add a data object to a SIF file",
 		Args:  cobra.ExactArgs(2),
 	}
 
-	opts := siftool.AddOptions{
-		Datatype: ret.Flags().Int64("datatype", -1, `the type of data to add
+	datatype := ret.Flags().Int("datatype", 0, `the type of data to add
 [NEEDED, no default]:
   1-Deffile,   2-EnvVar,    3-Labels,
-  4-Partition, 5-Signature, 6-GenericJSON`),
-		Parttype: ret.Flags().Int64("parttype", -1, `the type of partition (with -datatype 4-Partition)
+  4-Partition, 5-Signature, 6-GenericJSON`)
+	parttype := ret.Flags().Int32("parttype", 0, `the type of partition (with -datatype 4-Partition)
 [NEEDED, no default]:
   1-System,    2-PrimSys,   3-Data,
-  4-Overlay`),
-		Partfs: ret.Flags().Int64("partfs", -1, `the filesystem used (with -datatype 4-Partition)
+  4-Overlay`)
+	partfs := ret.Flags().Int32("partfs", 0, `the filesystem used (with -datatype 4-Partition)
 [NEEDED, no default]:
   1-Squash,    2-Ext3,      3-ImmuObj,
-  4-Raw`),
-		Partarch: ret.Flags().Int64("partarch", -1, `the main architecture used (with -datatype 4-Partition)
+  4-Raw`)
+	partarch := ret.Flags().Int32("partarch", 0, `the main architecture used (with -datatype 4-Partition)
 [NEEDED, no default]:
   1-386,       2-amd64,     3-arm,
   4-arm64,     5-ppc64,     6-ppc64le,
   7-mips,      8-mipsle,    9-mips64,
-  10-mips64le, 11-s390x`),
-		Signhash: ret.Flags().Int64("signhash", -1, `the signature hash used (with -datatype 5-Signature)
+  10-mips64le, 11-s390x`)
+	signhash := ret.Flags().Int32("signhash", 0, `the signature hash used (with -datatype 5-Signature)
 [NEEDED, no default]:
   1-SHA256,    2-SHA384,    3-SHA512,
-  4-BLAKE2S,   5-BLAKE2B`),
-		Signentity: ret.Flags().String("signentity", "", `the entity that signs (with -datatype 5-Signature)
+  4-BLAKE2S,   5-BLAKE2B`)
+	signentity := ret.Flags().String("signentity", "", `the entity that signs (with -datatype 5-Signature)
 [NEEDED, no default]:
-  example: 433FE984155206BD962725E20E8713472A879943`),
-		Groupid:   ret.Flags().Int64("groupid", sif.DescrUnusedGroup, "set groupid [default: DescrUnusedGroup]"),
-		Link:      ret.Flags().Int64("link", sif.DescrUnusedLink, "set link pointer [default: DescrUnusedLink]"),
-		Alignment: ret.Flags().Int("alignment", 0, "set alignment constraint [default: aligned on page size]"),
-		Filename:  ret.Flags().String("filename", "", "set logical filename/handle [default: input filename]"),
-	}
+  example: 433FE984155206BD962725E20E8713472A879943`)
+	groupid := ret.Flags().Uint32("groupid", 0, "set groupid [default: 0]")
+	link := ret.Flags().Uint32("link", 0, "set link pointer [default: 0]")
+	alignment := ret.Flags().Int("alignment", 0, "set alignment constraint [default: aligned on page size]")
+	filename := ret.Flags().String("filename", "", "set logical filename/handle [default: input filename]")
 
 	ret.RunE = func(cmd *cobra.Command, args []string) error {
-		return siftool.Add(args[0], args[1], opts)
-	}
-
-	// function to set flag.DefVal to the "zero-value"
-	fn := func(name, setdef string) {
-		fl := ret.Flags().Lookup(name)
-		if fl == nil {
-			return
+		opts := siftool.AddOptions{
+			Groupid:   *groupid,
+			Link:      *link,
+			Alignment: *alignment,
+			Filename:  *filename,
+			Fp:        os.Stdin,
 		}
 
-		fl.DefValue = setdef
-	}
+		switch *datatype {
+		case 1:
+			opts.Datatype = sif.DataDeffile
+		case 2:
+			opts.Datatype = sif.DataEnvVar
+		case 3:
+			opts.Datatype = sif.DataLabels
+		case 4:
+			opts.Datatype = sif.DataPartition
+		case 5:
+			opts.Datatype = sif.DataSignature
+		case 6:
+			opts.Datatype = sif.DataGenericJSON
+		case 7:
+			opts.Datatype = sif.DataGeneric
+		case 8:
+			opts.Datatype = sif.DataCryptoMessage
+		default:
+			return errors.New("-datatype flag is required with a valid range")
+		}
 
-	// set the DefVal fields for all the siftool add flags
-	fn("datatype", "0")
-	fn("parttype", "0")
-	fn("partfs", "0")
-	fn("partarch", "0")
-	fn("signhash", "0")
-	fn("signentity", "")
-	fn("groupid", "0")
-	fn("link", "0")
-	fn("alignment", "0")
+		if opts.Datatype == sif.DataPartition {
+			if *partfs == 0 || *parttype == 0 || *partarch == 0 {
+				return errors.New("with partition datatype, -partfs, -parttype and -partarch must be passed")
+			}
+
+			opts.Parttype = sif.Parttype(*parttype)
+			opts.Partfs = sif.Fstype(*partfs)
+
+			switch *partarch {
+			case 1:
+				opts.Partarch = sif.HdrArch386
+			case 2:
+				opts.Partarch = sif.HdrArchAMD64
+			case 3:
+				opts.Partarch = sif.HdrArchARM
+			case 4:
+				opts.Partarch = sif.HdrArchARM64
+			case 5:
+				opts.Partarch = sif.HdrArchPPC64
+			case 6:
+				opts.Partarch = sif.HdrArchPPC64le
+			case 7:
+				opts.Partarch = sif.HdrArchMIPS
+			case 8:
+				opts.Partarch = sif.HdrArchMIPSle
+			case 9:
+				opts.Partarch = sif.HdrArchMIPS64
+			case 10:
+				opts.Partarch = sif.HdrArchMIPS64le
+			case 11:
+				opts.Partarch = sif.HdrArchS390x
+			default:
+				return errors.New("-partarch flag is required with a valid range")
+			}
+		} else if opts.Datatype == sif.DataSignature {
+			if *signhash == 0 || *signentity == "" {
+				return errors.New("with signature datatype, -signhash and -signentity must be passed")
+			}
+
+			opts.Signhash = sif.Hashtype(*signhash)
+			opts.Signentity = *signentity
+		}
+
+		if dataFile := args[1]; dataFile != "-" {
+			fp, err := os.Open(dataFile)
+			if err != nil {
+				return err
+			}
+			defer fp.Close()
+
+			opts.Fp = fp
+
+			if opts.Filename == "" {
+				opts.Filename = dataFile
+			}
+		}
+
+		return siftool.Add(args[0], opts)
+	}
 
 	return ret
 }

--- a/pkg/siftool/del.go
+++ b/pkg/siftool/del.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -28,7 +28,7 @@ func Del() *cobra.Command {
 				return fmt.Errorf("while converting input descriptor id: %s", err)
 			}
 
-			return siftool.Del(id, args[1])
+			return siftool.Del(args[1], uint32(id))
 		},
 	}
 }

--- a/pkg/siftool/dump.go
+++ b/pkg/siftool/dump.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // Copyright (c) 2018, Divya Cote <divya.cote@gmail.com> All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
@@ -29,7 +29,7 @@ func Dump() *cobra.Command {
 				return fmt.Errorf("while converting input descriptor id: %s", err)
 			}
 
-			return siftool.Dump(id, args[1])
+			return siftool.Dump(args[1], uint32(id))
 		},
 		DisableFlagsInUseLine: true,
 	}

--- a/pkg/siftool/info.go
+++ b/pkg/siftool/info.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // Copyright (c) 2018, Divya Cote <divya.cote@gmail.com> All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
@@ -29,7 +29,7 @@ func Info() *cobra.Command {
 				return fmt.Errorf("while converting input descriptor id: %s", err)
 			}
 
-			return siftool.Info(id, args[1])
+			return siftool.Info(args[1], uint32(id))
 		},
 		DisableFlagsInUseLine: true,
 	}

--- a/pkg/siftool/setprim.go
+++ b/pkg/siftool/setprim.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -28,7 +28,7 @@ func Setprim() *cobra.Command {
 				return fmt.Errorf("while converting input descriptor id: %s", err)
 			}
 
-			return siftool.Setprim(id, args[1])
+			return siftool.Setprim(args[1], uint32(id))
 		},
 	}
 }


### PR DESCRIPTION
Simplify code in `internal/app/siftool` package by removing unnecessary type casts and iterations on `DescrArr`. Move flag validation code to CLI packages.