### PR TITLE
Make Header type Un-Exported

### DIFF
--- a/pkg/sif/create_test.go
+++ b/pkg/sif/create_test.go
@@ -43,10 +43,10 @@ func TestNextAligned(t *testing.T) {
 }
 
 func TestDataStructs(t *testing.T) {
-	var header Header
+	var h header
 	var descr Descriptor
 
-	if hdrlen := binary.Size(header); hdrlen != headerLen {
+	if hdrlen := binary.Size(h); hdrlen != headerLen {
 		t.Errorf("expecting global header size of %d, got %d", headerLen, hdrlen)
 	}
 
@@ -243,7 +243,7 @@ func TestAddObjectPipe(t *testing.T) {
 	}
 
 	fimg := &FileImage{
-		Header: Header{
+		h: header{
 			Dfree:  1,
 			Dtotal: 1,
 		},
@@ -255,7 +255,7 @@ func TestAddObjectPipe(t *testing.T) {
 		t.Errorf("fimg.AddObject(...): %s", err)
 	}
 
-	if expected, actual := int64(0), fimg.Header.Dfree; actual != expected {
+	if expected, actual := int64(0), fimg.h.Dfree; actual != expected {
 		t.Errorf("after calling fimg.AddObject(...), unexpected value in fimg.Header.Dfree: expected=%d actual=%d",
 			expected, actual)
 	}
@@ -310,7 +310,7 @@ func TestSetPrimPart(t *testing.T) {
 	}
 
 	fimg := &FileImage{
-		Header: Header{
+		h: header{
 			Dfree:  int64(len(inputs)),
 			Dtotal: int64(len(inputs)),
 		},

--- a/pkg/sif/load.go
+++ b/pkg/sif/load.go
@@ -22,7 +22,7 @@ func readBinaryAt(r io.ReaderAt, off int64, data interface{}) error {
 
 // Read the global header from r and populate fimg.Header.
 func readHeader(r io.ReaderAt, fimg *FileImage) error {
-	if err := readBinaryAt(r, 0, &fimg.Header); err != nil {
+	if err := readBinaryAt(r, 0, &fimg.h); err != nil {
 		return fmt.Errorf("reading global header from container file: %s", err)
 	}
 
@@ -32,8 +32,8 @@ func readHeader(r io.ReaderAt, fimg *FileImage) error {
 // Read the descriptors from r and populate fimg.DescrArr.
 func readDescriptors(r io.ReaderAt, fimg *FileImage) error {
 	// Initialize descriptor array (slice) and read them all from file
-	fimg.DescrArr = make([]Descriptor, fimg.Header.Dtotal)
-	if err := readBinaryAt(r, fimg.Header.Descroff, &fimg.DescrArr); err != nil {
+	fimg.DescrArr = make([]Descriptor, fimg.h.Dtotal)
+	if err := readBinaryAt(r, fimg.h.Descroff, &fimg.DescrArr); err != nil {
 		fimg.DescrArr = nil
 		return fmt.Errorf("reading descriptor array from container file: %s", err)
 	}
@@ -48,11 +48,11 @@ func readDescriptors(r io.ReaderAt, fimg *FileImage) error {
 
 // isValidSif looks at key fields from the global header to assess SIF validity.
 func isValidSif(f *FileImage) error {
-	if got, want := trimZeroBytes(f.Header.Magic[:]), hdrMagic; got != want {
+	if got, want := trimZeroBytes(f.h.Magic[:]), hdrMagic; got != want {
 		return fmt.Errorf("invalid SIF file: Magic |%v| want |%v|", got, want)
 	}
 
-	if got, want := trimZeroBytes(f.Header.Version[:]), CurrentVersion.String(); got > want {
+	if got, want := trimZeroBytes(f.h.Version[:]), CurrentVersion.String(); got > want {
 		return fmt.Errorf("invalid SIF file: Version %s want <= %s", got, want)
 	}
 

--- a/pkg/sif/lookup.go
+++ b/pkg/sif/lookup.go
@@ -70,11 +70,6 @@ func GetGoArch(sifarch string) (goarch string) {
 	return goarch
 }
 
-// GetHeader returns the loaded SIF global header.
-func (fimg *FileImage) GetHeader() *Header {
-	return &fimg.Header
-}
-
 // GetFromDescrID searches for a descriptor with.
 func (fimg *FileImage) GetFromDescrID(id uint32) (*Descriptor, int, error) {
 	match := -1

--- a/pkg/sif/lookup_test.go
+++ b/pkg/sif/lookup_test.go
@@ -12,28 +12,6 @@ import (
 	"testing"
 )
 
-func TestGetHeader(t *testing.T) {
-	// load the test container
-	fimg, err := LoadContainer("testdata/testcontainer2.sif", true)
-	if err != nil {
-		t.Error("LoadContainer(testdata/testcontainer2.sif, true):", err)
-	}
-
-	header := fimg.GetHeader()
-	if header == nil {
-		t.Fatal("fimg.GetHeader(): returned nil")
-	}
-
-	if string(header.Magic[:9]) != "SIF_MAGIC" {
-		t.Error("fimg.GetHeader(): wrong magic")
-	}
-
-	// unload the test container
-	if err = fimg.UnloadContainer(); err != nil {
-		t.Error("UnloadContainer(fimg):", err)
-	}
-}
-
 func TestGetFromDescrID(t *testing.T) {
 	// load the test container
 	fimg, err := LoadContainer("testdata/testcontainer2.sif", true)

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -369,8 +369,8 @@ type CryptoMessage struct {
 	Messagetype Messagetype
 }
 
-// Header describes a loaded SIF file.
-type Header struct {
+// header describes a loaded SIF file.
+type header struct {
 	Launch [hdrLaunchLen]byte // #! shell execution line
 
 	Magic   [hdrMagicLen]byte   // look for "SIF_MAGIC"
@@ -390,7 +390,7 @@ type Header struct {
 }
 
 // GetIntegrityReader returns an io.Reader that reads the integrity-protected fields from h.
-func (h Header) GetIntegrityReader() io.Reader {
+func (h header) GetIntegrityReader() io.Reader {
 	return io.MultiReader(
 		bytes.NewReader(h.Launch[:]),
 		bytes.NewReader(h.Magic[:]),
@@ -420,7 +420,7 @@ type ReadWriter interface {
 
 // FileImage describes the representation of a SIF file in memory.
 type FileImage struct {
-	Header     Header        // the loaded SIF global header
+	h          header        // the loaded SIF global header
 	Fp         ReadWriter    // file pointer of opened SIF file
 	Filesize   int64         // file size of the opened SIF file
 	Filedata   []byte        // Deprecated: Filedata exists for historical compatibility and should not be used.
@@ -431,45 +431,45 @@ type FileImage struct {
 }
 
 // LaunchScript returns the image launch script.
-func (f *FileImage) LaunchScript() string { return trimZeroBytes(f.Header.Launch[:]) }
+func (f *FileImage) LaunchScript() string { return trimZeroBytes(f.h.Launch[:]) }
 
 // Version returns the SIF specification version of the image.
-func (f *FileImage) Version() string { return trimZeroBytes(f.Header.Version[:]) }
+func (f *FileImage) Version() string { return trimZeroBytes(f.h.Version[:]) }
 
 // PrimaryArch returns the primary CPU architecture of the image.
-func (f *FileImage) PrimaryArch() string { return GetGoArch(trimZeroBytes(f.Header.Arch[:])) }
+func (f *FileImage) PrimaryArch() string { return GetGoArch(trimZeroBytes(f.h.Arch[:])) }
 
 // ID returns the ID of the image.
-func (f *FileImage) ID() string { return f.Header.ID.String() }
+func (f *FileImage) ID() string { return f.h.ID.String() }
 
 // CreatedAt returns the creation time of the image.
-func (f *FileImage) CreatedAt() time.Time { return time.Unix(f.Header.Ctime, 0).UTC() }
+func (f *FileImage) CreatedAt() time.Time { return time.Unix(f.h.Ctime, 0).UTC() }
 
 // ModifiedAt returns the last modification time of the image.
-func (f *FileImage) ModifiedAt() time.Time { return time.Unix(f.Header.Mtime, 0).UTC() }
+func (f *FileImage) ModifiedAt() time.Time { return time.Unix(f.h.Mtime, 0).UTC() }
 
 // DescriptorsFree returns the number of free descriptors in the image.
-func (f *FileImage) DescriptorsFree() uint64 { return uint64(f.Header.Dfree) }
+func (f *FileImage) DescriptorsFree() uint64 { return uint64(f.h.Dfree) }
 
 // DescriptorsTotal returns the total number of descriptors in the image.
-func (f *FileImage) DescriptorsTotal() uint64 { return uint64(f.Header.Dtotal) }
+func (f *FileImage) DescriptorsTotal() uint64 { return uint64(f.h.Dtotal) }
 
 // DescriptorSectionOffset returns the offset (in bytes) of the descriptors section in the image.
-func (f *FileImage) DescriptorSectionOffset() uint64 { return uint64(f.Header.Descroff) }
+func (f *FileImage) DescriptorSectionOffset() uint64 { return uint64(f.h.Descroff) }
 
 // DescriptorSectionSize returns the size (in bytes) of the descriptors section in the image.
-func (f *FileImage) DescriptorSectionSize() uint64 { return uint64(f.Header.Descrlen) }
+func (f *FileImage) DescriptorSectionSize() uint64 { return uint64(f.h.Descrlen) }
 
 // DataSectionOffset returns the offset (in bytes) of the data section in the image.
-func (f *FileImage) DataSectionOffset() uint64 { return uint64(f.Header.Dataoff) }
+func (f *FileImage) DataSectionOffset() uint64 { return uint64(f.h.Dataoff) }
 
 // DataSectionSize returns the size (in bytes) of the data section in the image.
-func (f *FileImage) DataSectionSize() uint64 { return uint64(f.Header.Datalen) }
+func (f *FileImage) DataSectionSize() uint64 { return uint64(f.h.Datalen) }
 
 // GetHeaderIntegrityReader returns an io.Reader that reads the integrity-protected fields from the
 // header of the image.
 func (f *FileImage) GetHeaderIntegrityReader() io.Reader {
-	return f.Header.GetIntegrityReader()
+	return f.h.GetIntegrityReader()
 }
 
 // DescriptorInput describes the common info needed to create a data object descriptor.

--- a/pkg/sif/sif_test.go
+++ b/pkg/sif/sif_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestHeader_GetIntegrityReader(t *testing.T) {
-	h := Header{
+	h := header{
 		ID:    uuid.UUID{0xb2, 0x65, 0x9d, 0x4e, 0xbd, 0x50, 0x4e, 0xa5, 0xbd, 0x17, 0xee, 0xc5, 0xe5, 0x4f, 0x91, 0x8e},
 		Ctime: 1504657553,
 		Mtime: 1504657653,
@@ -26,57 +26,57 @@ func TestHeader_GetIntegrityReader(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		modFunc func(h Header) Header
+		modFunc func(h header) header
 	}{
-		{"Launch", func(h Header) Header {
+		{"Launch", func(h header) header {
 			copy(h.Launch[:], "#!/usr/bin/env rm\n")
 			return h
 		}},
-		{"Magic", func(h Header) Header {
+		{"Magic", func(h header) header {
 			copy(h.Magic[:], "BAD_MAGIC")
 			return h
 		}},
-		{"Version", func(h Header) Header {
+		{"Version", func(h header) header {
 			copy(h.Version[:], "02")
 			return h
 		}},
-		{"Arch", func(h Header) Header {
+		{"Arch", func(h header) header {
 			copy(h.Arch[:], HdrArchS390x)
 			return h
 		}},
-		{"ID", func(h Header) Header {
+		{"ID", func(h header) header {
 			h.ID[0]++
 			return h
 		}},
-		{"Ctime", func(h Header) Header {
+		{"Ctime", func(h header) header {
 			h.Ctime++
 			return h
 		}},
-		{"Mtime", func(h Header) Header {
+		{"Mtime", func(h header) header {
 			h.Mtime++
 			return h
 		}},
-		{"Dfree", func(h Header) Header {
+		{"Dfree", func(h header) header {
 			h.Dfree++
 			return h
 		}},
-		{"Dtotal", func(h Header) Header {
+		{"Dtotal", func(h header) header {
 			h.Dtotal++
 			return h
 		}},
-		{"Descroff", func(h Header) Header {
+		{"Descroff", func(h header) header {
 			h.Descroff++
 			return h
 		}},
-		{"Descrlen", func(h Header) Header {
+		{"Descrlen", func(h header) header {
 			h.Descrlen++
 			return h
 		}},
-		{"Dataoff", func(h Header) Header {
+		{"Dataoff", func(h header) header {
 			h.Dataoff++
 			return h
 		}},
-		{"Datalen", func(h Header) Header {
+		{"Datalen", func(h header) header {
 			h.Datalen++
 			return h
 		}},


### PR DESCRIPTION
Make `Header` type un-exported, and remove `GetHeader`.