### PR TITLE
Return Usable FileImage from CreateContainer (v2)

### DIFF
--- a/internal/app/siftool/modif.go
+++ b/internal/app/siftool/modif.go
@@ -16,8 +16,12 @@ import (
 
 // New creates a new empty SIF file.
 func (*App) New(path string) error {
-	_, err := sif.CreateContainer(path)
-	return err
+	f, err := sif.CreateContainer(path)
+	if err != nil {
+		return err
+	}
+
+	return f.UnloadContainer()
 }
 
 // AddOptions contains the options when adding a section to a SIF file.

--- a/pkg/sif/create_test.go
+++ b/pkg/sif/create_test.go
@@ -64,8 +64,13 @@ func TestCreateContainer(t *testing.T) {
 	f.Close()
 
 	// test container creation without any input descriptors
-	if _, err := CreateContainer(f.Name()); err != nil {
-		t.Errorf("failed to create container: %v", err)
+	fimg, err := CreateContainer(f.Name())
+	if err != nil {
+		t.Fatalf("failed to create container: %v", err)
+	}
+
+	if err := fimg.UnloadContainer(); err != nil {
+		t.Errorf("failed to unload container: %v", err)
 	}
 
 	// data we need to create a definition file descriptor
@@ -120,8 +125,13 @@ func TestCreateContainer(t *testing.T) {
 	}
 
 	// test container creation with two partition input descriptors
-	if _, err := CreateContainer(f.Name(), OptCreateWithDescriptors(definput, parinput)); err != nil {
-		t.Errorf("failed to create container: %v", err)
+	fimg, err = CreateContainer(f.Name(), OptCreateWithDescriptors(definput, parinput))
+	if err != nil {
+		t.Fatalf("failed to create container: %v", err)
+	}
+
+	if err := fimg.UnloadContainer(); err != nil {
+		t.Errorf("failed to unload container: %v", err)
 	}
 }
 


### PR DESCRIPTION
Do not close `Fp` in `CreateContainer`, so that `fimg` is usable by caller. Ensure internal calls to `CreateContainer` are mirrored with `UnloadContainer` (#67).