### PR TITLE
Deprecate Descriptor UID/Gid (V1)

### DIFF
--- a/pkg/sif/fmt.go
+++ b/pkg/sif/fmt.go
@@ -134,8 +134,6 @@ func (fimg *FileImage) FmtDescrInfo(id uint32) string {
 			s += fmt.Sprintln("  Filelen:  ", v.Filelen)
 			s += fmt.Sprintln("  Ctime:    ", time.Unix(v.Ctime, 0).UTC())
 			s += fmt.Sprintln("  Mtime:    ", time.Unix(v.Mtime, 0).UTC())
-			s += fmt.Sprintln("  UID:      ", v.UID)
-			s += fmt.Sprintln("  Gid:      ", v.Gid)
 			s += fmt.Sprintln("  Name:     ", trimZeroBytes(v.Name[:]))
 			switch v.Datatype {
 			case DataPartition:

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -309,8 +309,8 @@ type Descriptor struct {
 
 	Ctime int64                 // image creation time
 	Mtime int64                 // last modification time
-	UID   int64                 // system user owning the file
-	Gid   int64                 // system group owning the file
+	UID   int64                 // Deprecated: UID exists for historical compatibility and should not be used.
+	Gid   int64                 // Deprecated: Gid exists for historical compatibility and should not be used.
 	Name  [DescrNameLen]byte    // descriptor name (string identifier)
 	Extra [DescrMaxPrivLen]byte // big enough for extra data below
 }

--- a/pkg/sif/testdata/TestFileImage_FmtDescrInfo/One.golden
+++ b/pkg/sif/testdata/TestFileImage_FmtDescrInfo/One.golden
@@ -8,6 +8,4 @@ Descr slot#: 0
   Filelen:   62
   Ctime:     2018-08-14 07:45:59 +0000 UTC
   Mtime:     2018-08-14 07:45:59 +0000 UTC
-  UID:       1002
-  Gid:       1002
   Name:      busybox.deffile

--- a/pkg/sif/testdata/TestFileImage_FmtDescrInfo/Three.golden
+++ b/pkg/sif/testdata/TestFileImage_FmtDescrInfo/Three.golden
@@ -8,8 +8,6 @@ Descr slot#: 2
   Filelen:   955
   Ctime:     2018-08-14 07:47:36 +0000 UTC
   Mtime:     2018-08-14 07:47:36 +0000 UTC
-  UID:       1002
-  Gid:       1002
   Name:      part-signature
   Hashtype:  SHA384
   Entity:    9F2B6C36D999A3E91CB3104720671590C12D4222

--- a/pkg/sif/testdata/TestFileImage_FmtDescrInfo/Two.golden
+++ b/pkg/sif/testdata/TestFileImage_FmtDescrInfo/Two.golden
@@ -8,8 +8,6 @@ Descr slot#: 1
   Filelen:   704512
   Ctime:     2018-08-14 07:45:59 +0000 UTC
   Mtime:     2018-08-14 07:45:59 +0000 UTC
-  UID:       1002
-  Gid:       1002
   Name:      busybox.squash
   Fstype:    Squashfs
   Parttype:  *System


### PR DESCRIPTION
Mark `UID`/`Gid` fields deprecated in `type Descriptor struct` (see #59). Remove UID/GID values from `info` command output.