### PR TITLE
Reduce Siftool API Surface

### DIFF
--- a/cmd/siftool/siftool.go
+++ b/cmd/siftool/siftool.go
@@ -8,6 +8,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"runtime"
 
@@ -40,17 +41,12 @@ header, the data object descriptors and to dump data objects. It is also
 possible to modify a SIF file via this tool via the add/del commands.`,
 	}
 
-	root.AddCommand(
-		getVersion(),
-		siftool.Header(),
-		siftool.List(),
-		siftool.Info(),
-		siftool.Dump(),
-		siftool.New(),
-		siftool.Add(),
-		siftool.Del(),
-		siftool.Setprim(),
-	)
+	root.AddCommand(getVersion())
+
+	if err := siftool.AddCommands(&root); err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		os.Exit(1)
+	}
 
 	if err := root.Execute(); err != nil {
 		os.Exit(1)

--- a/internal/app/siftool/app.go
+++ b/internal/app/siftool/app.go
@@ -5,8 +5,15 @@
 
 package siftool
 
+import (
+	"io"
+	"os"
+)
+
 // appOpts contains configured options.
-type appOpts struct{}
+type appOpts struct {
+	out io.Writer
+}
 
 // AppOpt are used to configure optional behavior.
 type AppOpt func(*appOpts) error
@@ -16,9 +23,21 @@ type App struct {
 	opts appOpts
 }
 
+// OptAppOutput specifies that output should be written to w.
+func OptAppOutput(w io.Writer) AppOpt {
+	return func(o *appOpts) error {
+		o.out = w
+		return nil
+	}
+}
+
 // New creates a new App configured with opts.
 func New(opts ...AppOpt) (*App, error) {
-	a := App{}
+	a := App{
+		opts: appOpts{
+			out: os.Stdout,
+		},
+	}
 
 	for _, opt := range opts {
 		if err := opt(&a.opts); err != nil {

--- a/internal/app/siftool/app.go
+++ b/internal/app/siftool/app.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package siftool
+
+// appOpts contains configured options.
+type appOpts struct{}
+
+// AppOpt are used to configure optional behavior.
+type AppOpt func(*appOpts) error
+
+// App holds state and configured options.
+type App struct {
+	opts appOpts
+}
+
+// New creates a new App configured with opts.
+func New(opts ...AppOpt) (*App, error) {
+	a := App{}
+
+	for _, opt := range opts {
+		if err := opt(&a.opts); err != nil {
+			return nil, err
+		}
+	}
+
+	return &a, nil
+}

--- a/internal/app/siftool/info.go
+++ b/internal/app/siftool/info.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Header displays a SIF file global header.
-func Header(path string) error {
+func (*App) Header(path string) error {
 	return withFileImage(path, true, func(f *sif.FileImage) error {
 		//nolint:staticcheck // In use until v2 API to avoid code duplication
 		_, err := fmt.Print(f.FmtHeader())
@@ -27,7 +27,7 @@ func Header(path string) error {
 }
 
 // List displays a list of all active descriptors from a SIF file.
-func List(path string) error {
+func (*App) List(path string) error {
 	return withFileImage(path, false, func(f *sif.FileImage) error {
 		fmt.Println("Container id:", f.Header.ID)
 		fmt.Println("Created on:  ", time.Unix(f.Header.Ctime, 0).UTC())
@@ -43,7 +43,7 @@ func List(path string) error {
 }
 
 // Info displays detailed info about a descriptor from a SIF file.
-func Info(path string, id uint32) error {
+func (*App) Info(path string, id uint32) error {
 	return withFileImage(path, false, func(f *sif.FileImage) error {
 		//nolint:staticcheck // In use until v2 API to avoid code duplication
 		_, err := fmt.Print(f.FmtDescrInfo(id))
@@ -52,7 +52,7 @@ func Info(path string, id uint32) error {
 }
 
 // Dump extracts and outputs a data object from a SIF file.
-func Dump(path string, id uint32) error {
+func (*App) Dump(path string, id uint32) error {
 	return withFileImage(path, false, func(f *sif.FileImage) error {
 		d, _, err := f.GetFromDescrID(id)
 		if err != nil {

--- a/internal/app/siftool/info.go
+++ b/internal/app/siftool/info.go
@@ -11,55 +11,54 @@ package siftool
 import (
 	"fmt"
 	"io"
-	"os"
 	"time"
 
 	"github.com/sylabs/sif/v2/pkg/sif"
 )
 
 // Header displays a SIF file global header.
-func (*App) Header(path string) error {
+func (a *App) Header(path string) error {
 	return withFileImage(path, true, func(f *sif.FileImage) error {
 		//nolint:staticcheck // In use until v2 API to avoid code duplication
-		_, err := fmt.Print(f.FmtHeader())
+		_, err := fmt.Fprint(a.opts.out, f.FmtHeader())
 		return err
 	})
 }
 
 // List displays a list of all active descriptors from a SIF file.
-func (*App) List(path string) error {
+func (a *App) List(path string) error {
 	return withFileImage(path, false, func(f *sif.FileImage) error {
-		fmt.Println("Container id:", f.Header.ID)
-		fmt.Println("Created on:  ", time.Unix(f.Header.Ctime, 0).UTC())
-		fmt.Println("Modified on: ", time.Unix(f.Header.Mtime, 0).UTC())
-		fmt.Println("----------------------------------------------------")
+		fmt.Fprintln(a.opts.out, "Container id:", f.Header.ID)
+		fmt.Fprintln(a.opts.out, "Created on:  ", time.Unix(f.Header.Ctime, 0).UTC())
+		fmt.Fprintln(a.opts.out, "Modified on: ", time.Unix(f.Header.Mtime, 0).UTC())
+		fmt.Fprintln(a.opts.out, "----------------------------------------------------")
 
-		fmt.Println("Descriptor list:")
+		fmt.Fprintln(a.opts.out, "Descriptor list:")
 
 		//nolint:staticcheck // In use until v2 API to avoid code duplication
-		_, err := fmt.Print(f.FmtDescrList())
+		_, err := fmt.Fprint(a.opts.out, f.FmtDescrList())
 		return err
 	})
 }
 
 // Info displays detailed info about a descriptor from a SIF file.
-func (*App) Info(path string, id uint32) error {
+func (a *App) Info(path string, id uint32) error {
 	return withFileImage(path, false, func(f *sif.FileImage) error {
 		//nolint:staticcheck // In use until v2 API to avoid code duplication
-		_, err := fmt.Print(f.FmtDescrInfo(id))
+		_, err := fmt.Fprint(a.opts.out, f.FmtDescrInfo(id))
 		return err
 	})
 }
 
 // Dump extracts and outputs a data object from a SIF file.
-func (*App) Dump(path string, id uint32) error {
+func (a *App) Dump(path string, id uint32) error {
 	return withFileImage(path, false, func(f *sif.FileImage) error {
 		d, _, err := f.GetFromDescrID(id)
 		if err != nil {
 			return err
 		}
 
-		_, err = io.CopyN(os.Stdout, d.GetReader(f), d.Filelen)
+		_, err = io.CopyN(a.opts.out, d.GetReader(f), d.Filelen)
 		return err
 	})
 }

--- a/internal/app/siftool/modif.go
+++ b/internal/app/siftool/modif.go
@@ -16,7 +16,7 @@ import (
 )
 
 // New creates a new empty SIF file.
-func New(path string) error {
+func (*App) New(path string) error {
 	id, err := uuid.NewRandom()
 	if err != nil {
 		return err
@@ -49,7 +49,7 @@ type AddOptions struct {
 }
 
 // Add adds a data object to a SIF file.
-func Add(path string, opts AddOptions) error {
+func (*App) Add(path string, opts AddOptions) error {
 	input := sif.DescriptorInput{
 		Datatype:  opts.Datatype,
 		Groupid:   sif.DescrGroupMask | opts.Groupid,
@@ -75,14 +75,14 @@ func Add(path string, opts AddOptions) error {
 }
 
 // Del deletes a specified object descriptor and data from the SIF file.
-func Del(path string, id uint32) error {
+func (*App) Del(path string, id uint32) error {
 	return withFileImage(path, true, func(f *sif.FileImage) error {
 		return f.DeleteObject(id, 0)
 	})
 }
 
 // Setprim sets the primary system partition of the SIF file.
-func Setprim(path string, id uint32) error {
+func (*App) Setprim(path string, id uint32) error {
 	return withFileImage(path, true, func(f *sif.FileImage) error {
 		return f.SetPrimPart(id)
 	})

--- a/pkg/siftool/add.go
+++ b/pkg/siftool/add.go
@@ -141,7 +141,7 @@ func getAdd(co commandOpts) *cobra.Command {
 			}
 		}
 
-		return siftool.Add(args[0], opts)
+		return co.app.Add(args[0], opts)
 	}
 
 	return cmd

--- a/pkg/siftool/add.go
+++ b/pkg/siftool/add.go
@@ -16,45 +16,45 @@ import (
 	"github.com/sylabs/sif/v2/pkg/sif"
 )
 
-// Add implements 'siftool add' sub-command.
-func Add() *cobra.Command {
-	ret := &cobra.Command{
+// getAdd returns a command that adds a data object to a SIF.
+func getAdd(co commandOpts) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "add <containerfile> <dataobjectfile>",
 		Short: "Add a data object to a SIF file",
 		Args:  cobra.ExactArgs(2),
 	}
 
-	datatype := ret.Flags().Int("datatype", 0, `the type of data to add
+	datatype := cmd.Flags().Int("datatype", 0, `the type of data to add
 [NEEDED, no default]:
   1-Deffile,   2-EnvVar,    3-Labels,
   4-Partition, 5-Signature, 6-GenericJSON`)
