### PR TITLE
Functional Arguments for CreateContainer

### DIFF
--- a/cmd/siftool/siftool.go
+++ b/cmd/siftool/siftool.go
@@ -27,7 +27,7 @@ func getVersion() *cobra.Command {
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Printf("siftool version %s %s/%s\n", version, runtime.GOOS, runtime.GOARCH)
-			cmd.Printf("SIF spec versions supported: <= %s\n", sif.HdrVersion)
+			cmd.Printf("SIF spec versions supported: <= %s\n", sif.CurrentVersion)
 		},
 		DisableFlagsInUseLine: true,
 	}

--- a/internal/app/siftool/modif.go
+++ b/internal/app/siftool/modif.go
@@ -11,25 +11,12 @@ package siftool
 import (
 	"io"
 
-	"github.com/google/uuid"
 	"github.com/sylabs/sif/v2/pkg/sif"
 )
 
 // New creates a new empty SIF file.
 func (*App) New(path string) error {
-	id, err := uuid.NewRandom()
-	if err != nil {
-		return err
-	}
-
-	cinfo := sif.CreateInfo{
-		Pathname:   path,
-		Launchstr:  sif.HdrLaunch,
-		Sifversion: sif.HdrVersion,
-		ID:         id,
-	}
-
-	_, err = sif.CreateContainer(cinfo)
+	_, err := sif.CreateContainer(path)
 	return err
 }
 

--- a/pkg/integrity/testdata/gen_sifs.go
+++ b/pkg/integrity/testdata/gen_sifs.go
@@ -11,27 +11,13 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/google/uuid"
 	"github.com/sylabs/sif/v2/pkg/integrity"
 	"github.com/sylabs/sif/v2/pkg/sif"
 	"golang.org/x/crypto/openpgp"
 )
 
 func createImage(path string, dis []sif.DescriptorInput) error {
-	id, err := uuid.NewV4()
-	if err != nil {
-		return err
-	}
-
-	ci := sif.CreateInfo{
-		Pathname:   path,
-		Launchstr:  sif.HdrLaunch,
-		Sifversion: sif.HdrVersion,
-		ID:         id,
-		InputDescr: dis,
-	}
-
-	_, err = sif.CreateContainer(ci)
+	_, err := sif.CreateContainer(path, sif.WithDescriptors(dis...))
 	return err
 }
 

--- a/pkg/sif/create.go
+++ b/pkg/sif/create.go
@@ -271,7 +271,7 @@ func CreateContainer(path string, opts ...CreateOpt) (*FileImage, error) {
 		}
 	}
 
-	now := co.GetTime()
+	t := co.GetTime()
 
 	f := &FileImage{}
 	f.DescrArr = make([]Descriptor, DescrNumEntries)
