### PR TITLE
Improve Documentation

### DIFF
--- a/cmd/siftool/siftool.go
+++ b/cmd/siftool/siftool.go
@@ -22,7 +22,8 @@ var version = "unknown"
 func getVersion() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
-		Short: "Print version information",
+		Short: "Display version information",
+		Long:  "Display binary version and compatible SIF version(s).",
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Printf("siftool version %s %s/%s\n", version, runtime.GOOS, runtime.GOARCH)

--- a/pkg/siftool/add.go
+++ b/pkg/siftool/add.go
@@ -19,8 +19,9 @@ import (
 // getAdd returns a command that adds a data object to a SIF.
 func (c *command) getAdd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "add <containerfile> <dataobjectfile>",
-		Short: "Add a data object to a SIF file",
+		Use:   "add <sif_path> <object_path>",
+		Short: "Add data object",
+		Long:  "Add a data object to a SIF image.",
 		Args:  cobra.ExactArgs(2),
 	}
 

--- a/pkg/siftool/add.go
+++ b/pkg/siftool/add.go
@@ -10,19 +10,34 @@ package siftool
 import (
 	"errors"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/sylabs/sif/v2/internal/app/siftool"
 	"github.com/sylabs/sif/v2/pkg/sif"
 )
 
+// getAddExamples returns add command examples based on rootCmd.
+func getAddExamples(rootPath string) string {
+	examples := []string{
+		rootPath +
+			" add image.sif recipe.def -datatype 1",
+		rootPath +
+			" add image.sif rootfs.squashfs --datatype 4 --parttype 1 --partfs 1 ----partarch 2",
+		rootPath +
+			" add image.sif signature.bin -datatype 5 --signentity 433FE984155206BD962725E20E8713472A879943 --signhash 1",
+	}
+	return strings.Join(examples, "\n")
+}
+
 // getAdd returns a command that adds a data object to a SIF.
 func (c *command) getAdd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "add <sif_path> <object_path>",
