### PR TITLE
Simplify ReadWriter

### DIFF
--- a/pkg/sif/create.go
+++ b/pkg/sif/create.go
@@ -310,16 +310,8 @@ func (f *FileImage) AddObject(input DescriptorInput) error {
 	}
 
 	f.h.Mtime = time.Now().Unix()
-	// write down global header to file
-	if err := f.writeHeader(); err != nil {
-		return err
-	}
 
-	if err := f.fp.Sync(); err != nil {
-		return fmt.Errorf("while sync'ing new data object to SIF file: %s", err)
-	}
-
-	return nil
+	return f.writeHeader()
 }
 
 // descrIsLast return true if passed descriptor's object is the last in a SIF file.
@@ -409,16 +401,7 @@ func (f *FileImage) DeleteObject(id uint32, flags int) error {
 		return err
 	}
 
-	// update global header
-	if err = f.writeHeader(); err != nil {
-		return err
-	}
-
-	if err := f.fp.Sync(); err != nil {
-		return fmt.Errorf("while sync'ing deleted data object to SIF file: %s", err)
-	}
-
-	return nil
+	return f.writeHeader()
 }
 
 // SetPrimPart sets the specified system partition to be the primary one.
@@ -487,14 +470,6 @@ func (f *FileImage) SetPrimPart(id uint32) error {
 	}
 
 	f.h.Mtime = time.Now().Unix()
-	// write down global header to file
-	if err := f.writeHeader(); err != nil {
-		return err
-	}
 
-	if err := f.fp.Sync(); err != nil {
-		return fmt.Errorf("while sync'ing new data object to SIF file: %s", err)
-	}
-
-	return nil
+	return f.writeHeader()
 }

--- a/pkg/sif/create.go
+++ b/pkg/sif/create.go
@@ -323,8 +323,16 @@ func (f *FileImage) AddObject(input DescriptorInput) error {
 }
 
 // descrIsLast return true if passed descriptor's object is the last in a SIF file.
