### PR TITLE
Small Clean Up

### DIFF
--- a/pkg/sif/create.go
+++ b/pkg/sif/create.go
@@ -102,7 +102,7 @@ func (f *FileImage) writeDataObject(di DescriptorInput) error {
 
 // writeDescriptors writes the descriptors in f to backing storage.
 func (f *FileImage) writeDescriptors() error {
-	if _, err := f.rw.Seek(DescrStartOffset, io.SeekStart); err != nil {
+	if _, err := f.rw.Seek(descrStartOffset, io.SeekStart); err != nil {
 		return err
 	}
 
@@ -167,10 +167,10 @@ func createContainer(rw ReadWriter, co createOpts) (*FileImage, error) {
 		ID:       co.id,
 		Ctime:    co.t.Unix(),
 		Mtime:    co.t.Unix(),
-		Dfree:    DescrNumEntries,
-		Dtotal:   DescrNumEntries,
-		Descroff: DescrStartOffset,
-		Dataoff:  DataStartOffset,
+		Dfree:    descrNumEntries,
+		Dtotal:   descrNumEntries,
+		Descroff: descrStartOffset,
+		Dataoff:  dataStartOffset,
 	}
 	copy(h.Launch[:], hdrLaunch)
 	copy(h.Magic[:], hdrMagic)
@@ -179,10 +179,10 @@ func createContainer(rw ReadWriter, co createOpts) (*FileImage, error) {
 	f := &FileImage{
 		h:   h,
 		rw:  rw,
-		rds: make([]rawDescriptor, DescrNumEntries),
+		rds: make([]rawDescriptor, descrNumEntries),
 	}
 
-	if _, err := f.rw.Seek(DataStartOffset, io.SeekStart); err != nil {
+	if _, err := f.rw.Seek(dataStartOffset, io.SeekStart); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sif/descriptor.go
+++ b/pkg/sif/descriptor.go
@@ -38,8 +38,8 @@ type rawDescriptor struct {
 	Mtime int64                 // last modification time
 	UID   int64                 // Deprecated: UID exists for historical compatibility and should not be used.
 	GID   int64                 // Deprecated: GID exists for historical compatibility and should not be used.
-	Name  [DescrNameLen]byte    // descriptor name (string identifier)
-	Extra [DescrMaxPrivLen]byte // big enough for extra data below
+	Name  [descrNameLen]byte    // descriptor name (string identifier)
+	Extra [descrMaxPrivLen]byte // big enough for extra data below
 }
 
 // partition represents the SIF partition data object descriptor.
@@ -52,7 +52,7 @@ type partition struct {
 // signature represents the SIF signature data object descriptor.
 type signature struct {
 	Hashtype hashType
-	Entity   [DescrEntityLen]byte
+	Entity   [descrEntityLen]byte
 }
 
 // cryptoMessage represents the SIF crypto message object descriptor.
@@ -108,13 +108,13 @@ func (d rawDescriptor) GetID() uint32 { return d.ID }
 
 // GetGroupID returns the data object group ID of d, or zero if d is not part of a data object
 // group.
-func (d rawDescriptor) GetGroupID() uint32 { return d.Groupid &^ DescrGroupMask }
+func (d rawDescriptor) GetGroupID() uint32 { return d.Groupid &^ descrGroupMask }
 
 // GetLinkedID returns the object/group ID d is linked to, or zero if d does not contain a linked
 // ID. If isGroup is true, the returned id is an object group ID. Otherwise, the returned id is a
 // data object ID.
 func (d rawDescriptor) GetLinkedID() (id uint32, isGroup bool) {
-	return d.Link &^ DescrGroupMask, d.Link&DescrGroupMask == DescrGroupMask
+	return d.Link &^ descrGroupMask, d.Link&descrGroupMask == descrGroupMask
 }
 
 // GetOffset returns the offset of the data object.

--- a/pkg/sif/descriptor_input.go
+++ b/pkg/sif/descriptor_input.go
@@ -56,7 +56,7 @@ func OptLinkedGroupID(groupID uint32) DescriptorInputOpt {
 		if groupID == 0 {
 			return ErrInvalidGroupID
 		}
-		opts.linkID = groupID | DescrGroupMask
+		opts.linkID = groupID | descrGroupMask
 		return nil
 	}
 }
@@ -232,7 +232,7 @@ func NewDescriptorInput(t DataType, r io.Reader, opts ...DescriptorInputOpt) (De
 // fillDescriptor fills d according to di.
 func (di DescriptorInput) fillDescriptor(d *rawDescriptor) error {
 	d.Datatype = di.dt
-	d.Groupid = di.opts.groupID | DescrGroupMask
+	d.Groupid = di.opts.groupID | descrGroupMask
 	d.Link = di.opts.linkID
 	d.Ctime = di.opts.t.UTC().Unix()
 	d.Mtime = di.opts.t.UTC().Unix()

--- a/pkg/sif/descriptor_test.go
+++ b/pkg/sif/descriptor_test.go
@@ -293,7 +293,7 @@ func TestDescriptor_GetIntegrityReader(t *testing.T) {
 		Datatype: DataDeffile,
 		Used:     true,
 		ID:       1,
-		Groupid:  DescrGroupMask | 1,
+		Groupid:  descrGroupMask | 1,
 		Ctime:    1504657553,
 		Mtime:    1504657553,
 	}

--- a/pkg/sif/select_test.go
+++ b/pkg/sif/select_test.go
@@ -16,22 +16,22 @@ func TestFileImage_GetDescriptors(t *testing.T) {
 			Datatype: DataPartition,
 			Used:     true,
 			ID:       1,
-			Groupid:  1 | DescrGroupMask,
-			Link:     DescrUnusedLink,
+			Groupid:  1 | descrGroupMask,
+			Link:     descrUnusedLink,
 		},
 		{
 			Datatype: DataSignature,
 			Used:     true,
 			ID:       2,
-			Groupid:  1 | DescrGroupMask,
+			Groupid:  1 | descrGroupMask,
 			Link:     1,
 		},
 		{
 			Datatype: DataSignature,
 			Used:     true,
 			ID:       3,
-			Groupid:  DescrUnusedGroup,
-			Link:     1 | DescrGroupMask,
+			Groupid:  descrUnusedGroup,
+			Link:     1 | descrGroupMask,
 		},
 	}
 
@@ -138,8 +138,8 @@ func TestFileImage_GetDescriptor(t *testing.T) {
 		Datatype: DataPartition,
 		Used:     true,
 		ID:       1,
-		Groupid:  1 | DescrGroupMask,
-		Link:     DescrUnusedLink,
+		Groupid:  1 | descrGroupMask,
+		Link:     descrUnusedLink,
 	}
 
 	p := partition{
@@ -158,15 +158,15 @@ func TestFileImage_GetDescriptor(t *testing.T) {
 			Datatype: DataSignature,
 			Used:     true,
 			ID:       2,
-			Groupid:  1 | DescrGroupMask,
+			Groupid:  1 | descrGroupMask,
 			Link:     1,
 		},
 		{
 			Datatype: DataSignature,
 			Used:     true,
 			ID:       3,
-			Groupid:  DescrUnusedGroup,
-			Link:     1 | DescrGroupMask,
+			Groupid:  descrUnusedGroup,
+			Link:     1 | descrGroupMask,
 		},
 	}
 
@@ -233,22 +233,22 @@ func TestFileImage_WithDescriptors(t *testing.T) {
 			Datatype: DataPartition,
 			Used:     true,
 			ID:       1,
-			Groupid:  1 | DescrGroupMask,
-			Link:     DescrUnusedLink,
+			Groupid:  1 | descrGroupMask,
+			Link:     descrUnusedLink,
 		},
 		{
 			Datatype: DataSignature,
 			Used:     true,
 			ID:       2,
-			Groupid:  DescrUnusedGroup,
-			Link:     1 | DescrGroupMask,
+			Groupid:  descrUnusedGroup,
+			Link:     1 | descrGroupMask,
 		},
 		{
 			Datatype: DataSignature,
 			Used:     false,
 			ID:       3,
-			Groupid:  DescrUnusedGroup,
-			Link:     DescrUnusedLink,
+			Groupid:  descrUnusedGroup,
+			Link:     descrUnusedLink,
 		},
 	}
 

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -7,13 +7,6 @@
 
 // Package sif implements data structures and routines to create
 // and access SIF files.
-// 	- sif.go contains the data definition the file format.
-//	- create.go implements the core functionality for the creation of
-//	  of new SIF files.
-//	- load.go implements the core functionality for the loading of
-//	  existing SIF files.
-//	- lookup.go mostly implements search/lookup and printing routines
-//	  and access to specific descriptor/data found in SIF container files.
 //
 // Layout of a SIF file (example):
 //

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -108,16 +108,15 @@ const (
 const CurrentVersion = version01
 
 const (
-	DescrNumEntries   = 48                 // the default total number of available descriptors
-	DescrGroupMask    = 0xf0000000         // groups start at that offset
-	DescrUnusedGroup  = DescrGroupMask     // descriptor without a group
-	DescrDefaultGroup = DescrGroupMask | 1 // first groupid number created
-	DescrUnusedLink   = 0                  // descriptor without link to other
-	DescrEntityLen    = 256                // len("Joe Bloe <jbloe@gmail.com>...")
-	DescrNameLen      = 128                // descriptor name (string identifier)
-	DescrMaxPrivLen   = 384                // size reserved for descriptor specific data
-	DescrStartOffset  = 4096               // where descriptors start after global header
-	DataStartOffset   = 32768              // where data object start after descriptors
+	descrNumEntries  = 48             // the default total number of available descriptors
+	descrGroupMask   = 0xf0000000     // groups start at that offset
+	descrUnusedGroup = descrGroupMask // descriptor without a group
+	descrUnusedLink  = 0              // descriptor without link to other
+	descrEntityLen   = 256            // len("Joe Bloe <jbloe@gmail.com>...")
+	descrNameLen     = 128            // descriptor name (string identifier)
+	descrMaxPrivLen  = 384            // size reserved for descriptor specific data
+	descrStartOffset = 4096           // where descriptors start after global header
+	dataStartOffset  = 32768          // where data object start after descriptors
 )
 
 // DataType represents the different SIF data object types stored in the image.


### PR DESCRIPTION
Clean up package comment, and don't export unnecessary `const`s.