-		Short: "Add data object",
-		Long:  "Add a data object to a SIF image.",
-		Args:  cobra.ExactArgs(2),
+		Use:     "add <sif_path> <object_path>",
+		Short:   "Add data object",
+		Long:    "Add a data object to a SIF image.",
+		Example: getAddExamples(c.opts.rootPath),
+		Args:    cobra.ExactArgs(2),
 	}
 
 	datatype := cmd.Flags().Int("datatype", 0, `the type of data to add

--- a/pkg/siftool/del.go
+++ b/pkg/siftool/del.go
@@ -20,6 +20,7 @@ func (c *command) getDel() *cobra.Command {
 		Use:     "del <id> <sif_path>",
 		Short:   "Delete data object",
 		Long:    "Delete a data object from a SIF image.",
+		Example: c.opts.rootPath + " del 1 image.sif",
 		Args:    cobra.ExactArgs(2),
 		PreRunE: c.initApp,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/siftool/del.go
+++ b/pkg/siftool/del.go
@@ -17,10 +17,10 @@ import (
 // getDel returns a command that deletes a data object from a SIF.
 func (c *command) getDel() *cobra.Command {
 	return &cobra.Command{
-		Use:   "del <descriptorid> <containerfile>",
-		Short: "Delete a specified object descriptor and data from SIF file",
-		Args:  cobra.ExactArgs(2),
-
+		Use:     "del <id> <sif_path>",
+		Short:   "Delete data object",
+		Long:    "Delete a data object from a SIF image.",
+		Args:    cobra.ExactArgs(2),
 		PreRunE: c.initApp,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := strconv.ParseUint(args[0], 10, 32)

--- a/pkg/siftool/dump.go
+++ b/pkg/siftool/dump.go
@@ -18,10 +18,10 @@ import (
 // getDump returns a command that dumps a data object from a SIF file.
 func (c *command) getDump() *cobra.Command {
 	return &cobra.Command{
-		Use:   "dump <descriptorid> <containerfile>",
-		Short: "Extract and output data objects from SIF files",
-		Args:  cobra.ExactArgs(2),
-
+		Use:     "dump <id> <sif_path>",
+		Short:   "Dump data object",
+		Long:    "Dump a data object from a SIF image.",
+		Args:    cobra.ExactArgs(2),
 		PreRunE: c.initApp,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := strconv.ParseUint(args[0], 10, 32)

--- a/pkg/siftool/dump.go
+++ b/pkg/siftool/dump.go
@@ -21,6 +21,7 @@ func (c *command) getDump() *cobra.Command {
 		Use:     "dump <id> <sif_path>",
 		Short:   "Dump data object",
 		Long:    "Dump a data object from a SIF image.",
+		Example: c.opts.rootPath + " dump 1 image.sif",
 		Args:    cobra.ExactArgs(2),
 		PreRunE: c.initApp,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/siftool/header.go
+++ b/pkg/siftool/header.go
@@ -18,6 +18,7 @@ func (c *command) getHeader() *cobra.Command {
 		Use:     "header <sif_path>",
 		Short:   "Display global header",
 		Long:    "Display global header from a SIF image.",
+		Example: c.opts.rootPath + " header image.sif",
 		Args:    cobra.ExactArgs(1),
 		PreRunE: c.initApp,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/siftool/header.go
+++ b/pkg/siftool/header.go
@@ -15,10 +15,10 @@ import (
 // getHeader returns a command that displays the global SIF header.
 func (c *command) getHeader() *cobra.Command {
 	return &cobra.Command{
-		Use:   "header <containerfile>",
-		Short: "Display SIF global headers",
-		Args:  cobra.ExactArgs(1),
-
+		Use:     "header <sif_path>",
+		Short:   "Display global header",
+		Long:    "Display global header from a SIF image.",
+		Args:    cobra.ExactArgs(1),
 		PreRunE: c.initApp,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return c.app.Header(args[0])

--- a/pkg/siftool/info.go
+++ b/pkg/siftool/info.go
@@ -22,6 +22,7 @@ func (c *command) getInfo() *cobra.Command {
 		Use:     "info <id> <sif_path>",
 		Short:   "Display data object info",
 		Long:    "Display info about a data object from a SIF image.",
+		Example: c.opts.rootPath + " info 1 image.sif",
 		Args:    cobra.ExactArgs(2),
 		PreRunE: c.initApp,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/siftool/info.go
+++ b/pkg/siftool/info.go
@@ -19,10 +19,10 @@ import (
 // image.
 func (c *command) getInfo() *cobra.Command {
 	return &cobra.Command{
-		Use:   "info <descriptorid> <containerfile>",
-		Short: "Display detailed information of object descriptors",
-		Args:  cobra.ExactArgs(2),
-
+		Use:     "info <id> <sif_path>",
+		Short:   "Display data object info",
+		Long:    "Display info about a data object from a SIF image.",
+		Args:    cobra.ExactArgs(2),
 		PreRunE: c.initApp,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := strconv.ParseUint(args[0], 10, 32)

--- a/pkg/siftool/list.go
+++ b/pkg/siftool/list.go
@@ -18,6 +18,7 @@ func (c *command) getList() *cobra.Command {
 		Use:     "list <sif_path>",
 		Short:   "List data objects",
 		Long:    "List data objects from a SIF image.",
+		Example: c.opts.rootPath + " list image.sif",
 		Args:    cobra.ExactArgs(1),
 		PreRunE: c.initApp,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/siftool/list.go
+++ b/pkg/siftool/list.go
@@ -15,10 +15,10 @@ import (
 // getList returns a command that lists object descriptors from a SIF image.
 func (c *command) getList() *cobra.Command {
 	return &cobra.Command{
-		Use:   "list <containerfile>",
-		Short: "List object descriptors from SIF files",
-		Args:  cobra.ExactArgs(1),
-
+		Use:     "list <sif_path>",
+		Short:   "List data objects",
+		Long:    "List data objects from a SIF image.",
+		Args:    cobra.ExactArgs(1),
 		PreRunE: c.initApp,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return c.app.List(args[0])

--- a/pkg/siftool/new.go
+++ b/pkg/siftool/new.go
@@ -14,10 +14,10 @@ import (
 // getNew returns a command that creates a new, empty SIF image.
 func (c *command) getNew() *cobra.Command {
 	return &cobra.Command{
-		Use:   "new <containerfile>",
-		Short: "Create a new empty SIF image file",
-		Args:  cobra.ExactArgs(1),
-
+		Use:     "new <sif_path>",
+		Short:   "Create SIF image",
+		Long:    "Create a new, empty SIF image.",
+		Args:    cobra.ExactArgs(1),
 		PreRunE: c.initApp,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return c.app.New(args[0])

--- a/pkg/siftool/new.go
+++ b/pkg/siftool/new.go
@@ -17,6 +17,7 @@ func (c *command) getNew() *cobra.Command {
 		Use:     "new <sif_path>",
 		Short:   "Create SIF image",
 		Long:    "Create a new, empty SIF image.",
+		Example: c.opts.rootPath + " new image.sif",
 		Args:    cobra.ExactArgs(1),
 		PreRunE: c.initApp,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/siftool/setprim.go
+++ b/pkg/siftool/setprim.go
@@ -20,6 +20,7 @@ func (c *command) getSetPrim() *cobra.Command {
 		Use:     "setprim <id> <sif_path>",
 		Short:   "Set primary system partition",
 		Long:    "Set the primary system partition in a SIF image.",
+		Example: c.opts.rootPath + " setprim 1 image.sif",
 		Args:    cobra.ExactArgs(2),
 		PreRunE: c.initApp,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/siftool/setprim.go
+++ b/pkg/siftool/setprim.go
@@ -17,10 +17,10 @@ import (
 // getSetPrim returns a command that sets the primary system partition.
 func (c *command) getSetPrim() *cobra.Command {
 	return &cobra.Command{
-		Use:   "setprim <descriptorid> <containerfile>",
-		Short: "Set primary system partition",
-		Args:  cobra.ExactArgs(2),
-
+		Use:     "setprim <id> <sif_path>",
+		Short:   "Set primary system partition",
+		Long:    "Set the primary system partition in a SIF image.",
+		Args:    cobra.ExactArgs(2),
 		PreRunE: c.initApp,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := strconv.ParseUint(args[0], 10, 32)

--- a/pkg/siftool/siftool.go
+++ b/pkg/siftool/siftool.go
@@ -30,7 +30,9 @@ func (c *command) initApp(cmd *cobra.Command, args []string) error {
 }
 
 // commandOpts contains configured options.
-type commandOpts struct{}
+type commandOpts struct {
+	rootPath string
+}
 
 // CommandOpt are used to configure optional command behavior.
 type CommandOpt func(*commandOpts) error
@@ -41,7 +43,11 @@ type CommandOpt func(*commandOpts) error
 // header, the data object descriptors and to dump data objects. It is also
 // possible to modify a SIF file via this tool via the add/del commands.
 func AddCommands(cmd *cobra.Command, opts ...CommandOpt) error {
-	c := command{}
+	c := command{
+		opts: commandOpts{
+			rootPath: cmd.CommandPath(),
+		},
+	}
 
 	for _, opt := range opts {
 		if err := opt(&c.opts); err != nil {

--- a/pkg/siftool/siftool_test.go
+++ b/pkg/siftool/siftool_test.go
@@ -73,6 +73,7 @@ func runCommand(t *testing.T, cmd *cobra.Command, args []string) {
 func TestAddCommands(t *testing.T) {
 	tests := []struct {
 		name string
+		opts []CommandOpt
 		args []string
 	}{
 		{
@@ -118,7 +119,7 @@ func TestAddCommands(t *testing.T) {
 				Use: "siftool",
 			}
 
-			if err := AddCommands(cmd); err != nil {
+			if err := AddCommands(cmd, tt.opts...); err != nil {
 				t.Fatal(err)
 			}
 

--- a/pkg/siftool/testdata/TestAddCommands/Add/out.golden
+++ b/pkg/siftool/testdata/TestAddCommands/Add/out.golden
@@ -3,6 +3,11 @@ Add a data object to a SIF image.
 Usage:
   siftool add <sif_path> <object_path> [flags]
 
+Examples:
+siftool add image.sif recipe.def -datatype 1
+siftool add image.sif rootfs.squashfs --datatype 4 --parttype 1 --partfs 1 ----partarch 2
+siftool add image.sif signature.bin -datatype 5 --signentity 433FE984155206BD962725E20E8713472A879943 --signhash 1
+
 Flags:
       --alignment int       set alignment constraint [default: aligned on page size]
       --datatype int        the type of data to add

--- a/pkg/siftool/testdata/TestAddCommands/Add/out.golden
+++ b/pkg/siftool/testdata/TestAddCommands/Add/out.golden
@@ -1,7 +1,7 @@
-Add a data object to a SIF file
+Add a data object to a SIF image.
 
 Usage:
-  siftool add <containerfile> <dataobjectfile> [flags]
+  siftool add <sif_path> <object_path> [flags]
 
 Flags:
       --alignment int       set alignment constraint [default: aligned on page size]

--- a/pkg/siftool/testdata/TestAddCommands/Del/out.golden
+++ b/pkg/siftool/testdata/TestAddCommands/Del/out.golden
@@ -1,7 +1,7 @@
-Delete a specified object descriptor and data from SIF file
+Delete a data object from a SIF image.
 
 Usage:
-  siftool del <descriptorid> <containerfile>
+  siftool del <id> <sif_path>
 
 Flags:
   -h, --help   help for del

--- a/pkg/siftool/testdata/TestAddCommands/Del/out.golden
+++ b/pkg/siftool/testdata/TestAddCommands/Del/out.golden
@@ -3,5 +3,8 @@ Delete a data object from a SIF image.
 Usage:
   siftool del <id> <sif_path>
 
+Examples:
+siftool del 1 image.sif
+
 Flags:
   -h, --help   help for del

--- a/pkg/siftool/testdata/TestAddCommands/Dump/out.golden
+++ b/pkg/siftool/testdata/TestAddCommands/Dump/out.golden
@@ -1,7 +1,7 @@
-Extract and output data objects from SIF files
+Dump a data object from a SIF image.
 
 Usage:
-  siftool dump <descriptorid> <containerfile>
+  siftool dump <id> <sif_path>
 
 Flags:
   -h, --help   help for dump

--- a/pkg/siftool/testdata/TestAddCommands/Dump/out.golden
+++ b/pkg/siftool/testdata/TestAddCommands/Dump/out.golden
@@ -3,5 +3,8 @@ Dump a data object from a SIF image.
 Usage:
   siftool dump <id> <sif_path>
 
+Examples:
+siftool dump 1 image.sif
+
 Flags:
   -h, --help   help for dump

--- a/pkg/siftool/testdata/TestAddCommands/Header/out.golden
+++ b/pkg/siftool/testdata/TestAddCommands/Header/out.golden
@@ -3,5 +3,8 @@ Display global header from a SIF image.
 Usage:
   siftool header <sif_path>
 
+Examples:
+siftool header image.sif
+
 Flags:
   -h, --help   help for header

--- a/pkg/siftool/testdata/TestAddCommands/Header/out.golden
+++ b/pkg/siftool/testdata/TestAddCommands/Header/out.golden
@@ -1,7 +1,7 @@
-Display SIF global headers
+Display global header from a SIF image.
 
 Usage:
-  siftool header <containerfile>
+  siftool header <sif_path>
 
 Flags:
   -h, --help   help for header

--- a/pkg/siftool/testdata/TestAddCommands/Info/out.golden
+++ b/pkg/siftool/testdata/TestAddCommands/Info/out.golden
@@ -1,7 +1,7 @@
-Display detailed information of object descriptors
+Display info about a data object from a SIF image.
 
 Usage:
-  siftool info <descriptorid> <containerfile>
+  siftool info <id> <sif_path>
 
 Flags:
   -h, --help   help for info

--- a/pkg/siftool/testdata/TestAddCommands/Info/out.golden
+++ b/pkg/siftool/testdata/TestAddCommands/Info/out.golden
@@ -3,5 +3,8 @@ Display info about a data object from a SIF image.
 Usage:
   siftool info <id> <sif_path>
 
+Examples:
+siftool info 1 image.sif
+
 Flags:
   -h, --help   help for info

--- a/pkg/siftool/testdata/TestAddCommands/List/out.golden
+++ b/pkg/siftool/testdata/TestAddCommands/List/out.golden
@@ -3,5 +3,8 @@ List data objects from a SIF image.
 Usage:
   siftool list <sif_path>
 
+Examples:
+siftool list image.sif
+
 Flags:
   -h, --help   help for list

--- a/pkg/siftool/testdata/TestAddCommands/List/out.golden
+++ b/pkg/siftool/testdata/TestAddCommands/List/out.golden
@@ -1,7 +1,7 @@
-List object descriptors from SIF files
+List data objects from a SIF image.
 
 Usage:
-  siftool list <containerfile>
+  siftool list <sif_path>
 
 Flags:
   -h, --help   help for list

--- a/pkg/siftool/testdata/TestAddCommands/New/out.golden
+++ b/pkg/siftool/testdata/TestAddCommands/New/out.golden
@@ -1,7 +1,7 @@
-Create a new empty SIF image file
+Create a new, empty SIF image.
 
 Usage:
-  siftool new <containerfile>
+  siftool new <sif_path>
 
 Flags:
   -h, --help   help for new

--- a/pkg/siftool/testdata/TestAddCommands/New/out.golden
+++ b/pkg/siftool/testdata/TestAddCommands/New/out.golden
@@ -3,5 +3,8 @@ Create a new, empty SIF image.
 Usage:
   siftool new <sif_path>
 
+Examples:
+siftool new image.sif
+
 Flags:
   -h, --help   help for new

--- a/pkg/siftool/testdata/TestAddCommands/SetPrim/out.golden
+++ b/pkg/siftool/testdata/TestAddCommands/SetPrim/out.golden
@@ -3,5 +3,8 @@ Set the primary system partition in a SIF image.
 Usage:
   siftool setprim <id> <sif_path>
 
+Examples:
+siftool setprim 1 image.sif
+
 Flags:
   -h, --help   help for setprim

--- a/pkg/siftool/testdata/TestAddCommands/SetPrim/out.golden
+++ b/pkg/siftool/testdata/TestAddCommands/SetPrim/out.golden
@@ -1,7 +1,7 @@
-Set primary system partition
+Set the primary system partition in a SIF image.
 
 Usage:
-  siftool setprim <descriptorid> <containerfile>
+  siftool setprim <id> <sif_path>
 
 Flags:
   -h, --help   help for setprim

--- a/pkg/siftool/testdata/TestAddCommands/SifTool/out.golden
+++ b/pkg/siftool/testdata/TestAddCommands/SifTool/out.golden
@@ -2,15 +2,15 @@ Usage:
   siftool [command]
 
 Available Commands:
-  add         Add a data object to a SIF file
+  add         Add data object
   completion  generate the autocompletion script for the specified shell
-  del         Delete a specified object descriptor and data from SIF file
-  dump        Extract and output data objects from SIF files
-  header      Display SIF global headers
+  del         Delete data object
+  dump        Dump data object
+  header      Display global header
   help        Help about any command
-  info        Display detailed information of object descriptors
-  list        List object descriptors from SIF files
-  new         Create a new empty SIF image file
+  info        Display data object info
+  list        List data objects
+  new         Create SIF image
   setprim     Set primary system partition
 
 Flags:


### PR DESCRIPTION
Improve `siftool` documentation by adding `Long` descriptions (used unconditionally by `singularity`), and improving consistency of terminology across commands.