### PR TITLE
Bump Module Version to v2

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # LICENSE
 
-Copyright (c) 2018-2020, Sylabs Inc. All rights reserved.
+Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Singularity Image Format (SIF)
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/sylabs/sif?status.svg)](https://pkg.go.dev/github.com/sylabs/sif)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/sylabs/sif/v2?status.svg)](https://pkg.go.dev/github.com/sylabs/sif/v2)
 [![Build Status](https://circleci.com/gh/sylabs/sif.svg?style=shield)](https://circleci.com/gh/sylabs/workflows/sif)
 [![Code Coverage](https://codecov.io/gh/sylabs/sif/branch/master/graph/badge.svg)](https://app.codecov.io/gh/sylabs/sif)
 [![Go Report Card](https://goreportcard.com/badge/github.com/sylabs/sif)](https://goreportcard.com/report/github.com/sylabs/sif)
@@ -16,7 +16,7 @@ Unless otherwise noted, the SIF source files are distributed under the BSD-style
 To get the sif package to use directly from your programs:
 
 ```sh
-go get github.com/sylabs/sif
+go get github.com/sylabs/sif/v2
 ```
 
 To get the siftool CLI program installed to `$(go env GOPATH)/bin` to manipulate SIF container files:

--- a/cmd/siftool/siftool.go
+++ b/cmd/siftool/siftool.go
@@ -12,8 +12,8 @@ import (
 	"runtime"
 
 	"github.com/spf13/cobra"
-	"github.com/sylabs/sif/pkg/sif"
-	"github.com/sylabs/sif/pkg/siftool"
+	"github.com/sylabs/sif/v2/pkg/sif"
+	"github.com/sylabs/sif/v2/pkg/siftool"
 )
 
 var version = "unknown"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sylabs/sif
+module github.com/sylabs/sif/v2
 
 go 1.15
 

--- a/internal/app/siftool/file.go
+++ b/internal/app/siftool/file.go
@@ -6,7 +6,7 @@
 package siftool
 
 import (
-	"github.com/sylabs/sif/pkg/sif"
+	"github.com/sylabs/sif/v2/pkg/sif"
 )
 
 // withFileImage calls fn with a FileImage loaded from path.

--- a/internal/app/siftool/info.go
+++ b/internal/app/siftool/info.go
@@ -14,7 +14,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/sylabs/sif/pkg/sif"
+	"github.com/sylabs/sif/v2/pkg/sif"
 )
 
 // Header displays a SIF file global header.

--- a/internal/app/siftool/modif.go
+++ b/internal/app/siftool/modif.go
@@ -12,7 +12,7 @@ import (
 	"io"
 
 	uuid "github.com/satori/go.uuid"
-	"github.com/sylabs/sif/pkg/sif"
+	"github.com/sylabs/sif/v2/pkg/sif"
 )
 
 // New creates a new empty SIF file.

--- a/pkg/integrity/digest.go
+++ b/pkg/integrity/digest.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -15,7 +15,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/sylabs/sif/pkg/sif"
+	"github.com/sylabs/sif/v2/pkg/sif"
 )
 
 var (

--- a/pkg/integrity/digest_test.go
+++ b/pkg/integrity/digest_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 
 	"github.com/sebdah/goldie/v2"
-	"github.com/sylabs/sif/pkg/sif"
+	"github.com/sylabs/sif/v2/pkg/sif"
 )
 
 func TestNewLegacyDigest(t *testing.T) {

--- a/pkg/integrity/metadata.go
+++ b/pkg/integrity/metadata.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/sylabs/sif/pkg/sif"
+	"github.com/sylabs/sif/v2/pkg/sif"
 )
 
 var (

--- a/pkg/integrity/metadata_test.go
+++ b/pkg/integrity/metadata_test.go
@@ -19,7 +19,7 @@ import (
 
 	uuid "github.com/satori/go.uuid"
 	"github.com/sebdah/goldie/v2"
-	"github.com/sylabs/sif/pkg/sif"
+	"github.com/sylabs/sif/v2/pkg/sif"
 )
 
 func TestWriteHeader(t *testing.T) {

--- a/pkg/integrity/result.go
+++ b/pkg/integrity/result.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -6,7 +6,7 @@
 package integrity
 
 import (
-	"github.com/sylabs/sif/pkg/sif"
+	"github.com/sylabs/sif/v2/pkg/sif"
 	"golang.org/x/crypto/openpgp"
 )
 

--- a/pkg/integrity/select.go
+++ b/pkg/integrity/select.go
@@ -12,7 +12,7 @@ import (
 	"io"
 	"sort"
 
-	"github.com/sylabs/sif/pkg/sif"
+	"github.com/sylabs/sif/v2/pkg/sif"
 )
 
 var (

--- a/pkg/integrity/sign.go
+++ b/pkg/integrity/sign.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/sylabs/sif/pkg/sif"
+	"github.com/sylabs/sif/v2/pkg/sif"
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/packet"
 )

--- a/pkg/integrity/sign_test.go
+++ b/pkg/integrity/sign_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 
 	"github.com/sebdah/goldie/v2"
-	"github.com/sylabs/sif/pkg/sif"
+	"github.com/sylabs/sif/v2/pkg/sif"
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/packet"
 )

--- a/pkg/integrity/testdata/gen_sifs.go
+++ b/pkg/integrity/testdata/gen_sifs.go
@@ -12,8 +12,8 @@ import (
 	"path/filepath"
 
 	uuid "github.com/satori/go.uuid"
-	"github.com/sylabs/sif/pkg/integrity"
-	"github.com/sylabs/sif/pkg/sif"
+	"github.com/sylabs/sif/v2/pkg/integrity"
+	"github.com/sylabs/sif/v2/pkg/sif"
 	"golang.org/x/crypto/openpgp"
 )
 

--- a/pkg/integrity/verify.go
+++ b/pkg/integrity/verify.go
@@ -13,7 +13,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/sylabs/sif/pkg/sif"
+	"github.com/sylabs/sif/v2/pkg/sif"
 	"golang.org/x/crypto/openpgp"
 )
 

--- a/pkg/integrity/verify_test.go
+++ b/pkg/integrity/verify_test.go
@@ -12,7 +12,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sylabs/sif/pkg/sif"
+	"github.com/sylabs/sif/v2/pkg/sif"
 	"golang.org/x/crypto/openpgp"
 	pgperrors "golang.org/x/crypto/openpgp/errors"
 )

--- a/pkg/siftool/add.go
+++ b/pkg/siftool/add.go
@@ -12,8 +12,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/sylabs/sif/internal/app/siftool"
-	"github.com/sylabs/sif/pkg/sif"
+	"github.com/sylabs/sif/v2/internal/app/siftool"
+	"github.com/sylabs/sif/v2/pkg/sif"
 )
 
 // Add implements 'siftool add' sub-command.

--- a/pkg/siftool/del.go
+++ b/pkg/siftool/del.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 
 	"github.com/spf13/cobra"
-	"github.com/sylabs/sif/internal/app/siftool"
+	"github.com/sylabs/sif/v2/internal/app/siftool"
 )
 
 // Del implements 'siftool del' sub-command.

--- a/pkg/siftool/dump.go
+++ b/pkg/siftool/dump.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 
 	"github.com/spf13/cobra"
-	"github.com/sylabs/sif/internal/app/siftool"
+	"github.com/sylabs/sif/v2/internal/app/siftool"
 )
 
 // Dump implements 'siftool dump' sub-command.

--- a/pkg/siftool/header.go
+++ b/pkg/siftool/header.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // Copyright (c) 2018, Divya Cote <divya.cote@gmail.com> All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
@@ -10,7 +10,7 @@ package siftool
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/sylabs/sif/internal/app/siftool"
+	"github.com/sylabs/sif/v2/internal/app/siftool"
 )
 
 // Header implements 'siftool header' sub-command.