-	parttype := ret.Flags().Int32("parttype", 0, `the type of partition (with -datatype 4-Partition)
+	parttype := cmd.Flags().Int32("parttype", 0, `the type of partition (with -datatype 4-Partition)
 [NEEDED, no default]:
   1-System,    2-PrimSys,   3-Data,
   4-Overlay`)
-	partfs := ret.Flags().Int32("partfs", 0, `the filesystem used (with -datatype 4-Partition)
+	partfs := cmd.Flags().Int32("partfs", 0, `the filesystem used (with -datatype 4-Partition)
 [NEEDED, no default]:
   1-Squash,    2-Ext3,      3-ImmuObj,
   4-Raw`)
-	partarch := ret.Flags().Int32("partarch", 0, `the main architecture used (with -datatype 4-Partition)
+	partarch := cmd.Flags().Int32("partarch", 0, `the main architecture used (with -datatype 4-Partition)
 [NEEDED, no default]:
   1-386,       2-amd64,     3-arm,
   4-arm64,     5-ppc64,     6-ppc64le,
   7-mips,      8-mipsle,    9-mips64,
   10-mips64le, 11-s390x`)
-	signhash := ret.Flags().Int32("signhash", 0, `the signature hash used (with -datatype 5-Signature)
+	signhash := cmd.Flags().Int32("signhash", 0, `the signature hash used (with -datatype 5-Signature)
 [NEEDED, no default]:
   1-SHA256,    2-SHA384,    3-SHA512,
   4-BLAKE2S,   5-BLAKE2B`)
-	signentity := ret.Flags().String("signentity", "", `the entity that signs (with -datatype 5-Signature)
+	signentity := cmd.Flags().String("signentity", "", `the entity that signs (with -datatype 5-Signature)
 [NEEDED, no default]:
   example: 433FE984155206BD962725E20E8713472A879943`)
-	groupid := ret.Flags().Uint32("groupid", 0, "set groupid [default: 0]")
-	link := ret.Flags().Uint32("link", 0, "set link pointer [default: 0]")
-	alignment := ret.Flags().Int("alignment", 0, "set alignment constraint [default: aligned on page size]")
-	filename := ret.Flags().String("filename", "", "set logical filename/handle [default: input filename]")
+	groupid := cmd.Flags().Uint32("groupid", 0, "set groupid [default: 0]")
+	link := cmd.Flags().Uint32("link", 0, "set link pointer [default: 0]")
+	alignment := cmd.Flags().Int("alignment", 0, "set alignment constraint [default: aligned on page size]")
+	filename := cmd.Flags().String("filename", "", "set logical filename/handle [default: input filename]")
 
-	ret.RunE = func(cmd *cobra.Command, args []string) error {
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		opts := siftool.AddOptions{
 			Groupid:   *groupid,
 			Link:      *link,
@@ -144,5 +144,5 @@ func Add() *cobra.Command {
 		return siftool.Add(args[0], opts)
 	}
 
-	return ret
+	return cmd
 }

--- a/pkg/siftool/del.go
+++ b/pkg/siftool/del.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 
 	"github.com/spf13/cobra"
-	"github.com/sylabs/sif/v2/internal/app/siftool"
 )
 
 // getDel returns a command that deletes a data object from a SIF.
@@ -28,7 +27,7 @@ func getDel(co commandOpts) *cobra.Command {
 				return fmt.Errorf("while converting input descriptor id: %s", err)
 			}
 
-			return siftool.Del(args[1], uint32(id))
+			return co.app.Del(args[1], uint32(id))
 		},
 	}
 }

--- a/pkg/siftool/del.go
+++ b/pkg/siftool/del.go
@@ -15,8 +15,8 @@ import (
 	"github.com/sylabs/sif/v2/internal/app/siftool"
 )
 
-// Del implements 'siftool del' sub-command.
-func Del() *cobra.Command {
+// getDel returns a command that deletes a data object from a SIF.
+func getDel(co commandOpts) *cobra.Command {
 	return &cobra.Command{
 		Use:   "del <descriptorid> <containerfile>",
 		Short: "Delete a specified object descriptor and data from SIF file",

--- a/pkg/siftool/dump.go
+++ b/pkg/siftool/dump.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 
 	"github.com/spf13/cobra"
-	"github.com/sylabs/sif/v2/internal/app/siftool"
 )
 
 // getDump returns a command that dumps a data object from a SIF file.
@@ -29,7 +28,7 @@ func getDump(co commandOpts) *cobra.Command {
 				return fmt.Errorf("while converting input descriptor id: %s", err)
 			}
 
-			return siftool.Dump(args[1], uint32(id))
+			return co.app.Dump(args[1], uint32(id))
 		},
 		DisableFlagsInUseLine: true,
 	}

--- a/pkg/siftool/dump.go
+++ b/pkg/siftool/dump.go
@@ -16,8 +16,8 @@ import (
 	"github.com/sylabs/sif/v2/internal/app/siftool"
 )
 
-// Dump implements 'siftool dump' sub-command.
-func Dump() *cobra.Command {
+// getDump returns a command that dumps a data object from a SIF file.
+func getDump(co commandOpts) *cobra.Command {
 	return &cobra.Command{
 		Use:   "dump <descriptorid> <containerfile>",
 		Short: "Extract and output data objects from SIF files",

--- a/pkg/siftool/header.go
+++ b/pkg/siftool/header.go
@@ -10,7 +10,6 @@ package siftool
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/sylabs/sif/v2/internal/app/siftool"
 )
 
 // getHeader returns a command that displays the global SIF header.
@@ -21,7 +20,7 @@ func getHeader(co commandOpts) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return siftool.Header(args[0])
+			return co.app.Header(args[0])
 		},
 		DisableFlagsInUseLine: true,
 	}

--- a/pkg/siftool/header.go
+++ b/pkg/siftool/header.go
@@ -13,8 +13,8 @@ import (
 	"github.com/sylabs/sif/v2/internal/app/siftool"
 )
 
-// Header implements 'siftool header' sub-command.
-func Header() *cobra.Command {
+// getHeader returns a command that displays the global SIF header.
+func getHeader(co commandOpts) *cobra.Command {
 	return &cobra.Command{
 		Use:   "header <containerfile>",
 		Short: "Display SIF global headers",

--- a/pkg/siftool/info.go
+++ b/pkg/siftool/info.go
@@ -16,8 +16,9 @@ import (
 	"github.com/sylabs/sif/v2/internal/app/siftool"
 )
 
-// Info implements 'siftool info' sub-command.
-func Info() *cobra.Command {
+// getInfo returns a command that displays detailed information of an object descriptor from a SIF
+// image.
+func getInfo(co commandOpts) *cobra.Command {
 	return &cobra.Command{
 		Use:   "info <descriptorid> <containerfile>",
 		Short: "Display detailed information of object descriptors",

--- a/pkg/siftool/info.go
+++ b/pkg/siftool/info.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 
 	"github.com/spf13/cobra"
-	"github.com/sylabs/sif/v2/internal/app/siftool"
 )
 
 // getInfo returns a command that displays detailed information of an object descriptor from a SIF
@@ -30,7 +29,7 @@ func getInfo(co commandOpts) *cobra.Command {
 				return fmt.Errorf("while converting input descriptor id: %s", err)
 			}
 
-			return siftool.Info(args[1], uint32(id))
+			return co.app.Info(args[1], uint32(id))
 		},
 		DisableFlagsInUseLine: true,
 	}

--- a/pkg/siftool/list.go
+++ b/pkg/siftool/list.go
@@ -13,8 +13,8 @@ import (
 	"github.com/sylabs/sif/v2/internal/app/siftool"
 )
 
-// List implements 'siftool list' sub-command.
-func List() *cobra.Command {
+// getList returns a command that lists object descriptors from a SIF image.
+func getList(co commandOpts) *cobra.Command {
 	return &cobra.Command{
 		Use:   "list <containerfile>",
 		Short: "List object descriptors from SIF files",

--- a/pkg/siftool/list.go
+++ b/pkg/siftool/list.go
@@ -10,7 +10,6 @@ package siftool
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/sylabs/sif/v2/internal/app/siftool"
 )
 
 // getList returns a command that lists object descriptors from a SIF image.
@@ -21,7 +20,7 @@ func getList(co commandOpts) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return siftool.List(args[0])
+			return co.app.List(args[0])
 		},
 		DisableFlagsInUseLine: true,
 	}

--- a/pkg/siftool/new.go
+++ b/pkg/siftool/new.go
@@ -9,7 +9,6 @@ package siftool
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/sylabs/sif/v2/internal/app/siftool"
 )
 
 // getNew returns a command that creates a new, empty SIF image.
@@ -20,7 +19,7 @@ func getNew(co commandOpts) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return siftool.New(args[0])
+			return co.app.New(args[0])
 		},
 		DisableFlagsInUseLine: true,
 	}

--- a/pkg/siftool/new.go
+++ b/pkg/siftool/new.go
@@ -12,8 +12,8 @@ import (
 	"github.com/sylabs/sif/v2/internal/app/siftool"
 )
 
-// New implements 'siftool new' sub-command.
-func New() *cobra.Command {
+// getNew returns a command that creates a new, empty SIF image.
+func getNew(co commandOpts) *cobra.Command {
 	return &cobra.Command{
 		Use:   "new <containerfile>",
 		Short: "Create a new empty SIF image file",

--- a/pkg/siftool/setprim.go
+++ b/pkg/siftool/setprim.go
@@ -15,8 +15,8 @@ import (
 	"github.com/sylabs/sif/v2/internal/app/siftool"
 )
 
-// Setprim implements 'siftool setprim' sub-command.
-func Setprim() *cobra.Command {
+// getSetPrim returns a command that sets the primary system partition.
+func getSetPrim(co commandOpts) *cobra.Command {
 	return &cobra.Command{
 		Use:   "setprim <descriptorid> <containerfile>",
 		Short: "Set primary system partition",

--- a/pkg/siftool/setprim.go
+++ b/pkg/siftool/setprim.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 
 	"github.com/spf13/cobra"
-	"github.com/sylabs/sif/v2/internal/app/siftool"
 )
 
 // getSetPrim returns a command that sets the primary system partition.
@@ -28,7 +27,7 @@ func getSetPrim(co commandOpts) *cobra.Command {
 				return fmt.Errorf("while converting input descriptor id: %s", err)
 			}
 
-			return siftool.Setprim(args[1], uint32(id))
+			return co.app.Setprim(args[1], uint32(id))
 		},
 	}
 }

--- a/pkg/siftool/siftool.go
+++ b/pkg/siftool/siftool.go
@@ -5,48 +5,41 @@
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
-// Package siftool implements cobra.Command structs for the siftool functionality. This
-// allows for easy inclusion of siftool functions in the singularity cli.
+// Package siftool adds siftool commands to a parent cobra.Command.
 package siftool
 
-import (
-	"github.com/spf13/cobra"
-)
+import "github.com/spf13/cobra"
 
-const (
-	siftoolLong = `
-  A set of commands are provided to display elements such as the SIF global 
-  header, the data object descriptors and to dump data objects. It is also 
-  possible to modify a SIF file via this tool via the add/del commands.`
-)
+// commandOpts contains configured options.
+type commandOpts struct{}
 
-// Siftool is a program for Singularity Image Format (SIF) file manipulation.
+// CommandOpt are used to configure optional command behavior.
+type CommandOpt func(*commandOpts) error
+
+// AddCommands adds siftool commands to cmd according to opts.
 //
 // A set of commands are provided to display elements such as the SIF global
 // header, the data object descriptors and to dump data objects. It is also
 // possible to modify a SIF file via this tool via the add/del commands.
-func Siftool() *cobra.Command {
-	// Siftool is a program for Singularity Image Format (SIF) file manipulation.
-	//
-	// A set of commands are provided to display elements such as the SIF global
-	// header, the data object descriptors and to dump data objects. It is also
-	// possible to modify a SIF file via this tool via the add/del commands.
-	Siftool := &cobra.Command{
-		Use:                   "sif",
-		Short:                 "siftool is a program for Singularity Image Format (SIF) file manipulation",
-		Long:                  siftoolLong,
-		Aliases:               []string{"siftool"},
-		DisableFlagsInUseLine: true,
+func AddCommands(cmd *cobra.Command, opts ...CommandOpt) error {
+	co := commandOpts{}
+
+	for _, opt := range opts {
+		if err := opt(&co); err != nil {
+			return err
+		}
 	}
 
-	Siftool.AddCommand(Header())
-	Siftool.AddCommand(List())
-	Siftool.AddCommand(Info())
-	Siftool.AddCommand(Dump())
-	Siftool.AddCommand(New())
-	Siftool.AddCommand(Add())
-	Siftool.AddCommand(Del())
-	Siftool.AddCommand(Setprim())
+	cmd.AddCommand(
+		getHeader(co),
+		getList(co),
+		getInfo(co),
+		getDump(co),
+		getNew(co),
+		getAdd(co),
+		getDel(co),
+		getSetPrim(co),
+	)
 
-	return Siftool
+	return nil
 }

--- a/pkg/siftool/siftool.go
+++ b/pkg/siftool/siftool.go
@@ -8,10 +8,15 @@
 // Package siftool adds siftool commands to a parent cobra.Command.
 package siftool
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+	"github.com/sylabs/sif/v2/internal/app/siftool"
+)
 
 // commandOpts contains configured options.
-type commandOpts struct{}
+type commandOpts struct {
+	app *siftool.App
+}
 
 // CommandOpt are used to configure optional command behavior.
 type CommandOpt func(*commandOpts) error
@@ -22,7 +27,12 @@ type CommandOpt func(*commandOpts) error
 // header, the data object descriptors and to dump data objects. It is also
 // possible to modify a SIF file via this tool via the add/del commands.
 func AddCommands(cmd *cobra.Command, opts ...CommandOpt) error {
-	co := commandOpts{}
+	app, err := siftool.New()
+	if err != nil {
+		return err
+	}
+
+	co := commandOpts{app: app}
 
 	for _, opt := range opts {
 		if err := opt(&co); err != nil {


### PR DESCRIPTION
Reduce `github.com/sylabs/sif/v2/pkg/siftool` API surface. Add functional options in `github.com/sylabs/sif/v2/internal/app/siftool` package, and add `OptAppOutput` in  to support writing unit tests (#38).

Closes #39 