### PR TITLE
Enable Dependabot on v1 Branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,9 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  target-branch: v1
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  target-branch: master


### PR DESCRIPTION
The `v1` branch tracks maintenance of the 1.x.x major version, and should receive dependency updates.