### PR TITLE
Modify GetData to Return Error

### DIFF
--- a/pkg/integrity/select.go
+++ b/pkg/integrity/select.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"sort"
 
 	"github.com/sylabs/sif/v2/pkg/sif"
@@ -152,8 +151,8 @@ func getGroupSignatures(f *sif.FileImage, groupID uint32, legacy bool) ([]*sif.D
 	// Filter signatures based on legacy flag.
 	sigs := make([]*sif.Descriptor, 0, len(ods))
 	for _, od := range ods {
-		b := make([]byte, od.Filelen)
-		if _, err := io.ReadFull(od.GetReader(f), b); err != nil {
+		b, err := od.GetData(f)
+		if err != nil {
 			return nil, err
 		}
 

--- a/pkg/integrity/verify.go
+++ b/pkg/integrity/verify.go
@@ -128,8 +128,8 @@ func (v *groupVerifier) fingerprints() ([][20]byte, error) {
 // of a data object descriptor fails, a DescriptorIntegrityError is returned. If verification of a
 // data object fails, a ObjectIntegrityError is returned.
 func (v *groupVerifier) verifySignature(sig *sif.Descriptor, kr openpgp.KeyRing) (imageMetadata, []uint32, *openpgp.Entity, error) { // nolint:lll
-	b := make([]byte, sig.Filelen)
-	if _, err := io.ReadFull(sig.GetReader(v.f), b); err != nil {
+	b, err := sig.GetData(v.f)
+	if err != nil {
 		return imageMetadata{}, nil, nil, err
 	}
 

--- a/pkg/sif/lookup.go
+++ b/pkg/sif/lookup.go
@@ -252,13 +252,13 @@ func (fimg *FileImage) GetFromDescr(descr Descriptor) ([]*Descriptor, []int, err
 	return descrs, indexes, nil
 }
 
-// GetData returns the data object associated with descriptor d from image fimg, or nil on error.
-func (d *Descriptor) GetData(fimg *FileImage) []byte {
+// GetData returns the data object associated with descriptor d from f.
+func (d *Descriptor) GetData(f *FileImage) ([]byte, error) {
 	b := make([]byte, d.Filelen)
-	if _, err := io.ReadFull(d.GetReader(fimg), b); err != nil {
-		return nil
+	if _, err := io.ReadFull(d.GetReader(f), b); err != nil {
+		return nil, err
 	}
-	return b
+	return b, nil
 }
 
 // GetReader returns a io.Reader that reads the data object associated with descriptor d from f.

--- a/pkg/sif/lookup_test.go
+++ b/pkg/sif/lookup_test.go
@@ -288,8 +288,11 @@ func TestGetData(t *testing.T) {
 				t.Fatalf("failed to get descriptor: %v", err)
 			}
 
-			// Read data via ReadSeeker and validate data.
-			b := descr.GetData(tt.fimg)
+			b, err := descr.GetData(tt.fimg)
+			if err != nil {
+				t.Fatalf("failed to get data: %v", err)
+			}
+
 			if got, want := string(b[5:10]), "BEGIN"; got != want {
 				t.Errorf("got data %#v, want %#v", got, want)
 			}


### PR DESCRIPTION
Modify `GetData` to return `error`. Use `GetData` where appropriate to simplify code.

Closes #13 