-func objectIsLast(fimg *FileImage, descr *rawDescriptor) bool {
-	return fimg.size == descr.Fileoff+descr.Filelen
+func objectIsLast(f *FileImage, d *rawDescriptor) bool {
+	isLast := true
+
+	end := d.GetOffset() + d.GetSize()
+	f.WithDescriptors(func(d Descriptor) bool {
+		isLast = d.GetOffset()+d.GetSize() <= end
+		return !isLast
+	})
+
+	return isLast
 }
 
 // compactAtDescr joins data objects leading and following "descr" by compacting a SIF file.

--- a/pkg/sif/create_test.go
+++ b/pkg/sif/create_test.go
@@ -219,8 +219,8 @@ func TestSetPrimPart(t *testing.T) {
 			Dfree:  int64(len(inputs)),
 			Dtotal: int64(len(inputs)),
 		},
-		fp:       &mockSifReadWriter{},
-		descrArr: make([]rawDescriptor, len(inputs)),
+		rw:  &mockSifReadWriter{},
+		rds: make([]rawDescriptor, len(inputs)),
 	}
 
 	for i := range inputs {
@@ -232,7 +232,7 @@ func TestSetPrimPart(t *testing.T) {
 			Fstype:   FsRaw,
 			Parttype: PartSystem,
 		}
-		if err := fimg.descrArr[i].setExtra(p); err != nil {
+		if err := fimg.rds[i].setExtra(p); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -240,13 +240,13 @@ func TestSetPrimPart(t *testing.T) {
 	// the first pass tests that the primary partition can be set;
 	// the second pass tests that the primary can be changed.
 	for i := range inputs {
-		if err := fimg.SetPrimPart(fimg.descrArr[i].ID); err != nil {
+		if err := fimg.SetPrimPart(fimg.rds[i].ID); err != nil {
 			t.Error("fimg.SetPrimPart(...):", err)
 		}
 
 		if part, err := fimg.GetDescriptor(WithPartitionType(PartPrimSys)); err != nil {
 			t.Fatal(err)
-		} else if want, got := part.ID, fimg.descrArr[i].ID; got != want {
+		} else if want, got := part.ID, fimg.rds[i].ID; got != want {
 			t.Errorf("got ID %v, want %v", got, want)
 		}
 	}

--- a/pkg/sif/descriptor.go
+++ b/pkg/sif/descriptor.go
@@ -201,7 +201,7 @@ func (d rawDescriptor) GetData(f *FileImage) ([]byte, error) {
 
 // GetReader returns a io.Reader that reads the data object associated with descriptor d from f.
 func (d rawDescriptor) GetReader(f *FileImage) io.Reader {
-	return io.NewSectionReader(f.fp, d.Fileoff, d.Filelen)
+	return io.NewSectionReader(f.rw, d.Fileoff, d.Filelen)
 }
 
 // GetIntegrityReader returns an io.Reader that reads the integrity-protected fields from d.

--- a/pkg/sif/descriptor_input.go
+++ b/pkg/sif/descriptor_input.go
@@ -172,7 +172,7 @@ func OptSignatureMetadata(ht HashType, fp [20]byte) DescriptorInputOpt {
 // DescriptorInput describes a new data object.
 type DescriptorInput struct {
 	dt   DataType
-	fp   io.Reader
+	r    io.Reader
 	opts descriptorOpts
 }
 
@@ -204,7 +204,7 @@ func NewDescriptorInput(t DataType, r io.Reader, opts ...DescriptorInputOpt) (De
 
 	di := DescriptorInput{
 		dt:   t,
-		fp:   r,
+		r:    r,
 		opts: dopts,
 	}
 

--- a/pkg/sif/load.go
+++ b/pkg/sif/load.go
@@ -32,9 +32,9 @@ func readHeader(r io.ReaderAt, fimg *FileImage) error {
 // Read the descriptors from r and populate fimg.DescrArr.
 func readDescriptors(r io.ReaderAt, fimg *FileImage) error {
 	// Initialize descriptor array (slice) and read them all from file
-	fimg.descrArr = make([]rawDescriptor, fimg.h.Dtotal)
-	if err := readBinaryAt(r, fimg.h.Descroff, &fimg.descrArr); err != nil {
-		fimg.descrArr = nil
+	fimg.rds = make([]rawDescriptor, fimg.h.Dtotal)
+	if err := readBinaryAt(r, fimg.h.Descroff, &fimg.rds); err != nil {
+		fimg.rds = nil
 		return fmt.Errorf("reading descriptor array from container file: %s", err)
 	}
 
@@ -88,7 +88,7 @@ func LoadContainerFp(fp ReadWriter, rdonly bool) (fimg FileImage, err error) {
 	if fp == nil {
 		return fimg, fmt.Errorf("provided fp for file is invalid")
 	}
-	fimg.fp = fp
+	fimg.rw = fp
 
 	// read global header from SIF file
 	if err = readHeader(fp, &fimg); err != nil {
@@ -133,7 +133,7 @@ func LoadContainerReader(b *bytes.Reader) (fimg FileImage, err error) {
 
 // UnloadContainer unloads f, releasing associated resources.
 func (f *FileImage) UnloadContainer() error {
-	if c, ok := f.fp.(io.Closer); ok {
+	if c, ok := f.rw.(io.Closer); ok {
 		if err := c.Close(); err != nil {
 			return err
 		}

--- a/pkg/sif/load.go
+++ b/pkg/sif/load.go
@@ -131,15 +131,14 @@ func LoadContainerReader(b *bytes.Reader) (fimg FileImage, err error) {
 	return fimg, err
 }
 
-// UnloadContainer closes the SIF container file and free associated resources if needed.
-func (f *FileImage) UnloadContainer() (err error) {
-	// if SIF data comes from file, not a slice buffer (see LoadContainer() variants)
-	if f.fp != nil {
-		if err = f.fp.Close(); err != nil {
-			return fmt.Errorf("closing SIF file failed, corrupted: don't use: %s", err)
+// UnloadContainer unloads f, releasing associated resources.
+func (f *FileImage) UnloadContainer() error {
+	if c, ok := f.fp.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return err
 		}
 	}
-	return
+	return nil
 }
 
 func trimZeroBytes(str []byte) string {

--- a/pkg/sif/load.go
+++ b/pkg/sif/load.go
@@ -90,12 +90,6 @@ func LoadContainerFp(fp ReadWriter, rdonly bool) (fimg FileImage, err error) {
 	}
 	fimg.fp = fp
 
-	info, err := fimg.fp.Stat()
-	if err != nil {
-		return fimg, err
-	}
-	fimg.size = info.Size()
-
 	// read global header from SIF file
 	if err = readHeader(fp, &fimg); err != nil {
 		return

--- a/pkg/sif/load_test.go
+++ b/pkg/sif/load_test.go
@@ -11,7 +11,6 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
-	"time"
 )
 
 func TestLoadContainer(t *testing.T) {
@@ -59,36 +58,6 @@ func TestLoadContainerFp(t *testing.T) {
 			}
 		})
 	}
-}
-
-type mockFileInfo struct {
-	name string
-	size int64
-	time time.Time
-}
-
-func (m *mockFileInfo) Name() string {
-	return m.name
-}
-
-func (m *mockFileInfo) Size() int64 {
-	return m.size
-}
-
-func (m *mockFileInfo) Mode() os.FileMode {
-	return 0o644
-}
-
-func (m *mockFileInfo) ModTime() time.Time {
-	return m.time
-}
-
-func (m *mockFileInfo) IsDir() bool {
-	return false
-}
-
-func (m *mockFileInfo) Sys() interface{} {
-	return nil
 }
 
 type mockSifReadWriter struct {
@@ -169,10 +138,6 @@ func (m *mockSifReadWriter) Seek(offset int64, whence int) (ret int64, err error
 	m.pos = ret
 
 	return ret, err
-}
-
-func (m *mockSifReadWriter) Stat() (os.FileInfo, error) {
-	return &mockFileInfo{name: m.name, size: int64(len(m.buf)), time: time.Unix(0, 0)}, nil
 }
 
 func (m *mockSifReadWriter) Sync() error {

--- a/pkg/sif/load_test.go
+++ b/pkg/sif/load_test.go
@@ -183,7 +183,7 @@ func TestLoadContainerReader(t *testing.T) {
 	// and that DescrArr is set to nil (since not complete)
 	r := bytes.NewReader(content[:31768])
 	fimg, err := LoadContainerReader(r)
-	if err != nil || fimg.descrArr != nil {
+	if err != nil || fimg.rds != nil {
 		t.Error(`LoadContainerReader(buf):`, err)
 	}
 

--- a/pkg/sif/load_test.go
+++ b/pkg/sif/load_test.go
@@ -101,10 +101,6 @@ func (m *mockSifReadWriter) Seek(offset int64, whence int) (ret int64, err error
 	return ret, err
 }
 
-func (m *mockSifReadWriter) Sync() error {
-	return nil
-}
-
 func (m *mockSifReadWriter) Truncate(size int64) error {
 	m.pos = 0
 	return nil
@@ -133,7 +129,7 @@ func TestLoadContainerFpMock(t *testing.T) {
 	// very dumb buffer. This specific test could be exteded to test
 	// for more error conditions as it would be possible to report
 	// errors from cases where it would be otherwise hard to do so
-	// (e.g. Seek, ReadAt, Sync or Truncate reporting errors).
+	// (e.g. Seek, ReadAt or Truncate reporting errors).
 
 	// Load a valid SIF file to test the happy path.
 	content, err := ioutil.ReadFile("testdata/testcontainer2.sif")

--- a/pkg/sif/load_test.go
+++ b/pkg/sif/load_test.go
@@ -61,21 +61,11 @@ func TestLoadContainerFp(t *testing.T) {
 }
 
 type mockSifReadWriter struct {
-	buf    []byte
-	pos    int64
-	closed bool
-}
-
-func (m *mockSifReadWriter) Close() error {
-	m.closed = true
-	return nil
+	buf []byte
+	pos int64
 }
 
 func (m *mockSifReadWriter) ReadAt(b []byte, off int64) (n int, err error) {
-	if m.closed {
-		return 0, os.ErrInvalid
-	}
-
 	if off >= int64(len(m.buf)) {
 		return 0, io.EOF
 	}
@@ -84,10 +74,6 @@ func (m *mockSifReadWriter) ReadAt(b []byte, off int64) (n int, err error) {
 }
 
 func (m *mockSifReadWriter) Seek(offset int64, whence int) (ret int64, err error) {
-	if m.closed {
-		return 0, os.ErrInvalid
-	}
-
 	sz := int64(len(m.buf))
 
 	switch whence {
@@ -125,10 +111,6 @@ func (m *mockSifReadWriter) Truncate(size int64) error {
 }
 
 func (m *mockSifReadWriter) Write(b []byte) (n int, err error) {
-	if m.closed {
-		return 0, os.ErrInvalid
-	}
-
 	if len(b) > cap(m.buf[m.pos:]) {
 		buf := make([]byte, m.pos, m.pos+int64(len(b)))
 		copy(buf, m.buf)

--- a/pkg/sif/load_test.go
+++ b/pkg/sif/load_test.go
@@ -62,22 +62,13 @@ func TestLoadContainerFp(t *testing.T) {
 
 type mockSifReadWriter struct {
 	buf    []byte
-	name   string
 	pos    int64
 	closed bool
-}
-
-func (m *mockSifReadWriter) Name() string {
-	return m.name
 }
 
 func (m *mockSifReadWriter) Close() error {
 	m.closed = true
 	return nil
-}
-
-func (m *mockSifReadWriter) Fd() uintptr {
-	return ^uintptr(0)
 }
 
 func (m *mockSifReadWriter) Read(b []byte) (n int, err error) {
@@ -185,8 +176,7 @@ func TestLoadContainerFpMock(t *testing.T) {
 	}
 
 	fp := &mockSifReadWriter{
-		buf:  content,
-		name: "mockSifReadWriter",
+		buf: content,
 	}
 
 	fimg, err := LoadContainerFp(fp, true)
@@ -212,8 +202,7 @@ func TestLoadContainerInvalidMagic(t *testing.T) {
 	copy(content[hdrLaunchLen:hdrLaunchLen+hdrMagicLen], "SIF_MAGIX")
 
 	fp := &mockSifReadWriter{
-		buf:  content,
-		name: "invalid_magic",
+		buf: content,
 	}
 
 	fimg, err := LoadContainerFp(fp, true)

--- a/pkg/sif/load_test.go
+++ b/pkg/sif/load_test.go
@@ -71,22 +71,6 @@ func (m *mockSifReadWriter) Close() error {
 	return nil
 }
 
-func (m *mockSifReadWriter) Read(b []byte) (n int, err error) {
-	if m.closed {
-		return 0, os.ErrInvalid
-	}
-
-	if m.pos >= int64(len(m.buf)) {
-		return 0, io.EOF
-	}
-
-	n = copy(b, m.buf[m.pos:])
-
-	m.pos += int64(n)
-
-	return n, err
-}
-
 func (m *mockSifReadWriter) ReadAt(b []byte, off int64) (n int, err error) {
 	if m.closed {
 		return 0, os.ErrInvalid
@@ -167,7 +151,7 @@ func TestLoadContainerFpMock(t *testing.T) {
 	// very dumb buffer. This specific test could be exteded to test
 	// for more error conditions as it would be possible to report
 	// errors from cases where it would be otherwise hard to do so
-	// (e.g. Seek, Read, Sync or Truncate reporting errors).
+	// (e.g. Seek, ReadAt, Sync or Truncate reporting errors).
 
 	// Load a valid SIF file to test the happy path.
 	content, err := ioutil.ReadFile("testdata/testcontainer2.sif")

--- a/pkg/sif/select.go
+++ b/pkg/sif/select.go
@@ -153,18 +153,18 @@ func multiSelectorFunc(fns ...DescriptorSelectorFunc) DescriptorSelectorFunc {
 // true. If selectFn or onMatchFn return a non-nil error, the iteration halts, and the error is
 // returned to the caller.
 func (f *FileImage) withDescriptors(selectFn DescriptorSelectorFunc, onMatchFn func(*rawDescriptor) error) error {
-	for i, d := range f.descrArr {
+	for i, d := range f.rds {
 		if !d.Used {
 			continue
 		}
 
-		if ok, err := selectFn(Descriptor{f.descrArr[i]}); err != nil {
+		if ok, err := selectFn(Descriptor{f.rds[i]}); err != nil {
 			return err
 		} else if !ok {
 			continue
 		}
 
-		if err := onMatchFn(&f.descrArr[i]); err != nil {
+		if err := onMatchFn(&f.rds[i]); err != nil {
 			return err
 		}
 	}

--- a/pkg/sif/select_test.go
+++ b/pkg/sif/select_test.go
@@ -115,7 +115,7 @@ func TestFileImage_GetDescriptors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fimg := &FileImage{descrArr: ds}
+			fimg := &FileImage{rds: ds}
 
 			ds, err := fimg.GetDescriptors(tt.fns...)
 			if got, want := err, tt.wantErr; !errors.Is(got, want) {
@@ -214,7 +214,7 @@ func TestFileImage_GetDescriptor(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fimg := &FileImage{descrArr: ds}
+			fimg := &FileImage{rds: ds}
 
 			d, err := fimg.GetDescriptor(tt.fns...)
 			if got, want := err, tt.wantErr; !errors.Is(got, want) {
@@ -281,7 +281,7 @@ func TestFileImage_WithDescriptors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := &FileImage{descrArr: ds}
+			f := &FileImage{rds: ds}
 
 			f.WithDescriptors(tt.fn(t))
 		})

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -86,7 +86,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
 	"time"
 
 	"github.com/google/uuid"
@@ -343,7 +342,6 @@ type ReadWriter interface {
 	io.Closer
 	Name() string
 	Fd() uintptr
-	Stat() (os.FileInfo, error)
 	Sync() error
 	Truncate(size int64) error
 }
@@ -352,7 +350,6 @@ type ReadWriter interface {
 type FileImage struct {
 	h          header          // the loaded SIF global header
 	fp         ReadWriter      // file pointer of opened SIF file
-	size       int64           // file size of the opened SIF file
 	descrArr   []rawDescriptor // slice of loaded descriptors from SIF file
 	primPartID uint32          // ID of primary system partition if present
 }

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -339,7 +339,6 @@ func (h header) GetIntegrityReader() io.Reader {
 type ReadWriter interface {
 	io.ReaderAt
 	io.WriteSeeker
-	io.Closer
 	Sync() error
 	Truncate(int64) error
 }

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -339,7 +339,6 @@ func (h header) GetIntegrityReader() io.Reader {
 type ReadWriter interface {
 	io.ReaderAt
 	io.WriteSeeker
-	Sync() error
 	Truncate(int64) error
 }
 

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -340,8 +340,6 @@ type ReadWriter interface {
 	io.ReadWriteSeeker
 	io.ReaderAt
 	io.Closer
-	Name() string
-	Fd() uintptr
 	Sync() error
 	Truncate(size int64) error
 }

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -337,11 +337,11 @@ func (h header) GetIntegrityReader() io.Reader {
 // ReadWriter describes the operations needed to support reading and
 // writing SIF files.
 type ReadWriter interface {
-	io.ReadWriteSeeker
 	io.ReaderAt
+	io.WriteSeeker
 	io.Closer
 	Sync() error
-	Truncate(size int64) error
+	Truncate(int64) error
 }
 
 // FileImage describes the representation of a SIF file in memory.

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -328,14 +328,7 @@ func (h header) GetIntegrityReader() io.Reader {
 	)
 }
 
-//
-// This section describes SIF creation/loading data structures used when
-// building or opening a SIF file. Transient data not found in the final
-// SIF file. Those data structures are internal.
-//
-
-// ReadWriter describes the operations needed to support reading and
-// writing SIF files.
+// ReadWriter describes the interface required to read and write SIF images.
 type ReadWriter interface {
 	io.ReaderAt
 	io.WriteSeeker
@@ -344,10 +337,10 @@ type ReadWriter interface {
 
 // FileImage describes the representation of a SIF file in memory.
 type FileImage struct {
-	h          header          // the loaded SIF global header
-	fp         ReadWriter      // file pointer of opened SIF file
-	descrArr   []rawDescriptor // slice of loaded descriptors from SIF file
-	primPartID uint32          // ID of primary system partition if present
+	h          header
+	rw         ReadWriter
+	rds        []rawDescriptor
+	primPartID uint32
 }
 
 // LaunchScript returns the image launch script.


### PR DESCRIPTION
Simplify `ReadWriter interface` by removing the following:

- `io.Reader`: unused, code uses `io.ReaderAt` intstead.
- `io.Closer`: previously used in `UnloadContainer`. `LoadContainerReader` supports loading from a type that does not implement `Close`, for which conditional logic is necessary. Given this, we instead dynamically check if the underlying `ReadWriter` implements `io.Closer`, simplifying both the implementation as well as the exported interface.
- `Name`: unused, replaced with `OptObjectName`, which allows a user to explicitly pass a name.
- `Fd`: unused.
- `Stat`: previously used to obtain file size. We now use `Seek` to obtain file size.
- `Sync`:  `LoadContainerReader` supports loading from a type that does not implement `Sync`, for which conditional logic is necessary. In practice, the code paths that leverage `Sync` are almost always followed by call to `UnloadContainer`, which will implicitly `Sync` when `Close` is called. If a use case comes up where this is required, a dynamic type check can be used to check if the underlying `ReadWriter` supports `Sync` instead.

Simplify `mockSifReadWriter` to reflect changes to the `ReadWriter interface` it mocks.

Closes #75 