### PR TITLE
Use Crypto Hash Type

### DIFF
--- a/internal/app/siftool/modif_test.go
+++ b/internal/app/siftool/modif_test.go
@@ -7,6 +7,7 @@ package siftool
 
 import (
 	"bytes"
+	"crypto"
 	"errors"
 	"os"
 	"testing"
@@ -58,7 +59,7 @@ func TestApp_Add(t *testing.T) {
 			data:     []byte{0xde, 0xad, 0xbe, 0xef},
 			dataType: sif.DataSignature,
 			opts: []sif.DescriptorInputOpt{
-				sif.OptSignatureMetadata(sif.HashSHA256, [...]byte{
+				sif.OptSignatureMetadata(crypto.SHA256, [...]byte{
 					0x12, 0x04, 0x5c, 0x8c, 0x0b, 0x10, 0x04, 0xd0, 0x58, 0xde,
 					0x4b, 0xed, 0xa2, 0x0c, 0x27, 0xee, 0x7f, 0xf7, 0xba, 0x84,
 				}),

--- a/internal/app/siftool/testdata/TestApp_Info/Three.golden
+++ b/internal/app/siftool/testdata/TestApp_Info/Three.golden
@@ -7,5 +7,5 @@
   Ctime:     2020-06-30 00:01:56 +0000 UTC
   Mtime:     2020-06-30 00:01:56 +0000 UTC
   Name:      .
-  Hashtype:  SHA256
+  Hashtype:  SHA-256
   Entity:    12045C8C0B1004D058DE4BEDA20C27EE7FF7BA84

--- a/internal/app/siftool/testdata/TestApp_List/OneGroupSigned.golden
+++ b/internal/app/siftool/testdata/TestApp_List/OneGroupSigned.golden
@@ -7,4 +7,4 @@ ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)
 2    |1       |NONE    |36864-36868               |FS (Squashfs/*System/386)
-3    |NONE    |1   (G) |40960-41981               |Signature (SHA256)
+3    |NONE    |1   (G) |40960-41981               |Signature (SHA-256)

--- a/internal/app/siftool/testdata/TestApp_List/OneGroupSignedLegacy.golden
+++ b/internal/app/siftool/testdata/TestApp_List/OneGroupSignedLegacy.golden
@@ -7,4 +7,4 @@ ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)
 2    |1       |NONE    |36864-36868               |FS (Squashfs/*System/386)
-3    |1       |2       |40960-41569               |Signature (SHA384)
+3    |1       |2       |40960-41569               |Signature (SHA-384)

--- a/internal/app/siftool/testdata/TestApp_List/OneGroupSignedLegacyAll.golden
+++ b/internal/app/siftool/testdata/TestApp_List/OneGroupSignedLegacyAll.golden
@@ -7,5 +7,5 @@ ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)
 2    |1       |NONE    |36864-36868               |FS (Squashfs/*System/386)
-3    |1       |1       |40960-41569               |Signature (SHA384)
-4    |1       |2       |45056-45665               |Signature (SHA384)
+3    |1       |1       |40960-41569               |Signature (SHA-384)
+4    |1       |2       |45056-45665               |Signature (SHA-384)

--- a/internal/app/siftool/testdata/TestApp_List/OneGroupSignedLegacyGroup.golden
+++ b/internal/app/siftool/testdata/TestApp_List/OneGroupSignedLegacyGroup.golden
@@ -7,4 +7,4 @@ ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)
 2    |1       |NONE    |36864-36868               |FS (Squashfs/*System/386)
-3    |NONE    |1   (G) |40960-41569               |Signature (SHA384)
+3    |NONE    |1   (G) |40960-41569               |Signature (SHA-384)

--- a/internal/app/siftool/testdata/TestApp_List/TwoGroupsSigned.golden
+++ b/internal/app/siftool/testdata/TestApp_List/TwoGroupsSigned.golden
@@ -8,5 +8,5 @@ ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)
 2    |1       |NONE    |36864-36868               |FS (Squashfs/*System/386)
 3    |2       |NONE    |40960-40964               |FS (Ext3/System/amd64)
-4    |NONE    |1   (G) |45056-46077               |Signature (SHA256)
-5    |NONE    |2   (G) |49152-49974               |Signature (SHA256)
+4    |NONE    |1   (G) |45056-46077               |Signature (SHA-256)
+5    |NONE    |2   (G) |49152-49974               |Signature (SHA-256)

--- a/internal/app/siftool/testdata/TestApp_List/TwoGroupsSignedLegacy.golden
+++ b/internal/app/siftool/testdata/TestApp_List/TwoGroupsSignedLegacy.golden
@@ -8,4 +8,4 @@ ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)
 2    |1       |NONE    |36864-36868               |FS (Squashfs/*System/386)
 3    |2       |NONE    |40960-40964               |FS (Ext3/System/amd64)
-4    |1       |2       |45056-45665               |Signature (SHA384)
+4    |1       |2       |45056-45665               |Signature (SHA-384)

--- a/internal/app/siftool/testdata/TestApp_List/TwoGroupsSignedLegacyAll.golden
+++ b/internal/app/siftool/testdata/TestApp_List/TwoGroupsSignedLegacyAll.golden
@@ -8,5 +8,5 @@ ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)
 2    |1       |NONE    |36864-36868               |FS (Squashfs/*System/386)
 3    |2       |NONE    |40960-40964               |FS (Ext3/System/amd64)
-4    |1       |1       |45056-45665               |Signature (SHA384)
-5    |1       |2       |49152-49761               |Signature (SHA384)
+4    |1       |1       |45056-45665               |Signature (SHA-384)
+5    |1       |2       |49152-49761               |Signature (SHA-384)

--- a/internal/app/siftool/testdata/TestApp_List/TwoGroupsSignedLegacyGroup.golden
+++ b/internal/app/siftool/testdata/TestApp_List/TwoGroupsSignedLegacyGroup.golden
@@ -8,4 +8,4 @@ ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)
 2    |1       |NONE    |36864-36868               |FS (Squashfs/*System/386)
 3    |2       |NONE    |40960-40964               |FS (Ext3/System/amd64)
-4    |NONE    |1   (G) |45056-45665               |Signature (SHA384)
+4    |NONE    |1   (G) |45056-45665               |Signature (SHA-384)

--- a/pkg/integrity/digest.go
+++ b/pkg/integrity/digest.go
@@ -14,8 +14,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-
-	"github.com/sylabs/sif/v2/pkg/sif"
 )
 
 var (
@@ -74,19 +72,6 @@ func newDigestReader(h crypto.Hash, r io.Reader) (digest, error) {
 	return newDigest(h, value)
 }
 
-// hashType converts ht into a crypto.Hash value.
-func hashType(ht sif.HashType) (crypto.Hash, error) {
-	switch ht {
-	case sif.HashSHA256:
-		return crypto.SHA256, nil
-	case sif.HashSHA384:
-		return crypto.SHA384, nil
-	case sif.HashSHA512:
-		return crypto.SHA512, nil
-	}
-	return 0, errHashUnsupported
-}
-
 // newLegacyDigest parses legacy signature plaintext b, and returns a digest based on the hash type
 // ht and the digest value read from the plaintext.
 //
@@ -95,15 +80,9 @@ func hashType(ht sif.HashType) (crypto.Hash, error) {
 //
 // 	SIFHASH:
 //  2f0b3dca0ec42683d306338f68689aba29cdb83625b8cc0b8a789f8de92342495a6264b0c134e706630636bf90c6f331
-func newLegacyDigest(ht sif.HashType, b []byte) (digest, error) {
+func newLegacyDigest(ht crypto.Hash, b []byte) (digest, error) {
 	b = bytes.TrimPrefix(b, []byte("SIFHASH:\n"))
 	b = bytes.TrimSuffix(b, []byte("\n"))
-
-	// Convert hash type.
-	h, err := hashType(ht)
-	if err != nil {
-		return digest{}, err
-	}
 
 	// Decode hex input.
 	value := make([]byte, hex.DecodedLen(len(b)))
@@ -111,7 +90,7 @@ func newLegacyDigest(ht sif.HashType, b []byte) (digest, error) {
 		return digest{}, err
 	}
 
-	return newDigest(h, value)
+	return newDigest(ht, value)
 }
 
 // matches returns whether the digest in d matches r.

--- a/pkg/integrity/digest_test.go
+++ b/pkg/integrity/digest_test.go
@@ -17,13 +17,12 @@ import (
 	"testing"
 
 	"github.com/sebdah/goldie/v2"
-	"github.com/sylabs/sif/v2/pkg/sif"
 )
 
 func TestNewLegacyDigest(t *testing.T) {
 	tests := []struct {
 		name       string
-		ht         sif.HashType
+		ht         crypto.Hash
 		text       string
 		wantError  error
 		wantDigest digest
@@ -35,19 +34,19 @@ func TestNewLegacyDigest(t *testing.T) {
 		},
 		{
 			name:      "DigestMalformed",
-			ht:        sif.HashSHA256,
+			ht:        crypto.SHA256,
 			text:      "1234",
 			wantError: errDigestMalformed,
 		},
 		{
 			name:      "HexLength",
-			ht:        sif.HashSHA256,
+			ht:        crypto.SHA256,
 			text:      "12345",
 			wantError: hex.ErrLength,
 		},
 		{
 			name: "SHA256",
-			ht:   sif.HashSHA256,
+			ht:   crypto.SHA256,
 			text: "SIFHASH:\n9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08\n",
 			wantDigest: digest{
 				hash: crypto.SHA256,
@@ -60,7 +59,7 @@ func TestNewLegacyDigest(t *testing.T) {
 		},
 		{
 			name: "SHA384",
-			ht:   sif.HashSHA384,
+			ht:   crypto.SHA384,
 			text: "SIFHASH:\n768412320f7b0aa5812fce428dc4706b3cae50e02a64caa16a782249bfe8efc4b7ef1ccb126255d196047dfedf17a0a9\n",
 			wantDigest: digest{
 				hash: crypto.SHA384,
@@ -74,7 +73,7 @@ func TestNewLegacyDigest(t *testing.T) {
 		},
 		{
 			name: "SHA512",
-			ht:   sif.HashSHA512,
+			ht:   crypto.SHA512,
 			text: "SIFHASH:\nee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff\n", // nolint:lll
 			wantDigest: digest{
 				hash: crypto.SHA512,

--- a/pkg/integrity/sign.go
+++ b/pkg/integrity/sign.go
@@ -26,29 +26,13 @@ var (
 // ErrNoKeyMaterial is the error returned when no key material was provided.
 var ErrNoKeyMaterial = errors.New("key material not provided")
 
-func sifHashType(h crypto.Hash) sif.HashType {
-	switch h {
-	case crypto.SHA256:
-		return sif.HashSHA256
-	case crypto.SHA384:
-		return sif.HashSHA384
-	case crypto.SHA512:
-		return sif.HashSHA512
-	case crypto.BLAKE2s_256:
-		return sif.HashBLAKE2S
-	case crypto.BLAKE2b_256, crypto.BLAKE2b_384, crypto.BLAKE2b_512:
-		return sif.HashBLAKE2B
-	}
-	return 0
-}
-
 type groupSigner struct {
 	f         *sif.FileImage   // SIF image to sign.
 	id        uint32           // Group ID.
 	ods       []sif.Descriptor // Descriptors of object(s) to sign.
 	mdHash    crypto.Hash      // Hash type for metadata.
 	sigConfig *packet.Config   // Configuration for signature.
-	sigHash   sif.HashType     // SIF hash type for signature.
+	sigHash   crypto.Hash      // Hash type for signature.
 }
 
 // groupSignerOpt are used to configure gs.
@@ -131,8 +115,8 @@ func newGroupSigner(f *sif.FileImage, groupID uint32, opts ...groupSignerOpt) (*
 		}
 	}
 
-	// Populate SIF hash type.
-	gs.sigHash = sifHashType(gs.sigConfig.Hash())
+	// Populate hash type.
+	gs.sigHash = gs.sigConfig.Hash()
 
 	return &gs, nil
 }

--- a/pkg/integrity/sign_test.go
+++ b/pkg/integrity/sign_test.go
@@ -124,7 +124,7 @@ func TestNewGroupSigner(t *testing.T) {
 		wantErr     error
 		wantObjects []uint32
 		wantMDHash  crypto.Hash
-		wantSigHash sif.HashType
+		wantSigHash crypto.Hash
 	}{
 		{
 			name:    "InvalidGroupID",
@@ -151,7 +151,7 @@ func TestNewGroupSigner(t *testing.T) {
 			groupID:     1,
 			wantObjects: []uint32{1, 2},
 			wantMDHash:  crypto.SHA256,
-			wantSigHash: sif.HashSHA256,
+			wantSigHash: crypto.SHA256,
 		},
 		{
 			name:        "Group2",
@@ -159,7 +159,7 @@ func TestNewGroupSigner(t *testing.T) {
 			groupID:     2,
 			wantObjects: []uint32{3},
 			wantMDHash:  crypto.SHA256,
-			wantSigHash: sif.HashSHA256,
+			wantSigHash: crypto.SHA256,
 		},
 		{
 			name:        "OptSignGroupObject1",
@@ -168,7 +168,7 @@ func TestNewGroupSigner(t *testing.T) {
 			opts:        []groupSignerOpt{optSignGroupObjects(1)},
 			wantObjects: []uint32{1},
 			wantMDHash:  crypto.SHA256,
-			wantSigHash: sif.HashSHA256,
+			wantSigHash: crypto.SHA256,
 		},
 		{
 			name:        "OptSignGroupObject2",
@@ -177,7 +177,7 @@ func TestNewGroupSigner(t *testing.T) {
 			opts:        []groupSignerOpt{optSignGroupObjects(2)},
 			wantObjects: []uint32{2},
 			wantMDHash:  crypto.SHA256,
-			wantSigHash: sif.HashSHA256,
+			wantSigHash: crypto.SHA256,
 		},
 		{
 			name:        "OptSignGroupObject3",
@@ -186,7 +186,7 @@ func TestNewGroupSigner(t *testing.T) {
 			opts:        []groupSignerOpt{optSignGroupObjects(3)},
 			wantObjects: []uint32{3},
 			wantMDHash:  crypto.SHA256,
-			wantSigHash: sif.HashSHA256,
+			wantSigHash: crypto.SHA256,
 		},
 		{
 			name:        "OptSignGroupMetadataHash",
@@ -195,7 +195,7 @@ func TestNewGroupSigner(t *testing.T) {
 			opts:        []groupSignerOpt{optSignGroupMetadataHash(crypto.SHA1)},
 			wantObjects: []uint32{1, 2},
 			wantMDHash:  crypto.SHA1,
-			wantSigHash: sif.HashSHA256,
+			wantSigHash: crypto.SHA256,
 		},
 		{
 			name:    "OptSignGroupSignatureConfigSHA256",
@@ -206,7 +206,7 @@ func TestNewGroupSigner(t *testing.T) {
 			})},
 			wantObjects: []uint32{1, 2},
 			wantMDHash:  crypto.SHA256,
-			wantSigHash: sif.HashSHA256,
+			wantSigHash: crypto.SHA256,
 		},
 		{
 			name:    "OptSignGroupSignatureConfigSHA384",
@@ -217,7 +217,7 @@ func TestNewGroupSigner(t *testing.T) {
 			})},
 			wantObjects: []uint32{1, 2},
 			wantMDHash:  crypto.SHA256,
-			wantSigHash: sif.HashSHA384,
+			wantSigHash: crypto.SHA384,
 		},
 		{
 			name:    "OptSignGroupSignatureConfigSHA512",
@@ -228,7 +228,7 @@ func TestNewGroupSigner(t *testing.T) {
 			})},
 			wantObjects: []uint32{1, 2},
 			wantMDHash:  crypto.SHA256,
-			wantSigHash: sif.HashSHA512,
+			wantSigHash: crypto.SHA512,
 		},
 		{
 			name:    "OptSignGroupSignatureConfigBLAKE2s_256",
@@ -239,7 +239,7 @@ func TestNewGroupSigner(t *testing.T) {
 			})},
 			wantObjects: []uint32{1, 2},
 			wantMDHash:  crypto.SHA256,
-			wantSigHash: sif.HashBLAKE2S,
+			wantSigHash: crypto.BLAKE2s_256,
 		},
 		{
 			name:    "OptSignGroupSignatureConfigBLAKE2b_256",
@@ -250,7 +250,7 @@ func TestNewGroupSigner(t *testing.T) {
 			})},
 			wantObjects: []uint32{1, 2},
 			wantMDHash:  crypto.SHA256,
-			wantSigHash: sif.HashBLAKE2B,
+			wantSigHash: crypto.BLAKE2b_256,
 		},
 		{
 			name:    "OptSignGroupSignatureConfigBLAKE2b_384",
@@ -261,7 +261,7 @@ func TestNewGroupSigner(t *testing.T) {
 			})},
 			wantObjects: []uint32{1, 2},
 			wantMDHash:  crypto.SHA256,
-			wantSigHash: sif.HashBLAKE2B,
+			wantSigHash: crypto.BLAKE2b_384,
 		},
 		{
 			name:    "OptSignGroupSignatureConfigBLAKE2b_512",
@@ -272,7 +272,7 @@ func TestNewGroupSigner(t *testing.T) {
 			})},
 			wantObjects: []uint32{1, 2},
 			wantMDHash:  crypto.SHA256,
-			wantSigHash: sif.HashBLAKE2B,
+			wantSigHash: crypto.BLAKE2b_512,
 		},
 	}
 

--- a/pkg/sif/descriptor.go
+++ b/pkg/sif/descriptor.go
@@ -51,7 +51,7 @@ type partition struct {
 
 // signature represents the SIF signature data object descriptor.
 type signature struct {
-	Hashtype HashType
+	Hashtype hashType
 	Entity   [DescrEntityLen]byte
 }
 
@@ -160,17 +160,17 @@ func (d rawDescriptor) isPartitionOfType(pt PartType) bool {
 var errHashUnsupported = errors.New("hash algorithm unsupported")
 
 // getHashType converts ht into a crypto.Hash.
-func getHashType(ht HashType) (crypto.Hash, error) {
+func getHashType(ht hashType) (crypto.Hash, error) {
 	switch ht {
-	case HashSHA256:
+	case hashSHA256:
 		return crypto.SHA256, nil
-	case HashSHA384:
+	case hashSHA384:
 		return crypto.SHA384, nil
-	case HashSHA512:
+	case hashSHA512:
 		return crypto.SHA512, nil
-	case HashBLAKE2S:
+	case hashBLAKE2S:
 		return crypto.BLAKE2s_256, nil
-	case HashBLAKE2B:
+	case hashBLAKE2B:
 		return crypto.BLAKE2b_256, nil
 	}
 	return 0, errHashUnsupported

--- a/pkg/sif/descriptor_input.go
+++ b/pkg/sif/descriptor_input.go
@@ -151,18 +151,18 @@ func OptPartitionMetadata(fs FSType, pt PartType, arch string) DescriptorInputOp
 }
 
 // sifHashType converts h into a HashType.
-func sifHashType(h crypto.Hash) HashType {
+func sifHashType(h crypto.Hash) hashType {
 	switch h {
 	case crypto.SHA256:
-		return HashSHA256
+		return hashSHA256
 	case crypto.SHA384:
-		return HashSHA384
+		return hashSHA384
 	case crypto.SHA512:
-		return HashSHA512
+		return hashSHA512
 	case crypto.BLAKE2s_256:
-		return HashBLAKE2S
+		return hashBLAKE2S
 	case crypto.BLAKE2b_256:
-		return HashBLAKE2B
+		return hashBLAKE2B
 	}
 	return 0
 }

--- a/pkg/sif/descriptor_input_test.go
+++ b/pkg/sif/descriptor_input_test.go
@@ -7,6 +7,7 @@ package sif
 
 import (
 	"bytes"
+	"crypto"
 	"encoding/binary"
 	"errors"
 	"testing"
@@ -138,7 +139,7 @@ func TestNewDescriptorInput(t *testing.T) {
 			name: "OptSignatureMetadataUnexpectedDataType",
 			t:    DataGeneric,
 			opts: []DescriptorInputOpt{
-				OptSignatureMetadata(HashSHA256, fp),
+				OptSignatureMetadata(crypto.SHA256, fp),
 			},
 			wantErr: &unexpectedDataTypeError{DataGeneric, DataSignature},
 		},
@@ -146,7 +147,7 @@ func TestNewDescriptorInput(t *testing.T) {
 			name: "OptSignatureMetadata",
 			t:    DataSignature,
 			opts: []DescriptorInputOpt{
-				OptSignatureMetadata(HashSHA256, fp),
+				OptSignatureMetadata(crypto.SHA256, fp),
 				OptObjectTime(testTime),
 			},
 		},

--- a/pkg/sif/descriptor_test.go
+++ b/pkg/sif/descriptor_test.go
@@ -174,7 +174,7 @@ func TestDescriptor_GetPartitionMetadata(t *testing.T) {
 
 func TestDescriptor_GetSignatureMetadata(t *testing.T) {
 	s := signature{
-		Hashtype: HashSHA384,
+		Hashtype: hashSHA384,
 	}
 	copy(s.Entity[:], []byte{
 		0x12, 0x04, 0x5c, 0x8c, 0x0b, 0x10, 0x04, 0xd0, 0x58, 0xde,

--- a/pkg/sif/descriptor_test.go
+++ b/pkg/sif/descriptor_test.go
@@ -7,6 +7,7 @@ package sif
 
 import (
 	"bytes"
+	"crypto"
 	"errors"
 	"io"
 	"os"
@@ -190,7 +191,7 @@ func TestDescriptor_GetSignatureMetadata(t *testing.T) {
 	tests := []struct {
 		name    string
 		rd      rawDescriptor
-		wantHT  HashType
+		wantHT  crypto.Hash
 		wantFP  [20]byte
 		wantErr error
 	}{
@@ -204,7 +205,7 @@ func TestDescriptor_GetSignatureMetadata(t *testing.T) {
 		{
 			name:   "OK",
 			rd:     rd,
-			wantHT: HashSHA384,
+			wantHT: crypto.SHA384,
 			wantFP: [...]byte{
 				0x12, 0x04, 0x5c, 0x8c, 0x0b, 0x10, 0x04, 0xd0, 0x58, 0xde,
 				0x4b, 0xed, 0xa2, 0x0c, 0x27, 0xee, 0x7f, 0xf7, 0xba, 0x84,

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -220,34 +220,17 @@ func (t PartType) String() string {
 	return "Unknown"
 }
 
-// HashType represents the different SIF hashing function types used to fingerprint data objects.
-type HashType int32
+// hashType represents the different SIF hashing function types used to fingerprint data objects.
+type hashType int32
 
 // List of supported hash functions.
 const (
-	HashSHA256 HashType = iota + 1
-	HashSHA384
-	HashSHA512
-	HashBLAKE2S
-	HashBLAKE2B
+	hashSHA256 hashType = iota + 1
+	hashSHA384
+	hashSHA512
+	hashBLAKE2S
+	hashBLAKE2B
 )
-
-// String returns a human-readable representation of t.
-func (t HashType) String() string {
-	switch t {
-	case HashSHA256:
-		return "SHA256"
-	case HashSHA384:
-		return "SHA384"
-	case HashSHA512:
-		return "SHA512"
-	case HashBLAKE2S:
-		return "BLAKE2S"
-	case HashBLAKE2B:
-		return "BLAKE2B"
-	}
-	return "Unknown"
-}
 
 // FormatType represents the different formats used to store cryptographic message objects.
 type FormatType int32

--- a/pkg/siftool/add.go
+++ b/pkg/siftool/add.go
@@ -8,6 +8,7 @@
 package siftool
 
 import (
+	"crypto"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -68,8 +69,8 @@ func addFlags(fs *pflag.FlagSet) {
   10-mips64le, 11-s390x`)
 	signHash = fs.Int32("signhash", 0, `the signature hash used (with -datatype 5-Signature)
 [NEEDED, no default]:
-  1-SHA256,    2-SHA384,    3-SHA512,
-  4-BLAKE2S,   5-BLAKE2B`)
+  1-SHA256,      2-SHA384,      3-SHA512,
+  4-BLAKE2s_256, 5-BLAKE2b_256`)
 	signEntity = fs.String("signentity", "", `the entity that signs (with -datatype 5-Signature)
 [NEEDED, no default]:
   example: 433FE984155206BD962725E20E8713472A879943`)
@@ -132,6 +133,23 @@ func getArch() string {
 	}
 }
 
+func getHashType() (crypto.Hash, error) {
+	switch *signHash {
+	case 1:
+		return crypto.SHA256, nil
+	case 2:
+		return crypto.SHA384, nil
+	case 3:
+		return crypto.SHA512, nil
+	case 4:
+		return crypto.BLAKE2s_256, nil
+	case 5:
+		return crypto.BLAKE2b_256, nil
+	default:
+		return 0, fmt.Errorf("invalid hash type: %v", *signHash)
+	}
+}
+
 func getOptions(dt sif.DataType, fs *pflag.FlagSet) ([]sif.DescriptorInputOpt, error) {
 	var opts []sif.DescriptorInputOpt
 
@@ -167,13 +185,18 @@ func getOptions(dt sif.DataType, fs *pflag.FlagSet) ([]sif.DescriptorInputOpt, e
 			return nil, fmt.Errorf("failed to decode signing entity fingerprint: %w", err)
 		}
 
+		ht, err := getHashType()
+		if err != nil {
+			return nil, err
+		}
+
 		var fp [20]byte
 		if got, want := len(b), len(fp); got != want {
 			return nil, fmt.Errorf("invalid signing entity fingerprint length: got %v, want %v", got, want)
 		}
 		copy(fp[:], b)
 
-		opts = append(opts, sif.OptSignatureMetadata(sif.HashType(*signHash), fp))
+		opts = append(opts, sif.OptSignatureMetadata(ht, fp))
 	}
 
 	return opts, nil

--- a/pkg/siftool/info_test.go
+++ b/pkg/siftool/info_test.go
@@ -24,13 +24,13 @@ func Test_command_getInfo(t *testing.T) {
 		},
 		{
 			name: "Two",
-			path: filepath.Join(corpus, "one-group-signed.sif"),
 			id:   "2",
+			path: filepath.Join(corpus, "one-group-signed.sif"),
 		},
 		{
 			name: "Three",
-			path: filepath.Join(corpus, "one-group-signed.sif"),
 			id:   "3",
+			path: filepath.Join(corpus, "one-group-signed.sif"),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/siftool/siftool_test.go
+++ b/pkg/siftool/siftool_test.go
@@ -48,6 +48,8 @@ func makeTestSIF(t *testing.T, withDataObject bool) string {
 }
 
 func runCommand(t *testing.T, cmd *cobra.Command, args []string) {
+	t.Helper()
+
 	var out, err bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&err)

--- a/pkg/siftool/testdata/TestAddCommands/Add/out.golden
+++ b/pkg/siftool/testdata/TestAddCommands/Add/out.golden
@@ -38,5 +38,5 @@ Flags:
                               example: 433FE984155206BD962725E20E8713472A879943
       --signhash int32      the signature hash used (with -datatype 5-Signature)
                             [NEEDED, no default]:
-                              1-SHA256,    2-SHA384,    3-SHA512,
-                              4-BLAKE2S,   5-BLAKE2B
+                              1-SHA256,      2-SHA384,      3-SHA512,
+                              4-BLAKE2s_256, 5-BLAKE2b_256

--- a/pkg/siftool/testdata/Test_command_getInfo/Three/out.golden
+++ b/pkg/siftool/testdata/Test_command_getInfo/Three/out.golden
@@ -7,5 +7,5 @@
   Ctime:     2020-06-30 00:01:56 +0000 UTC
   Mtime:     2020-06-30 00:01:56 +0000 UTC
   Name:      .
-  Hashtype:  SHA256
+  Hashtype:  SHA-256
   Entity:    12045C8C0B1004D058DE4BEDA20C27EE7FF7BA84

--- a/pkg/siftool/testdata/Test_command_getList/OneGroupSigned/out.golden
+++ b/pkg/siftool/testdata/Test_command_getList/OneGroupSigned/out.golden
@@ -7,4 +7,4 @@ ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)
 2    |1       |NONE    |36864-36868               |FS (Squashfs/*System/386)
-3    |NONE    |1   (G) |40960-41981               |Signature (SHA256)
+3    |NONE    |1   (G) |40960-41981               |Signature (SHA-256)

--- a/pkg/siftool/testdata/Test_command_getList/OneGroupSignedLegacy/out.golden
+++ b/pkg/siftool/testdata/Test_command_getList/OneGroupSignedLegacy/out.golden
@@ -7,4 +7,4 @@ ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)
 2    |1       |NONE    |36864-36868               |FS (Squashfs/*System/386)
-3    |1       |2       |40960-41569               |Signature (SHA384)
+3    |1       |2       |40960-41569               |Signature (SHA-384)

--- a/pkg/siftool/testdata/Test_command_getList/OneGroupSignedLegacyAll/out.golden
+++ b/pkg/siftool/testdata/Test_command_getList/OneGroupSignedLegacyAll/out.golden
@@ -7,5 +7,5 @@ ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)
 2    |1       |NONE    |36864-36868               |FS (Squashfs/*System/386)
-3    |1       |1       |40960-41569               |Signature (SHA384)
-4    |1       |2       |45056-45665               |Signature (SHA384)
+3    |1       |1       |40960-41569               |Signature (SHA-384)
+4    |1       |2       |45056-45665               |Signature (SHA-384)

--- a/pkg/siftool/testdata/Test_command_getList/OneGroupSignedLegacyGroup/out.golden
+++ b/pkg/siftool/testdata/Test_command_getList/OneGroupSignedLegacyGroup/out.golden
@@ -7,4 +7,4 @@ ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)
 2    |1       |NONE    |36864-36868               |FS (Squashfs/*System/386)
-3    |NONE    |1   (G) |40960-41569               |Signature (SHA384)
+3    |NONE    |1   (G) |40960-41569               |Signature (SHA-384)

--- a/pkg/siftool/testdata/Test_command_getList/TwoGroupsSigned/out.golden
+++ b/pkg/siftool/testdata/Test_command_getList/TwoGroupsSigned/out.golden
@@ -8,5 +8,5 @@ ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)
 2    |1       |NONE    |36864-36868               |FS (Squashfs/*System/386)
 3    |2       |NONE    |40960-40964               |FS (Ext3/System/amd64)
-4    |NONE    |1   (G) |45056-46077               |Signature (SHA256)
-5    |NONE    |2   (G) |49152-49974               |Signature (SHA256)
+4    |NONE    |1   (G) |45056-46077               |Signature (SHA-256)
+5    |NONE    |2   (G) |49152-49974               |Signature (SHA-256)

--- a/pkg/siftool/testdata/Test_command_getList/TwoGroupsSignedLegacy/out.golden
+++ b/pkg/siftool/testdata/Test_command_getList/TwoGroupsSignedLegacy/out.golden
@@ -8,4 +8,4 @@ ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)
 2    |1       |NONE    |36864-36868               |FS (Squashfs/*System/386)
 3    |2       |NONE    |40960-40964               |FS (Ext3/System/amd64)
-4    |1       |2       |45056-45665               |Signature (SHA384)
+4    |1       |2       |45056-45665               |Signature (SHA-384)

--- a/pkg/siftool/testdata/Test_command_getList/TwoGroupsSignedLegacyAll/out.golden
+++ b/pkg/siftool/testdata/Test_command_getList/TwoGroupsSignedLegacyAll/out.golden
@@ -8,5 +8,5 @@ ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)
 2    |1       |NONE    |36864-36868               |FS (Squashfs/*System/386)
 3    |2       |NONE    |40960-40964               |FS (Ext3/System/amd64)
-4    |1       |1       |45056-45665               |Signature (SHA384)
-5    |1       |2       |49152-49761               |Signature (SHA384)
+4    |1       |1       |45056-45665               |Signature (SHA-384)
+5    |1       |2       |49152-49761               |Signature (SHA-384)

--- a/pkg/siftool/testdata/Test_command_getList/TwoGroupsSignedLegacyGroup/out.golden
+++ b/pkg/siftool/testdata/Test_command_getList/TwoGroupsSignedLegacyGroup/out.golden
@@ -8,4 +8,4 @@ ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)
 2    |1       |NONE    |36864-36868               |FS (Squashfs/*System/386)
 3    |2       |NONE    |40960-40964               |FS (Ext3/System/amd64)
-4    |NONE    |1   (G) |45056-45665               |Signature (SHA384)
+4    |NONE    |1   (G) |45056-45665               |Signature (SHA-384)


### PR DESCRIPTION
Use [`crypto.Hash`](https://pkg.go.dev/crypto#Hash) types in exported API.

Closes #76 