### PR TITLE
Wrap Descriptor and Use Consistent Case for Types

### DIFF
--- a/internal/app/siftool/modif.go
+++ b/internal/app/siftool/modif.go
@@ -25,7 +25,7 @@ func (*App) New(path string) error {
 }
 
 // Add adds a data object to a SIF file.
-func (*App) Add(path string, t sif.Datatype, r io.Reader, opts ...sif.DescriptorInputOpt) error {
+func (*App) Add(path string, t sif.DataType, r io.Reader, opts ...sif.DescriptorInputOpt) error {
 	return withFileImage(path, true, func(f *sif.FileImage) error {
 		input, err := sif.NewDescriptorInput(t, r, opts...)
 		if err != nil {

--- a/internal/app/siftool/modif_test.go
+++ b/internal/app/siftool/modif_test.go
@@ -41,7 +41,7 @@ func TestApp_Add(t *testing.T) {
 	tests := []struct {
 		name     string
 		data     []byte
-		dataType sif.Datatype
+		dataType sif.DataType
 		opts     []sif.DescriptorInputOpt
 		wantErr  error
 	}{

--- a/pkg/integrity/digest.go
+++ b/pkg/integrity/digest.go
@@ -75,7 +75,7 @@ func newDigestReader(h crypto.Hash, r io.Reader) (digest, error) {
 }
 
 // hashType converts ht into a crypto.Hash value.
-func hashType(ht sif.Hashtype) (crypto.Hash, error) {
+func hashType(ht sif.HashType) (crypto.Hash, error) {
 	switch ht {
 	case sif.HashSHA256:
 		return crypto.SHA256, nil
@@ -95,7 +95,7 @@ func hashType(ht sif.Hashtype) (crypto.Hash, error) {
 //
 // 	SIFHASH:
 //  2f0b3dca0ec42683d306338f68689aba29cdb83625b8cc0b8a789f8de92342495a6264b0c134e706630636bf90c6f331
-func newLegacyDigest(ht sif.Hashtype, b []byte) (digest, error) {
+func newLegacyDigest(ht sif.HashType, b []byte) (digest, error) {
 	b = bytes.TrimPrefix(b, []byte("SIFHASH:\n"))
 	b = bytes.TrimSuffix(b, []byte("\n"))
 

--- a/pkg/integrity/digest_test.go
+++ b/pkg/integrity/digest_test.go
@@ -23,7 +23,7 @@ import (
 func TestNewLegacyDigest(t *testing.T) {
 	tests := []struct {
 		name       string
-		ht         sif.Hashtype
+		ht         sif.HashType
 		text       string
 		wantError  error
 		wantDigest digest

--- a/pkg/integrity/sign.go
+++ b/pkg/integrity/sign.go
@@ -26,7 +26,7 @@ var (
 // ErrNoKeyMaterial is the error returned when no key material was provided.
 var ErrNoKeyMaterial = errors.New("key material not provided")
 
-func sifHashType(h crypto.Hash) sif.Hashtype {
+func sifHashType(h crypto.Hash) sif.HashType {
 	switch h {
 	case crypto.SHA256:
 		return sif.HashSHA256
@@ -48,7 +48,7 @@ type groupSigner struct {
 	ods       []sif.Descriptor // Descriptors of object(s) to sign.
 	mdHash    crypto.Hash      // Hash type for metadata.
 	sigConfig *packet.Config   // Configuration for signature.
-	sigHash   sif.Hashtype     // SIF hash type for signature.
+	sigHash   sif.HashType     // SIF hash type for signature.
 }
 
 // groupSignerOpt are used to configure gs.

--- a/pkg/integrity/sign_test.go
+++ b/pkg/integrity/sign_test.go
@@ -115,7 +115,7 @@ func TestNewGroupSigner(t *testing.T) {
 		wantErr     error
 		wantObjects []uint32
 		wantMDHash  crypto.Hash
-		wantSigHash sif.Hashtype
+		wantSigHash sif.HashType
 	}{
 		{
 			name:    "InvalidGroupID",

--- a/pkg/sif/create_test.go
+++ b/pkg/sif/create_test.go
@@ -44,7 +44,7 @@ func TestNextAligned(t *testing.T) {
 
 func TestDataStructs(t *testing.T) {
 	var h header
-	var descr Descriptor
+	var descr rawDescriptor
 
 	if hdrlen := binary.Size(h); hdrlen != headerLen {
 		t.Errorf("expecting global header size of %d, got %d", headerLen, hdrlen)
@@ -220,7 +220,7 @@ func TestSetPrimPart(t *testing.T) {
 			Dtotal: int64(len(inputs)),
 		},
 		fp:       &mockSifReadWriter{},
-		descrArr: make([]Descriptor, len(inputs)),
+		descrArr: make([]rawDescriptor, len(inputs)),
 	}
 
 	for i := range inputs {

--- a/pkg/sif/descriptor.go
+++ b/pkg/sif/descriptor.go
@@ -23,7 +23,7 @@ type Descriptor struct {
 
 // rawDescriptor represents the on-disk descriptor type.
 type rawDescriptor struct {
-	Datatype Datatype // informs of descriptor type
+	Datatype DataType // informs of descriptor type
 	Used     bool     // is the descriptor in use
 	ID       uint32   // a unique id for this data object
 	Groupid  uint32   // object group this data object is related to
@@ -42,21 +42,21 @@ type rawDescriptor struct {
 
 // partition represents the SIF partition data object descriptor.
 type partition struct {
-	Fstype   Fstype
-	Parttype Parttype
+	Fstype   FSType
+	Parttype PartType
 	Arch     [hdrArchLen]byte // arch the image is built for
 }
 
 // signature represents the SIF signature data object descriptor.
 type signature struct {
-	Hashtype Hashtype
+	Hashtype HashType
 	Entity   [DescrEntityLen]byte
 }
 
 // cryptoMessage represents the SIF crypto message object descriptor.
 type cryptoMessage struct {
-	Formattype  Formattype
-	Messagetype Messagetype
+	Formattype  FormatType
+	Messagetype MessageType
 }
 
 var errNameTooLarge = errors.New("name value too large")
@@ -99,7 +99,7 @@ func (d *rawDescriptor) setExtra(v interface{}) error {
 }
 
 // GetDataType returns the type of data object.
-func (d rawDescriptor) GetDataType() Datatype { return d.Datatype }
+func (d rawDescriptor) GetDataType() DataType { return d.Datatype }
 
 // GetID returns the data object ID of d.
 func (d rawDescriptor) GetID() uint32 { return d.ID }
@@ -122,7 +122,7 @@ func (d rawDescriptor) GetSize() int64 { return d.Filelen }
 func (d rawDescriptor) GetName() string { return strings.TrimRight(string(d.Name[:]), "\000") }
 
 // GetFsType extracts the Fstype field from the Extra field of a Partition Descriptor.
-func (d rawDescriptor) GetFsType() (Fstype, error) {
+func (d rawDescriptor) GetFsType() (FSType, error) {
 	if d.Datatype != DataPartition {
 		return -1, fmt.Errorf("expected DataPartition, got %v", d.Datatype)
 	}
@@ -137,7 +137,7 @@ func (d rawDescriptor) GetFsType() (Fstype, error) {
 }
 
 // GetPartType extracts the Parttype field from the Extra field of a Partition Descriptor.
-func (d rawDescriptor) GetPartType() (Parttype, error) {
+func (d rawDescriptor) GetPartType() (PartType, error) {
 	if d.Datatype != DataPartition {
 		return -1, fmt.Errorf("expected DataPartition, got %v", d.Datatype)
 	}
@@ -167,7 +167,7 @@ func (d rawDescriptor) GetArch() ([hdrArchLen]byte, error) {
 }
 
 // GetHashType extracts the Hashtype field from the Extra field of a Signature Descriptor.
-func (d rawDescriptor) GetHashType() (Hashtype, error) {
+func (d rawDescriptor) GetHashType() (HashType, error) {
 	if d.Datatype != DataSignature {
 		return -1, fmt.Errorf("expected DataSignature, got %v", d.Datatype)
 	}
@@ -207,7 +207,7 @@ func (d rawDescriptor) GetEntityString() (string, error) {
 }
 
 // GetFormatType extracts the Formattype field from the Extra field of a Cryptographic Message Descriptor.
-func (d rawDescriptor) GetFormatType() (Formattype, error) {
+func (d rawDescriptor) GetFormatType() (FormatType, error) {
 	if d.Datatype != DataCryptoMessage {
 		return -1, fmt.Errorf("expected DataCryptoMessage, got %v", d.Datatype)
 	}
@@ -222,7 +222,7 @@ func (d rawDescriptor) GetFormatType() (Formattype, error) {
 }
 
 // GetMessageType extracts the Messagetype field from the Extra field of a Cryptographic Message Descriptor.
-func (d rawDescriptor) GetMessageType() (Messagetype, error) {
+func (d rawDescriptor) GetMessageType() (MessageType, error) {
 	if d.Datatype != DataCryptoMessage {
 		return -1, fmt.Errorf("expected DataCryptoMessage, got %v", d.Datatype)
 	}

--- a/pkg/sif/descriptor_input.go
+++ b/pkg/sif/descriptor_input.go
@@ -23,11 +23,11 @@ type descriptorOpts struct {
 }
 
 // DescriptorInputOpt are used to specify data object options.
-type DescriptorInputOpt func(Datatype, *descriptorOpts) error
+type DescriptorInputOpt func(DataType, *descriptorOpts) error
 
 // OptGroupID specifies groupID as data object group ID.
 func OptGroupID(groupID uint32) DescriptorInputOpt {
-	return func(_ Datatype, opts *descriptorOpts) error {
+	return func(_ DataType, opts *descriptorOpts) error {
 		if groupID == 0 {
 			return ErrInvalidGroupID
 		}
@@ -39,7 +39,7 @@ func OptGroupID(groupID uint32) DescriptorInputOpt {
 // OptLinkedID specifies that the data object is linked to the data object group with the specified
 // ID.
 func OptLinkedID(id uint32) DescriptorInputOpt {
-	return func(_ Datatype, opts *descriptorOpts) error {
+	return func(_ DataType, opts *descriptorOpts) error {
 		if id == 0 {
 			return ErrInvalidObjectID
 		}
@@ -51,7 +51,7 @@ func OptLinkedID(id uint32) DescriptorInputOpt {
 // OptLinkedGroupID specifies that the data object is linked to the data object group with the
 // specified groupID.
 func OptLinkedGroupID(groupID uint32) DescriptorInputOpt {
-	return func(_ Datatype, opts *descriptorOpts) error {
+	return func(_ DataType, opts *descriptorOpts) error {
 		if groupID == 0 {
 			return ErrInvalidGroupID
 		}
@@ -62,7 +62,7 @@ func OptLinkedGroupID(groupID uint32) DescriptorInputOpt {
 
 // OptObjectAlignment specifies n as the data alignment requirement.
 func OptObjectAlignment(n int) DescriptorInputOpt {
-	return func(_ Datatype, opts *descriptorOpts) error {
+	return func(_ DataType, opts *descriptorOpts) error {
 		opts.alignment = n
 		return nil
 	}
@@ -70,7 +70,7 @@ func OptObjectAlignment(n int) DescriptorInputOpt {
 
 // OptObjectName specifies name as the data object name.
 func OptObjectName(name string) DescriptorInputOpt {
-	return func(_ Datatype, opts *descriptorOpts) error {
+	return func(_ DataType, opts *descriptorOpts) error {
 		opts.name = name
 		return nil
 	}
@@ -78,15 +78,15 @@ func OptObjectName(name string) DescriptorInputOpt {
 
 // OptObjectTime specifies t as the dat object creation time.
 func OptObjectTime(t time.Time) DescriptorInputOpt {
-	return func(_ Datatype, opts *descriptorOpts) error {
+	return func(_ DataType, opts *descriptorOpts) error {
 		opts.t = t
 		return nil
 	}
 }
 
 type unexpectedDataTypeError struct {
-	got  Datatype
-	want Datatype
+	got  DataType
+	want DataType
 }
 
 func (e *unexpectedDataTypeError) Error() string {
@@ -106,8 +106,8 @@ func (e *unexpectedDataTypeError) Is(target error) bool {
 // to ft, and the message type is set to mt.
 //
 // If this option is applied to a data object with an incompatible type, an error is returned.
-func OptCryptoMessageMetadata(ft Formattype, mt Messagetype) DescriptorInputOpt {
-	return func(t Datatype, opts *descriptorOpts) error {
+func OptCryptoMessageMetadata(ft FormatType, mt MessageType) DescriptorInputOpt {
+	return func(t DataType, opts *descriptorOpts) error {
 		if got, want := t, DataCryptoMessage; got != want {
 			return &unexpectedDataTypeError{got, want}
 		}
@@ -127,8 +127,8 @@ func OptCryptoMessageMetadata(ft Formattype, mt Messagetype) DescriptorInputOpt 
 // should be the architecture as represented by the Go runtime.
 //
 // If this option is applied to a data object with an incompatible type, an error is returned.
-func OptPartitionMetadata(fs Fstype, pt Parttype, arch string) DescriptorInputOpt {
-	return func(t Datatype, opts *descriptorOpts) error {
+func OptPartitionMetadata(fs FSType, pt PartType, arch string) DescriptorInputOpt {
+	return func(t DataType, opts *descriptorOpts) error {
 		if got, want := t, DataPartition; got != want {
 			return &unexpectedDataTypeError{got, want}
 		}
@@ -153,8 +153,8 @@ func OptPartitionMetadata(fs Fstype, pt Parttype, arch string) DescriptorInputOp
 // the signing entity fingerprint is set to fp.
 //
 // If this option is applied to a data object with an incompatible type, an error is returned.
-func OptSignatureMetadata(ht Hashtype, fp [20]byte) DescriptorInputOpt {
-	return func(t Datatype, opts *descriptorOpts) error {
+func OptSignatureMetadata(ht HashType, fp [20]byte) DescriptorInputOpt {
+	return func(t DataType, opts *descriptorOpts) error {
 		if got, want := t, DataSignature; got != want {
 			return &unexpectedDataTypeError{got, want}
 		}
@@ -171,7 +171,7 @@ func OptSignatureMetadata(ht Hashtype, fp [20]byte) DescriptorInputOpt {
 
 // DescriptorInput describes a new data object.
 type DescriptorInput struct {
-	dt   Datatype
+	dt   DataType
 	fp   io.Reader
 	opts descriptorOpts
 }
@@ -190,7 +190,7 @@ type DescriptorInput struct {
 // override this behavior, consider using OptObjectAlignment.
 //
 // By default, no name is set for data object. To set a name, use OptObjectName.
-func NewDescriptorInput(t Datatype, r io.Reader, opts ...DescriptorInputOpt) (DescriptorInput, error) {
+func NewDescriptorInput(t DataType, r io.Reader, opts ...DescriptorInputOpt) (DescriptorInput, error) {
 	dopts := descriptorOpts{
 		alignment: os.Getpagesize(),
 		t:         time.Now(),

--- a/pkg/sif/descriptor_input.go
+++ b/pkg/sif/descriptor_input.go
@@ -212,7 +212,7 @@ func NewDescriptorInput(t Datatype, r io.Reader, opts ...DescriptorInputOpt) (De
 }
 
 // fillDescriptor fills d according to di.
-func (di DescriptorInput) fillDescriptor(d *Descriptor) error {
+func (di DescriptorInput) fillDescriptor(d *rawDescriptor) error {
 	d.Datatype = di.dt
 	d.Groupid = di.opts.groupID | DescrGroupMask
 	d.Link = di.opts.linkID

--- a/pkg/sif/descriptor_input_test.go
+++ b/pkg/sif/descriptor_input_test.go
@@ -27,7 +27,7 @@ func TestNewDescriptorInput(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		t       Datatype
+		t       DataType
 		opts    []DescriptorInputOpt
 		wantErr error
 	}{

--- a/pkg/sif/descriptor_input_test.go
+++ b/pkg/sif/descriptor_input_test.go
@@ -164,7 +164,7 @@ func TestNewDescriptorInput(t *testing.T) {
 			}
 
 			if err == nil {
-				d := Descriptor{}
+				d := rawDescriptor{}
 				if err := di.fillDescriptor(&d); err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/sif/descriptor_test.go
+++ b/pkg/sif/descriptor_test.go
@@ -331,7 +331,7 @@ func TestDescriptor_GetEntityString(t *testing.T) {
 }
 
 func TestDescriptor_GetIntegrityReader(t *testing.T) {
-	d := Descriptor{
+	d := rawDescriptor{
 		Datatype: DataDeffile,
 		Used:     true,
 		ID:       1,
@@ -345,19 +345,19 @@ func TestDescriptor_GetIntegrityReader(t *testing.T) {
 	tests := []struct {
 		name       string
 		relativeID uint32
-		modFunc    func(*Descriptor)
+		modFunc    func(*rawDescriptor)
 	}{
 		{
 			name:    "Datatype",
-			modFunc: func(od *Descriptor) { od.Datatype = DataEnvVar },
+			modFunc: func(od *rawDescriptor) { od.Datatype = DataEnvVar },
 		},
 		{
 			name:    "Used",
-			modFunc: func(od *Descriptor) { od.Used = !od.Used },
+			modFunc: func(od *rawDescriptor) { od.Used = !od.Used },
 		},
 		{
 			name:    "ID",
-			modFunc: func(od *Descriptor) { od.ID++ },
+			modFunc: func(od *rawDescriptor) { od.ID++ },
 		},
 		{
 			name:       "RelativeID",
@@ -365,47 +365,47 @@ func TestDescriptor_GetIntegrityReader(t *testing.T) {
 		},
 		{
 			name:    "Groupid",
-			modFunc: func(od *Descriptor) { od.Groupid++ },
+			modFunc: func(od *rawDescriptor) { od.Groupid++ },
 		},
 		{
 			name:    "Link",
-			modFunc: func(od *Descriptor) { od.Link++ },
+			modFunc: func(od *rawDescriptor) { od.Link++ },
 		},
 		{
 			name:    "Fileoff",
-			modFunc: func(od *Descriptor) { od.Fileoff++ },
+			modFunc: func(od *rawDescriptor) { od.Fileoff++ },
 		},
 		{
 			name:    "Filelen",
-			modFunc: func(od *Descriptor) { od.Filelen++ },
+			modFunc: func(od *rawDescriptor) { od.Filelen++ },
 		},
 		{
 			name:    "Storelen",
-			modFunc: func(od *Descriptor) { od.Storelen++ },
+			modFunc: func(od *rawDescriptor) { od.Storelen++ },
 		},
 		{
 			name:    "Ctime",
-			modFunc: func(od *Descriptor) { od.Ctime++ },
+			modFunc: func(od *rawDescriptor) { od.Ctime++ },
 		},
 		{
 			name:    "Mtime",
-			modFunc: func(od *Descriptor) { od.Mtime++ },
+			modFunc: func(od *rawDescriptor) { od.Mtime++ },
 		},
 		{
 			name:    "UID",
-			modFunc: func(od *Descriptor) { od.UID++ },
+			modFunc: func(od *rawDescriptor) { od.UID++ },
 		},
 		{
 			name:    "GID",
-			modFunc: func(od *Descriptor) { od.GID++ },
+			modFunc: func(od *rawDescriptor) { od.GID++ },
 		},
 		{
 			name:    "Name",
-			modFunc: func(od *Descriptor) { copy(od.Name[:], "BAD_NAME") },
+			modFunc: func(od *rawDescriptor) { copy(od.Name[:], "BAD_NAME") },
 		},
 		{
 			name:    "Extra",
-			modFunc: func(od *Descriptor) { copy(od.Extra[:], "BAD_EXTRA") },
+			modFunc: func(od *rawDescriptor) { copy(od.Extra[:], "BAD_EXTRA") },
 		},
 	}
 

--- a/pkg/sif/load.go
+++ b/pkg/sif/load.go
@@ -32,7 +32,7 @@ func readHeader(r io.ReaderAt, fimg *FileImage) error {
 // Read the descriptors from r and populate fimg.DescrArr.
 func readDescriptors(r io.ReaderAt, fimg *FileImage) error {
 	// Initialize descriptor array (slice) and read them all from file
-	fimg.descrArr = make([]Descriptor, fimg.h.Dtotal)
+	fimg.descrArr = make([]rawDescriptor, fimg.h.Dtotal)
 	if err := readBinaryAt(r, fimg.h.Descroff, &fimg.descrArr); err != nil {
 		fimg.descrArr = nil
 		return fmt.Errorf("reading descriptor array from container file: %s", err)

--- a/pkg/sif/select.go
+++ b/pkg/sif/select.go
@@ -26,7 +26,7 @@ var ErrInvalidGroupID = errors.New("invalid group ID")
 type DescriptorSelectorFunc func(d Descriptor) (bool, error)
 
 // WithDataType selects descriptors that have data type dt.
-func WithDataType(dt Datatype) DescriptorSelectorFunc {
+func WithDataType(dt DataType) DescriptorSelectorFunc {
 	return func(d Descriptor) (bool, error) {
 		return d.GetDataType() == dt, nil
 	}
@@ -83,7 +83,7 @@ func WithLinkedGroupID(groupID uint32) DescriptorSelectorFunc {
 }
 
 // WithPartitionType selects descriptors containing a partition of type pt.
-func WithPartitionType(pt Parttype) DescriptorSelectorFunc {
+func WithPartitionType(pt PartType) DescriptorSelectorFunc {
 	return func(d Descriptor) (bool, error) {
 		ptype, err := d.GetPartType()
 		if err != nil {

--- a/pkg/sif/select_test.go
+++ b/pkg/sif/select_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestFileImage_GetDescriptors(t *testing.T) {
-	ds := []Descriptor{
+	ds := []rawDescriptor{
 		{
 			Datatype: DataPartition,
 			Used:     true,
@@ -134,7 +134,7 @@ func TestFileImage_GetDescriptors(t *testing.T) {
 }
 
 func TestFileImage_GetDescriptor(t *testing.T) {
-	primPartDescr := Descriptor{
+	primPartDescr := rawDescriptor{
 		Datatype: DataPartition,
 		Used:     true,
 		ID:       1,
@@ -152,7 +152,7 @@ func TestFileImage_GetDescriptor(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ds := []Descriptor{
+	ds := []rawDescriptor{
 		primPartDescr,
 		{
 			Datatype: DataSignature,
@@ -228,7 +228,7 @@ func TestFileImage_GetDescriptor(t *testing.T) {
 }
 
 func TestFileImage_WithDescriptors(t *testing.T) {
-	ds := []Descriptor{
+	ds := []rawDescriptor{
 		{
 			Datatype: DataPartition,
 			Used:     true,

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -367,11 +367,11 @@ type ReadWriter interface {
 
 // FileImage describes the representation of a SIF file in memory.
 type FileImage struct {
-	h          header       // the loaded SIF global header
-	fp         ReadWriter   // file pointer of opened SIF file
-	size       int64        // file size of the opened SIF file
-	descrArr   []Descriptor // slice of loaded descriptors from SIF file
-	primPartID uint32       // ID of primary system partition if present
+	h          header          // the loaded SIF global header
+	fp         ReadWriter      // file pointer of opened SIF file
+	size       int64           // file size of the opened SIF file
+	descrArr   []rawDescriptor // slice of loaded descriptors from SIF file
+	primPartID uint32          // ID of primary system partition if present
 }
 
 // LaunchScript returns the image launch script.

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -145,12 +145,12 @@ const (
 	DataStartOffset   = 32768              // where data object start after descriptors
 )
 
-// Datatype represents the different SIF data object types stored in the image.
-type Datatype int32
+// DataType represents the different SIF data object types stored in the image.
+type DataType int32
 
 // List of supported SIF data types.
 const (
-	DataDeffile       Datatype = iota + 0x4001 // definition file data object
+	DataDeffile       DataType = iota + 0x4001 // definition file data object
 	DataEnvVar                                 // environment variables data object
 	DataLabels                                 // JSON labels data object
 	DataPartition                              // file system data object
@@ -161,7 +161,7 @@ const (
 )
 
 // String returns a human-readable representation of t.
-func (t Datatype) String() string {
+func (t DataType) String() string {
 	switch t {
 	case DataDeffile:
 		return "Def.FILE"
@@ -183,12 +183,12 @@ func (t Datatype) String() string {
 	return "Unknown"
 }
 
-// Fstype represents the different SIF file system types found in partition data objects.
-type Fstype int32
+// FSType represents the different SIF file system types found in partition data objects.
+type FSType int32
 
 // List of supported file systems.
 const (
-	FsSquash            Fstype = iota + 1 // Squashfs file system, RDONLY
+	FsSquash            FSType = iota + 1 // Squashfs file system, RDONLY
 	FsExt3                                // EXT3 file system, RDWR (deprecated)
 	FsImmuObj                             // immutable data object archive
 	FsRaw                                 // raw data
@@ -196,7 +196,7 @@ const (
 )
 
 // String returns a human-readable representation of t.
-func (t Fstype) String() string {
+func (t FSType) String() string {
 	switch t {
 	case FsSquash:
 		return "Squashfs"
@@ -212,19 +212,19 @@ func (t Fstype) String() string {
 	return "Unknown"
 }
 
-// Parttype represents the different SIF container partition types (system and data).
-type Parttype int32
+// PartType represents the different SIF container partition types (system and data).
+type PartType int32
 
 // List of supported partition types.
 const (
-	PartSystem  Parttype = iota + 1 // partition hosts an operating system
+	PartSystem  PartType = iota + 1 // partition hosts an operating system
 	PartPrimSys                     // partition hosts the primary operating system
 	PartData                        // partition hosts data only
 	PartOverlay                     // partition hosts an overlay
 )
 
 // String returns a human-readable representation of t.
-func (t Parttype) String() string {
+func (t PartType) String() string {
 	switch t {
 	case PartSystem:
 		return "System"
@@ -238,12 +238,12 @@ func (t Parttype) String() string {
 	return "Unknown"
 }
 
-// Hashtype represents the different SIF hashing function types used to fingerprint data objects.
-type Hashtype int32
+// HashType represents the different SIF hashing function types used to fingerprint data objects.
+type HashType int32
 
 // List of supported hash functions.
 const (
-	HashSHA256 Hashtype = iota + 1
+	HashSHA256 HashType = iota + 1
 	HashSHA384
 	HashSHA512
 	HashBLAKE2S
@@ -251,7 +251,7 @@ const (
 )
 
 // String returns a human-readable representation of t.
-func (t Hashtype) String() string {
+func (t HashType) String() string {
 	switch t {
 	case HashSHA256:
 		return "SHA256"
@@ -267,17 +267,17 @@ func (t Hashtype) String() string {
 	return "Unknown"
 }
 
-// Formattype represents the different formats used to store cryptographic message objects.
-type Formattype int32
+// FormatType represents the different formats used to store cryptographic message objects.
+type FormatType int32
 
 // List of supported cryptographic message formats.
 const (
-	FormatOpenPGP Formattype = iota + 1
+	FormatOpenPGP FormatType = iota + 1
 	FormatPEM
 )
 
 // String returns a human-readable representation of t.
-func (t Formattype) String() string {
+func (t FormatType) String() string {
 	switch t {
 	case FormatOpenPGP:
 		return "OpenPGP"
@@ -287,20 +287,20 @@ func (t Formattype) String() string {
 	return "Unknown"
 }
 
-// Messagetype represents the different messages stored within cryptographic message objects.
-type Messagetype int32
+// MessageType represents the different messages stored within cryptographic message objects.
+type MessageType int32
 
 // List of supported cryptographic message formats.
 const (
 	// openPGP formatted messages.
-	MessageClearSignature Messagetype = 0x100
+	MessageClearSignature MessageType = 0x100
 
 	// PEM formatted messages.
-	MessageRSAOAEP Messagetype = 0x200
+	MessageRSAOAEP MessageType = 0x200
 )
 
 // String returns a human-readable representation of t.
-func (t Messagetype) String() string {
+func (t MessageType) String() string {
 	switch t {
 	case MessageClearSignature:
 		return "Clear Signature"

--- a/pkg/siftool/add.go
+++ b/pkg/siftool/add.go
@@ -80,7 +80,7 @@ func addFlags(fs *pflag.FlagSet) {
 }
 
 // getDataType returns the data type corresponding to input.
-func getDataType() (sif.Datatype, error) {
+func getDataType() (sif.DataType, error) {
 	switch *dataType {
 	case 1:
 		return sif.DataDeffile, nil
@@ -132,7 +132,7 @@ func getArch() string {
 	}
 }
 
-func getOptions(dt sif.Datatype, fs *pflag.FlagSet) ([]sif.DescriptorInputOpt, error) {
+func getOptions(dt sif.DataType, fs *pflag.FlagSet) ([]sif.DescriptorInputOpt, error) {
 	var opts []sif.DescriptorInputOpt
 
 	if fs.Changed("groupid") {
@@ -157,7 +157,7 @@ func getOptions(dt sif.Datatype, fs *pflag.FlagSet) ([]sif.DescriptorInputOpt, e
 		}
 
 		opts = append(opts,
-			sif.OptPartitionMetadata(sif.Fstype(*partFS), sif.Parttype(*partType), getArch()),
+			sif.OptPartitionMetadata(sif.FSType(*partFS), sif.PartType(*partType), getArch()),
 		)
 	}
 
@@ -173,7 +173,7 @@ func getOptions(dt sif.Datatype, fs *pflag.FlagSet) ([]sif.DescriptorInputOpt, e
 		}
 		copy(fp[:], b)
 
-		opts = append(opts, sif.OptSignatureMetadata(sif.Hashtype(*signHash), fp))
+		opts = append(opts, sif.OptSignatureMetadata(sif.HashType(*signHash), fp))
 	}
 
 	return opts, nil


### PR DESCRIPTION
Use struct wrapping for `type Descriptor` to make internals non-exported. Use CamelCase for exported `type`s.