@@ -282,8 +282,8 @@ func CreateContainer(path string, opts ...CreateOpt) (*FileImage, error) {
 	copy(f.Header.Version[:], CurrentVersion.bytes())
 	copy(f.Header.Arch[:], HdrArchUnknown)
 	f.Header.ID = id
-	f.Header.Ctime = now.Unix()
-	f.Header.Mtime = now.Unix()
+	f.Header.Ctime = t.Unix()
+	f.Header.Mtime = t.Unix()
 	f.Header.Dfree = DescrNumEntries
 	f.Header.Dtotal = DescrNumEntries
 	f.Header.Descroff = DescrStartOffset

--- a/pkg/sif/create.go
+++ b/pkg/sif/create.go
@@ -277,8 +277,8 @@ func CreateContainer(path string, opts ...CreateOpt) (*FileImage, error) {
 	f.DescrArr = make([]Descriptor, DescrNumEntries)
 
 	// Prepare a fresh global header
-	copy(f.Header.Launch[:], HdrLaunch)
-	copy(f.Header.Magic[:], HdrMagic)
+	copy(f.Header.Launch[:], hdrLaunch)
+	copy(f.Header.Magic[:], hdrMagic)
 	copy(f.Header.Version[:], HdrVersion)
 	copy(f.Header.Arch[:], HdrArchUnknown)
 	f.Header.ID = id

--- a/pkg/sif/create.go
+++ b/pkg/sif/create.go
@@ -279,7 +279,7 @@ func CreateContainer(path string, opts ...CreateOpt) (*FileImage, error) {
 	// Prepare a fresh global header
 	copy(f.Header.Launch[:], hdrLaunch)
 	copy(f.Header.Magic[:], hdrMagic)
-	copy(f.Header.Version[:], HdrVersion)
+	copy(f.Header.Version[:], CurrentVersion.bytes())
 	copy(f.Header.Arch[:], HdrArchUnknown)
 	f.Header.ID = id
 	f.Header.Ctime = now.Unix()

--- a/pkg/sif/create_test.go
+++ b/pkg/sif/create_test.go
@@ -12,8 +12,6 @@ import (
 	"os"
 	"runtime"
 	"testing"
-
-	"github.com/google/uuid"
 )
 
 const (
@@ -65,22 +63,9 @@ func TestCreateContainer(t *testing.T) {
 	defer os.Remove(f.Name())
 	f.Close()
 
-	id, err := uuid.NewRandom()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// general info for the new SIF file creation
-	cinfo := CreateInfo{
-		Pathname:   f.Name(),
-		Launchstr:  HdrLaunch,
-		Sifversion: HdrVersion,
-		ID:         id,
-	}
-
 	// test container creation without any input descriptors
-	if _, err := CreateContainer(cinfo); err != nil {
-		t.Error("CreateContainer(cinfo): should allow empty input descriptor list")
+	if _, err := CreateContainer(f.Name()); err != nil {
+		t.Errorf("failed to create container: %v", err)
 	}
 
 	// data we need to create a definition file descriptor
@@ -105,9 +90,6 @@ func TestCreateContainer(t *testing.T) {
 		t.Errorf("CreateContainer(cinfo): can't stat definition file: %s", err)
 	}
 	definput.Size = fi.Size()
-
-	// add this descriptor input element to creation descriptor slice
-	cinfo.InputDescr = append(cinfo.InputDescr, definput)
 
 	// data we need to create a system partition descriptor
 	parinput := DescriptorInput{
@@ -137,12 +119,9 @@ func TestCreateContainer(t *testing.T) {
 		t.Errorf("CreateContainer(cinfo): can't set extra info: %s", err)
 	}
 
-	// add this descriptor input element to creation descriptor slice
-	cinfo.InputDescr = append(cinfo.InputDescr, parinput)
-
 	// test container creation with two partition input descriptors
-	if _, err := CreateContainer(cinfo); err != nil {
-		t.Errorf("CreateContainer(cinfo): CreateContainer(): %s", err)
+	if _, err := CreateContainer(f.Name(), WithDescriptors(definput, parinput)); err != nil {
+		t.Errorf("failed to create container: %v", err)
 	}
 }
 

--- a/pkg/sif/load.go
+++ b/pkg/sif/load.go
@@ -48,7 +48,7 @@ func readDescriptors(r io.ReaderAt, fimg *FileImage) error {
 
 // isValidSif looks at key fields from the global header to assess SIF validity.
 func isValidSif(f *FileImage) error {
-	if got, want := trimZeroBytes(f.Header.Magic[:]), HdrMagic; got != want {
+	if got, want := trimZeroBytes(f.Header.Magic[:]), hdrMagic; got != want {
 		return fmt.Errorf("invalid SIF file: Magic |%v| want |%v|", got, want)
 	}
 

--- a/pkg/sif/load.go
+++ b/pkg/sif/load.go
@@ -52,7 +52,7 @@ func isValidSif(f *FileImage) error {
 		return fmt.Errorf("invalid SIF file: Magic |%v| want |%v|", got, want)
 	}
 
-	if got, want := trimZeroBytes(f.Header.Version[:]), HdrVersion; got > want {
+	if got, want := trimZeroBytes(f.Header.Version[:]), CurrentVersion.String(); got > want {
 		return fmt.Errorf("invalid SIF file: Version %s want <= %s", got, want)
 	}
 

--- a/pkg/sif/load_test.go
+++ b/pkg/sif/load_test.go
@@ -244,7 +244,7 @@ func TestLoadContainerInvalidMagic(t *testing.T) {
 	// ... and edit the magic to make it invalid. Instead of
 	// exploring all kinds of invalid, simply mess with the last
 	// byte, as this would catch off-by-one errors in the code.
-	copy(content[HdrLaunchLen:HdrLaunchLen+HdrMagicLen], "SIF_MAGIX")
+	copy(content[hdrLaunchLen:hdrLaunchLen+hdrMagicLen], "SIF_MAGIX")
 
 	fp := &mockSifReadWriter{
 		buf:  content,

--- a/pkg/sif/lookup.go
+++ b/pkg/sif/lookup.go
@@ -302,15 +302,15 @@ func (d *Descriptor) GetPartType() (Parttype, error) {
 }
 
 // GetArch extracts the Arch field from the Extra field of a Partition Descriptor.
-func (d *Descriptor) GetArch() ([HdrArchLen]byte, error) {
+func (d *Descriptor) GetArch() ([hdrArchLen]byte, error) {
 	if d.Datatype != DataPartition {
-		return [HdrArchLen]byte{}, fmt.Errorf("expected DataPartition, got %v", d.Datatype)
+		return [hdrArchLen]byte{}, fmt.Errorf("expected DataPartition, got %v", d.Datatype)
 	}
 
 	var pinfo Partition
 	b := bytes.NewReader(d.Extra[:])
 	if err := binary.Read(b, binary.LittleEndian, &pinfo); err != nil {
-		return [HdrArchLen]byte{}, fmt.Errorf("while extracting Partition extra info: %s", err)
+		return [hdrArchLen]byte{}, fmt.Errorf("while extracting Partition extra info: %s", err)
 	}
 
 	return pinfo.Arch, nil

--- a/pkg/sif/lookup_test.go
+++ b/pkg/sif/lookup_test.go
@@ -449,7 +449,7 @@ func TestGetArch(t *testing.T) {
 	}
 
 	if trimZeroBytes(arch[:]) != HdrArchAMD64 {
-		t.Logf("|%s|%s|\n", arch[:HdrArchLen-1], HdrArchAMD64)
+		t.Logf("|%s|%s|\n", arch[:hdrArchLen-1], HdrArchAMD64)
 		t.Error("part.GetArch() should have returned 'HdrArchAMD64':", err)
 	}
 

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -84,6 +84,7 @@ package sif
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"time"
@@ -93,27 +94,45 @@ import (
 
 // SIF header constants and quantities.
 const (
-	hdrLaunch       = "#!/usr/bin/env run-singularity\n"
-	hdrMagic        = "SIF_MAGIC" // SIF identification
-	HdrVersion      = "01"        // SIF SPEC VERSION
-	HdrArchUnknown  = "00"        // Undefined/Unsupported arch
-	HdrArch386      = "01"        // 386 (i[3-6]86) arch code
-	HdrArchAMD64    = "02"        // AMD64 arch code
-	HdrArchARM      = "03"        // ARM arch code
-	HdrArchARM64    = "04"        // AARCH64 arch code
-	HdrArchPPC64    = "05"        // PowerPC 64 arch code
-	HdrArchPPC64le  = "06"        // PowerPC 64 little-endian arch code
-	HdrArchMIPS     = "07"        // MIPS arch code
-	HdrArchMIPSle   = "08"        // MIPS little-endian arch code
-	HdrArchMIPS64   = "09"        // MIPS64 arch code
-	HdrArchMIPS64le = "10"        // MIPS64 little-endian arch code
-	HdrArchS390x    = "11"        // IBM s390x arch code
-
+	hdrLaunch     = "#!/usr/bin/env run-singularity\n"
 	hdrLaunchLen  = 32 // len("#!/usr/bin/env... ")
+	hdrMagic      = "SIF_MAGIC"
 	hdrMagicLen   = 10 // len("SIF_MAGIC")
 	hdrVersionLen = 3  // len("99")
 	hdrArchLen    = 3  // len("99")
+)
 
+// SpecVersion specifies a SIF specification version.
+type SpecVersion uint8
+
+func (v SpecVersion) String() string { return fmt.Sprintf("%02d", v) }
+func (v SpecVersion) bytes() []byte  { return []byte(v.String()) }
+
+// SIF specification versions.
+const (
+	version01 SpecVersion = iota + 1
+)
+
+// CurrentVersion specifies the current SIF specification version.
+const CurrentVersion = version01
+
+// SIF architecture values.
+const (
+	HdrArchUnknown  = "00" // Undefined/Unsupported arch
+	HdrArch386      = "01" // 386 (i[3-6]86) arch code
+	HdrArchAMD64    = "02" // AMD64 arch code
+	HdrArchARM      = "03" // ARM arch code
+	HdrArchARM64    = "04" // AARCH64 arch code
+	HdrArchPPC64    = "05" // PowerPC 64 arch code
+	HdrArchPPC64le  = "06" // PowerPC 64 little-endian arch code
+	HdrArchMIPS     = "07" // MIPS arch code
+	HdrArchMIPSle   = "08" // MIPS little-endian arch code
+	HdrArchMIPS64   = "09" // MIPS64 arch code
+	HdrArchMIPS64le = "10" // MIPS64 little-endian arch code
+	HdrArchS390x    = "11" // IBM s390x arch code
+)
+
+const (
 	DescrNumEntries   = 48                 // the default total number of available descriptors
 	DescrGroupMask    = 0xf0000000         // groups start at that offset
 	DescrUnusedGroup  = DescrGroupMask     // descriptor without a group

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -93,8 +93,8 @@ import (
 
 // SIF header constants and quantities.
 const (
-	HdrLaunch       = "#!/usr/bin/env run-singularity\n"
-	HdrMagic        = "SIF_MAGIC" // SIF identification
+	hdrLaunch       = "#!/usr/bin/env run-singularity\n"
+	hdrMagic        = "SIF_MAGIC" // SIF identification
 	HdrVersion      = "01"        // SIF SPEC VERSION
 	HdrArchUnknown  = "00"        // Undefined/Unsupported arch
 	HdrArch386      = "01"        // 386 (i[3-6]86) arch code
@@ -109,10 +109,10 @@ const (
 	HdrArchMIPS64le = "10"        // MIPS64 little-endian arch code
 	HdrArchS390x    = "11"        // IBM s390x arch code
 
-	HdrLaunchLen  = 32 // len("#!/usr/bin/env... ")
-	HdrMagicLen   = 10 // len("SIF_MAGIC")
-	HdrVersionLen = 3  // len("99")
-	HdrArchLen    = 3  // len("99")
+	hdrLaunchLen  = 32 // len("#!/usr/bin/env... ")
+	hdrMagicLen   = 10 // len("SIF_MAGIC")
+	hdrVersionLen = 3  // len("99")
+	hdrArchLen    = 3  // len("99")
 
 	DescrNumEntries   = 48                 // the default total number of available descriptors
 	DescrGroupMask    = 0xf0000000         // groups start at that offset
@@ -329,7 +329,7 @@ type Envvar struct{}
 type Partition struct {
 	Fstype   Fstype
 	Parttype Parttype
-	Arch     [HdrArchLen]byte // arch the image is built for
+	Arch     [hdrArchLen]byte // arch the image is built for
 }
 
 // Signature represents the SIF signature data object descriptor.
@@ -352,11 +352,11 @@ type CryptoMessage struct {
 
 // Header describes a loaded SIF file.
 type Header struct {
-	Launch [HdrLaunchLen]byte // #! shell execution line
+	Launch [hdrLaunchLen]byte // #! shell execution line
 
-	Magic   [HdrMagicLen]byte   // look for "SIF_MAGIC"
-	Version [HdrVersionLen]byte // SIF version
-	Arch    [HdrArchLen]byte    // arch the primary partition is built for
+	Magic   [hdrMagicLen]byte   // look for "SIF_MAGIC"
+	Version [hdrVersionLen]byte // SIF version
+	Arch    [hdrArchLen]byte    // arch the primary partition is built for
 	ID      uuid.UUID           // image unique identifier
 
 	Ctime int64 // image creation time

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -453,15 +453,6 @@ func (f *FileImage) GetHeaderIntegrityReader() io.Reader {
 	return f.Header.GetIntegrityReader()
 }
 
-// CreateInfo wraps all SIF file creation info needed.
-type CreateInfo struct {
-	Pathname   string            // the end result output filename
-	Launchstr  string            // the shell run command
-	Sifversion string            // the SIF specification version used
-	ID         uuid.UUID         // image unique identifier
-	InputDescr []DescriptorInput // slice of input info for descriptor creation
-}
-
 // DescriptorInput describes the common info needed to create a data object descriptor.
 type DescriptorInput struct {
 	Datatype  Datatype // datatype being harvested for new descriptor

--- a/pkg/sif/sif_test.go
+++ b/pkg/sif/sif_test.go
@@ -21,7 +21,7 @@ func TestHeader_GetIntegrityReader(t *testing.T) {
 	}
 	copy(h.Launch[:], hdrLaunch)
 	copy(h.Magic[:], hdrMagic)
-	copy(h.Version[:], HdrVersion)
+	copy(h.Version[:], CurrentVersion.bytes())
 	copy(h.Arch[:], HdrArchAMD64)
 
 	tests := []struct {

--- a/pkg/sif/sif_test.go
+++ b/pkg/sif/sif_test.go
@@ -19,8 +19,8 @@ func TestHeader_GetIntegrityReader(t *testing.T) {
 		Ctime: 1504657553,
 		Mtime: 1504657653,
 	}
-	copy(h.Launch[:], HdrLaunch)
-	copy(h.Magic[:], HdrMagic)
+	copy(h.Launch[:], hdrLaunch)
+	copy(h.Magic[:], hdrMagic)
 	copy(h.Version[:], HdrVersion)
 	copy(h.Arch[:], HdrArchAMD64)
 


### PR DESCRIPTION
Use functional arguments for `CreateContainer`. Define `SpecVersion` type. Switch several header `const` values to be non-exported.

Closes #28 