--- a/pkg/siftool/info.go
+++ b/pkg/siftool/info.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 
 	"github.com/spf13/cobra"
-	"github.com/sylabs/sif/internal/app/siftool"
+	"github.com/sylabs/sif/v2/internal/app/siftool"
 )
 
 // Info implements 'siftool info' sub-command.

--- a/pkg/siftool/list.go
+++ b/pkg/siftool/list.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // Copyright (c) 2018, Divya Cote <divya.cote@gmail.com> All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
@@ -10,7 +10,7 @@ package siftool
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/sylabs/sif/internal/app/siftool"
+	"github.com/sylabs/sif/v2/internal/app/siftool"
 )
 
 // List implements 'siftool list' sub-command.

--- a/pkg/siftool/new.go
+++ b/pkg/siftool/new.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -9,7 +9,7 @@ package siftool
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/sylabs/sif/internal/app/siftool"
+	"github.com/sylabs/sif/v2/internal/app/siftool"
 )
 
 // New implements 'siftool new' sub-command.

--- a/pkg/siftool/setprim.go
+++ b/pkg/siftool/setprim.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 
 	"github.com/spf13/cobra"
-	"github.com/sylabs/sif/internal/app/siftool"
+	"github.com/sylabs/sif/v2/internal/app/siftool"
 )
 
 // Setprim implements 'siftool setprim' sub-command.


### PR DESCRIPTION
In preparation for version 2.0, update import path to `github.com/sylabs/sif/v2`.

Note: a [`v1` branch](https://github.com/sylabs/sif/tree/v1) has been created for ongoing 1.x maintenance. Development of version 2.x will occur on the `master` branch.