### PR TITLE
Hide rawDescriptor Internals

### DIFF
--- a/internal/app/siftool/info.go
+++ b/internal/app/siftool/info.go
@@ -19,15 +19,15 @@ import (
 )
 
 // readableSize returns the size in human readable format.
-func readableSize(size uint64) string {
-	if size < 1024 {
+func readableSize(size int64) string {
+	if -1024 < size && size < 1024 {
 		return fmt.Sprintf("%d B", size)
 	}
 
 	units := "KMGTPE"
 
 	div, exp := uint64(1024), 0
-	for n := size / 1024; (n >= 1024) && (exp < len(units)-1); n /= 1024 {
+	for n := size / 1024; (n <= -1024) || (1024 <= n); n /= 1024 {
 		div *= 1024
 		exp++
 	}

--- a/internal/app/siftool/info.go
+++ b/internal/app/siftool/info.go
@@ -148,7 +148,7 @@ func writeInfo(w io.Writer, v sif.Descriptor) error {
 	fmt.Fprintln(tw, "  Ctime:\t", v.CreatedAt())
 	fmt.Fprintln(tw, "  Mtime:\t", v.ModifiedAt())
 	fmt.Fprintln(tw, "  Name:\t", v.GetName())
-	switch v.Datatype {
+	switch v.GetDataType() {
 	case sif.DataPartition:
 		fs, pt, arch, _ := v.GetPartitionMetadata()
 		fmt.Fprintln(tw, "  Fstype:\t", fs)

--- a/internal/app/siftool/info_test.go
+++ b/internal/app/siftool/info_test.go
@@ -19,7 +19,7 @@ var corpus = filepath.Join("..", "..", "..", "pkg", "integrity", "testdata", "im
 func Test_readableSize(t *testing.T) {
 	tests := []struct {
 		name string
-		size uint64
+		size int64
 		want string
 	}{
 		{

--- a/pkg/integrity/metadata.go
+++ b/pkg/integrity/metadata.go
@@ -138,13 +138,13 @@ func (om objectMetadata) matches(f *sif.FileImage, od sif.Descriptor) error {
 	if ok, err := om.DescriptorDigest.matches(od.GetIntegrityReader(om.RelativeID)); err != nil {
 		return err
 	} else if !ok {
-		return &DescriptorIntegrityError{ID: od.GetID()}
+		return &DescriptorIntegrityError{ID: od.ID()}
 	}
 
 	if ok, err := om.ObjectDigest.matches(od.GetReader(f)); err != nil {
 		return err
 	} else if !ok {
-		return &ObjectIntegrityError{ID: od.GetID()}
+		return &ObjectIntegrityError{ID: od.ID()}
 	}
 	return nil
 }
@@ -175,7 +175,7 @@ func getImageMetadata(f *sif.FileImage, minID uint32, ods []sif.Descriptor, h cr
 
 	// Add object descriptor/data metadata.
 	for _, od := range ods {
-		id := od.GetID()
+		id := od.ID()
 
 		if id < minID { // shouldn't really be possible...
 			return imageMetadata{}, errMinimumIDInvalid
@@ -211,7 +211,7 @@ func (im imageMetadata) objectIDsMatch(ods []sif.Descriptor) error {
 
 	// Check each object in ods exists in ids, and mark as seen.
 	for _, od := range ods {
-		id := od.GetID()
+		id := od.ID()
 		if _, ok := ids[id]; !ok {
 			return fmt.Errorf("object %d: %w", id, errObjectNotSigned)
 		}
@@ -252,7 +252,7 @@ func (im imageMetadata) matches(f *sif.FileImage, ods []sif.Descriptor) ([]uint3
 
 	// Verify data object metadata.
 	for _, od := range ods {
-		id := od.GetID()
+		id := od.ID()
 
 		om, err := im.metadataForObject(id)
 		if err != nil {

--- a/pkg/integrity/result.go
+++ b/pkg/integrity/result.go
@@ -64,7 +64,7 @@ func (r legacyResult) Signature() uint32 {
 func (r legacyResult) Signed() []uint32 {
 	ids := make([]uint32, 0, len(r.ods))
 	for _, om := range r.ods {
-		ids = append(ids, om.GetID())
+		ids = append(ids, om.ID())
 	}
 	return ids
 }

--- a/pkg/integrity/select.go
+++ b/pkg/integrity/select.go
@@ -133,11 +133,11 @@ func getGroupMinObjectID(f *sif.FileImage, groupID uint32) (uint32, error) {
 	minID := ^uint32(0)
 
 	f.WithDescriptors(func(od sif.Descriptor) bool {
-		if od.GetGroupID() != groupID {
+		if od.GroupID() != groupID {
 			return false
 		}
 
-		if id := od.GetID(); id < minID {
+		if id := od.ID(); id < minID {
 			minID = id
 		}
 		return false
@@ -153,7 +153,7 @@ func getGroupMinObjectID(f *sif.FileImage, groupID uint32) (uint32, error) {
 // are present, errNoGroupsFound is returned.
 func getGroupIDs(f *sif.FileImage) (groupIDs []uint32, err error) {
 	f.WithDescriptors(func(od sif.Descriptor) bool {
-		if groupID := od.GetGroupID(); groupID != 0 {
+		if groupID := od.GroupID(); groupID != 0 {
 			groupIDs = insertSorted(groupIDs, groupID)
 		}
 		return false
@@ -171,7 +171,7 @@ func getFingerprints(sigs []sif.Descriptor) ([][20]byte, error) {
 	fps := make([][20]byte, 0, len(sigs))
 
 	for _, sig := range sigs {
-		_, fp, err := sig.GetSignatureMetadata()
+		_, fp, err := sig.SignatureMetadata()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/integrity/sign.go
+++ b/pkg/integrity/sign.go
@@ -123,13 +123,13 @@ func newGroupSigner(f *sif.FileImage, groupID uint32, opts ...groupSignerOpt) (*
 
 // addObject adds od to the list of object descriptors to be signed.
 func (gs *groupSigner) addObject(od sif.Descriptor) error {
-	if groupID := od.GetGroupID(); groupID != gs.id {
+	if groupID := od.GroupID(); groupID != gs.id {
 		return fmt.Errorf("%w (%v)", errUnexpectedGroupID, groupID)
 	}
 
 	// Insert into sorted descriptor list, if not already present.
-	i := sort.Search(len(gs.ods), func(i int) bool { return gs.ods[i].GetID() >= od.GetID() })
-	if i < len(gs.ods) && gs.ods[i].GetID() == od.GetID() {
+	i := sort.Search(len(gs.ods), func(i int) bool { return gs.ods[i].ID() >= od.ID() })
+	if i < len(gs.ods) && gs.ods[i].ID() == od.ID() {
 		return nil
 	}
 	gs.ods = append(gs.ods, sif.Descriptor{})
@@ -229,7 +229,7 @@ func OptSignObjects(ids ...uint32) SignerOpt {
 
 			// Note the group ID if it hasn't been seen before, and append the object ID to the
 			// appropriate group in the map.
-			groupID := od.GetGroupID()
+			groupID := od.GroupID()
 			if _, ok := groupObjectIDs[groupID]; !ok {
 				groupIDs = append(groupIDs, groupID)
 			}

--- a/pkg/integrity/sign_test.go
+++ b/pkg/integrity/sign_test.go
@@ -87,7 +87,7 @@ func TestOptSignGroupObjects(t *testing.T) {
 			if err == nil {
 				var got []uint32
 				for _, od := range gs.ods {
-					got = append(got, od.GetID())
+					got = append(got, od.ID())
 				}
 				if want := tt.ids; !reflect.DeepEqual(got, want) {
 					t.Errorf("got objects %v, want %v", got, want)
@@ -295,7 +295,7 @@ func TestNewGroupSigner(t *testing.T) {
 
 				var got []uint32
 				for _, od := range s.ods {
-					got = append(got, od.GetID())
+					got = append(got, od.ID())
 				}
 				if want := tt.wantObjects; !reflect.DeepEqual(got, want) {
 					t.Errorf("got objects %v, want %v", got, want)
@@ -450,15 +450,15 @@ func TestGroupSigner_SignWithEntity(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				if got, want := od.GetDataType(), sif.DataSignature; got != want {
+				if got, want := od.DataType(), sif.DataSignature; got != want {
 					t.Errorf("got data type %v, want %v", got, want)
 				}
 
-				if got, want := od.GetGroupID(), uint32(0); got != want {
+				if got, want := od.GroupID(), uint32(0); got != want {
 					t.Errorf("got group ID %v, want %v", got, want)
 				}
 
-				id, isGroup := od.GetLinkedID()
+				id, isGroup := od.LinkedID()
 				if got, want := isGroup, true; got != want {
 					t.Errorf("got link isGroup %v, want %v", got, want)
 				}
@@ -617,7 +617,7 @@ func TestOptSignObjects(t *testing.T) {
 					} else {
 						var got []uint32
 						for _, od := range gs.ods {
-							got = append(got, od.GetID())
+							got = append(got, od.ID())
 						}
 
 						if !reflect.DeepEqual(got, want) {
@@ -778,7 +778,7 @@ func TestNewSigner(t *testing.T) {
 					} else {
 						var got []uint32
 						for _, od := range signer.ods {
-							got = append(got, od.GetID())
+							got = append(got, od.ID())
 						}
 
 						if !reflect.DeepEqual(got, want) {

--- a/pkg/sif/create.go
+++ b/pkg/sif/create.go
@@ -318,7 +318,7 @@ func (f *FileImage) AddObject(input DescriptorInput) error {
 func objectIsLast(f *FileImage, d *rawDescriptor) bool {
 	isLast := true
 
-	end := d.GetOffset() + d.GetSize()
+	end := d.Fileoff + d.Filelen
 	f.WithDescriptors(func(d Descriptor) bool {
 		isLast = d.GetOffset()+d.GetSize() <= end
 		return !isLast
@@ -441,7 +441,7 @@ func (f *FileImage) SetPrimPart(id uint32) error {
 		return fmt.Errorf("not a volume partition")
 	}
 
-	fs, pt, arch, err := descr.GetPartitionMetadata()
+	fs, pt, arch, err := descr.getPartitionMetadata()
 	if err != nil {
 		return err
 	}
@@ -474,7 +474,7 @@ func (f *FileImage) SetPrimPart(id uint32) error {
 	}
 
 	if olddescr != nil {
-		oldfs, _, oldarch, err := olddescr.GetPartitionMetadata()
+		oldfs, _, oldarch, err := olddescr.getPartitionMetadata()
 		if err != nil {
 			return err
 		}

--- a/pkg/sif/create.go
+++ b/pkg/sif/create.go
@@ -320,7 +320,7 @@ func objectIsLast(f *FileImage, d *rawDescriptor) bool {
 
 	end := d.Fileoff + d.Filelen
 	f.WithDescriptors(func(d Descriptor) bool {
-		isLast = d.GetOffset()+d.GetSize() <= end
+		isLast = d.Offset()+d.Size() <= end
 		return !isLast
 	})
 

--- a/pkg/sif/create_test.go
+++ b/pkg/sif/create_test.go
@@ -244,7 +244,7 @@ func TestSetPrimPart(t *testing.T) {
 			t.Error("fimg.SetPrimPart(...):", err)
 		}
 
-		if part, err := fimg.GetDescriptor(WithPartitionType(PartPrimSys)); err != nil {
+		if part, err := fimg.getDescriptor(WithPartitionType(PartPrimSys)); err != nil {
 			t.Fatal(err)
 		} else if want, got := part.ID, fimg.rds[i].ID; got != want {
 			t.Errorf("got ID %v, want %v", got, want)

--- a/pkg/sif/descriptor.go
+++ b/pkg/sif/descriptor.go
@@ -125,28 +125,28 @@ type Descriptor struct {
 	raw rawDescriptor
 }
 
-// GetDataType returns the type of data object.
-func (d Descriptor) GetDataType() DataType { return d.raw.Datatype }
+// DataType returns the type of data object.
+func (d Descriptor) DataType() DataType { return d.raw.Datatype }
 
-// GetID returns the data object ID of d.
-func (d Descriptor) GetID() uint32 { return d.raw.ID }
+// ID returns the data object ID of d.
+func (d Descriptor) ID() uint32 { return d.raw.ID }
 
-// GetGroupID returns the data object group ID of d, or zero if d is not part of a data object
+// GroupID returns the data object group ID of d, or zero if d is not part of a data object
 // group.
-func (d Descriptor) GetGroupID() uint32 { return d.raw.Groupid &^ descrGroupMask }
+func (d Descriptor) GroupID() uint32 { return d.raw.Groupid &^ descrGroupMask }
 
-// GetLinkedID returns the object/group ID d is linked to, or zero if d does not contain a linked
+// LinkedID returns the object/group ID d is linked to, or zero if d does not contain a linked
 // ID. If isGroup is true, the returned id is an object group ID. Otherwise, the returned id is a
 // data object ID.
-func (d Descriptor) GetLinkedID() (id uint32, isGroup bool) {
+func (d Descriptor) LinkedID() (id uint32, isGroup bool) {
 	return d.raw.Link &^ descrGroupMask, d.raw.Link&descrGroupMask == descrGroupMask
 }
 
-// GetOffset returns the offset of the data object.
-func (d Descriptor) GetOffset() int64 { return d.raw.Fileoff }
+// Offset returns the offset of the data object.
+func (d Descriptor) Offset() int64 { return d.raw.Fileoff }
 
-// GetSize returns the data object size.
-func (d Descriptor) GetSize() int64 { return d.raw.Filelen }
+// Size returns the data object size.
+func (d Descriptor) Size() int64 { return d.raw.Filelen }
 
 // CreatedAt returns the creation time of the data object.
 func (d Descriptor) CreatedAt() time.Time { return time.Unix(d.raw.Ctime, 0).UTC() }
@@ -154,11 +154,11 @@ func (d Descriptor) CreatedAt() time.Time { return time.Unix(d.raw.Ctime, 0).UTC
 // ModifiedAt returns the modification time of the data object.
 func (d Descriptor) ModifiedAt() time.Time { return time.Unix(d.raw.Mtime, 0).UTC() }
 
-// GetName returns the name tag associated with the descriptor. Analogous to file name.
-func (d Descriptor) GetName() string { return strings.TrimRight(string(d.raw.Name[:]), "\000") }
+// Name returns the name of the data object.
+func (d Descriptor) Name() string { return strings.TrimRight(string(d.raw.Name[:]), "\000") }
 
-// GetPartitionMetadata gets metadata for a partition data object.
-func (d Descriptor) GetPartitionMetadata() (fs FSType, pt PartType, arch string, err error) {
+// PartitionMetadata gets metadata for a partition data object.
+func (d Descriptor) PartitionMetadata() (fs FSType, pt PartType, arch string, err error) {
 	return d.raw.getPartitionMetadata()
 }
 
@@ -181,8 +181,8 @@ func getHashType(ht hashType) (crypto.Hash, error) {
 	return 0, errHashUnsupported
 }
 
-// GetSignatureMetadata gets metadata for a signature data object.
-func (d Descriptor) GetSignatureMetadata() (ht crypto.Hash, fp [20]byte, err error) {
+// SignatureMetadata gets metadata for a signature data object.
+func (d Descriptor) SignatureMetadata() (ht crypto.Hash, fp [20]byte, err error) {
 	if got, want := d.raw.Datatype, DataSignature; got != want {
 		return ht, fp, &unexpectedDataTypeError{got, want}
 	}
@@ -203,8 +203,8 @@ func (d Descriptor) GetSignatureMetadata() (ht crypto.Hash, fp [20]byte, err err
 	return ht, fp, nil
 }
 
-// GetCryptoMessageMetadata gets metadata for a crypto message data object.
-func (d Descriptor) GetCryptoMessageMetadata() (FormatType, MessageType, error) {
+// CryptoMessageMetadata gets metadata for a crypto message data object.
+func (d Descriptor) CryptoMessageMetadata() (FormatType, MessageType, error) {
 	if got, want := d.raw.Datatype, DataCryptoMessage; got != want {
 		return 0, 0, &unexpectedDataTypeError{got, want}
 	}

--- a/pkg/sif/descriptor_test.go
+++ b/pkg/sif/descriptor_test.go
@@ -68,7 +68,7 @@ func TestDescriptor_GetReader(t *testing.T) {
 	}
 
 	// Read data via Reader and validate data.
-	b := make([]byte, descr.Filelen)
+	b := make([]byte, descr.GetSize())
 	if _, err := io.ReadFull(descr.GetReader(f), b); err != nil {
 		t.Fatalf("failed to read: %v", err)
 	}
@@ -149,7 +149,9 @@ func TestDescriptor_GetPartitionMetadata(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fs, part, arch, err := tt.rd.GetPartitionMetadata()
+			d := Descriptor{raw: tt.rd}
+
+			fs, part, arch, err := d.GetPartitionMetadata()
 
 			if got, want := err, tt.wantErr; !errors.Is(got, want) {
 				t.Fatalf("got error %v, want %v", got, want)
@@ -214,7 +216,9 @@ func TestDescriptor_GetSignatureMetadata(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ht, fp, err := tt.rd.GetSignatureMetadata()
+			d := Descriptor{raw: tt.rd}
+
+			ht, fp, err := d.GetSignatureMetadata()
 
 			if got, want := err, tt.wantErr; !errors.Is(got, want) {
 				t.Fatalf("got error %v, want %v", got, want)
@@ -269,7 +273,9 @@ func TestDescriptor_GetCryptoMessageMetadata(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ft, mt, err := tt.rd.GetCryptoMessageMetadata()
+			d := Descriptor{raw: tt.rd}
+
+			ft, mt, err := d.GetCryptoMessageMetadata()
 
 			if got, want := err, tt.wantErr; !errors.Is(got, want) {
 				t.Fatalf("got error %v, want %v", got, want)
@@ -289,7 +295,7 @@ func TestDescriptor_GetCryptoMessageMetadata(t *testing.T) {
 }
 
 func TestDescriptor_GetIntegrityReader(t *testing.T) {
-	d := rawDescriptor{
+	rd := rawDescriptor{
 		Datatype: DataDeffile,
 		Used:     true,
 		ID:       1,
@@ -297,8 +303,8 @@ func TestDescriptor_GetIntegrityReader(t *testing.T) {
 		Ctime:    1504657553,
 		Mtime:    1504657553,
 	}
-	copy(d.Name[:], "GOOD_NAME")
-	copy(d.Extra[:], "GOOD_EXTRA")
+	copy(rd.Name[:], "GOOD_NAME")
+	copy(rd.Extra[:], "GOOD_EXTRA")
 
 	tests := []struct {
 		name       string
@@ -370,9 +376,9 @@ func TestDescriptor_GetIntegrityReader(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			d := d
+			d := Descriptor{raw: rd}
 			if tt.modFunc != nil {
-				tt.modFunc(&d)
+				tt.modFunc(&d.raw)
 			}
 
 			b := bytes.Buffer{}

--- a/pkg/sif/descriptor_test.go
+++ b/pkg/sif/descriptor_test.go
@@ -68,7 +68,7 @@ func TestDescriptor_GetReader(t *testing.T) {
 	}
 
 	// Read data via Reader and validate data.
-	b := make([]byte, descr.GetSize())
+	b := make([]byte, descr.Size())
 	if _, err := io.ReadFull(descr.GetReader(f), b); err != nil {
 		t.Fatalf("failed to read: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestDescriptor_GetName(t *testing.T) {
 		t.Error("multiple partitions found where expecting 1")
 	}
 
-	if parts[0].GetName() != "busybox.squash" {
+	if parts[0].Name() != "busybox.squash" {
 		t.Error(`parts[0].GetName() != "busybox.squash"`)
 	}
 
@@ -151,7 +151,7 @@ func TestDescriptor_GetPartitionMetadata(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			d := Descriptor{raw: tt.rd}
 
-			fs, part, arch, err := d.GetPartitionMetadata()
+			fs, part, arch, err := d.PartitionMetadata()
 
 			if got, want := err, tt.wantErr; !errors.Is(got, want) {
 				t.Fatalf("got error %v, want %v", got, want)
@@ -218,7 +218,7 @@ func TestDescriptor_GetSignatureMetadata(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			d := Descriptor{raw: tt.rd}
 
-			ht, fp, err := d.GetSignatureMetadata()
+			ht, fp, err := d.SignatureMetadata()
 
 			if got, want := err, tt.wantErr; !errors.Is(got, want) {
 				t.Fatalf("got error %v, want %v", got, want)
@@ -275,7 +275,7 @@ func TestDescriptor_GetCryptoMessageMetadata(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			d := Descriptor{raw: tt.rd}
 
-			ft, mt, err := d.GetCryptoMessageMetadata()
+			ft, mt, err := d.CryptoMessageMetadata()
 
 			if got, want := err, tt.wantErr; !errors.Is(got, want) {
 				t.Fatalf("got error %v, want %v", got, want)

--- a/pkg/sif/load.go
+++ b/pkg/sif/load.go
@@ -38,7 +38,7 @@ func readDescriptors(r io.ReaderAt, fimg *FileImage) error {
 		return fmt.Errorf("reading descriptor array from container file: %s", err)
 	}
 
-	if d, err := fimg.GetDescriptor(WithPartitionType(PartPrimSys)); err == nil {
+	if d, err := fimg.getDescriptor(WithPartitionType(PartPrimSys)); err == nil {
 		fimg.primPartID = d.ID
 	}
 

--- a/pkg/sif/select.go
+++ b/pkg/sif/select.go
@@ -85,7 +85,7 @@ func WithLinkedGroupID(groupID uint32) DescriptorSelectorFunc {
 // WithPartitionType selects descriptors containing a partition of type pt.
 func WithPartitionType(pt PartType) DescriptorSelectorFunc {
 	return func(d Descriptor) (bool, error) {
-		return d.isPartitionOfType(pt), nil
+		return d.raw.isPartitionOfType(pt), nil
 	}
 }
 

--- a/pkg/sif/select.go
+++ b/pkg/sif/select.go
@@ -28,7 +28,7 @@ type DescriptorSelectorFunc func(d Descriptor) (bool, error)
 // WithDataType selects descriptors that have data type dt.
 func WithDataType(dt DataType) DescriptorSelectorFunc {
 	return func(d Descriptor) (bool, error) {
-		return d.GetDataType() == dt, nil
+		return d.DataType() == dt, nil
 	}
 }
 
@@ -38,14 +38,14 @@ func WithID(id uint32) DescriptorSelectorFunc {
 		if id == 0 {
 			return false, ErrInvalidObjectID
 		}
-		return d.GetID() == id, nil
+		return d.ID() == id, nil
 	}
 }
 
 // WithNoGroup selects descriptors that are not contained within an object group.
 func WithNoGroup() DescriptorSelectorFunc {
 	return func(d Descriptor) (bool, error) {
-		return d.GetGroupID() == 0, nil
+		return d.GroupID() == 0, nil
 	}
 }
 
@@ -55,7 +55,7 @@ func WithGroupID(groupID uint32) DescriptorSelectorFunc {
 		if groupID == 0 {
 			return false, ErrInvalidGroupID
 		}
-		return d.GetGroupID() == groupID, nil
+		return d.GroupID() == groupID, nil
 	}
 }
 
@@ -65,7 +65,7 @@ func WithLinkedID(id uint32) DescriptorSelectorFunc {
 		if id == 0 {
 			return false, ErrInvalidObjectID
 		}
-		linkedID, isGroup := d.GetLinkedID()
+		linkedID, isGroup := d.LinkedID()
 		return !isGroup && linkedID == id, nil
 	}
 }
@@ -77,7 +77,7 @@ func WithLinkedGroupID(groupID uint32) DescriptorSelectorFunc {
 		if groupID == 0 {
 			return false, ErrInvalidGroupID
 		}
-		linkedID, isGroup := d.GetLinkedID()
+		linkedID, isGroup := d.LinkedID()
 		return isGroup && linkedID == groupID, nil
 	}
 }

--- a/pkg/sif/select_test.go
+++ b/pkg/sif/select_test.go
@@ -125,7 +125,7 @@ func TestFileImage_GetDescriptors(t *testing.T) {
 				t.Errorf("got %v IDs, want %v", got, want)
 			}
 			for i := range ds {
-				if got, want := ds[i].GetID(), tt.wantIDs[i]; got != want {
+				if got, want := ds[i].ID(), tt.wantIDs[i]; got != want {
 					t.Errorf("got ID %v, want %v", got, want)
 				}
 			}
@@ -220,7 +220,7 @@ func TestFileImage_GetDescriptor(t *testing.T) {
 			if got, want := err, tt.wantErr; !errors.Is(got, want) {
 				t.Fatalf("got error %v, want %v", got, want)
 			}
-			if got, want := d.GetID(), tt.wantID; got != want {
+			if got, want := d.ID(), tt.wantID; got != want {
 				t.Errorf("got ID %v, want %v", got, want)
 			}
 		})
@@ -260,7 +260,7 @@ func TestFileImage_WithDescriptors(t *testing.T) {
 			name: "ReturnTrue",
 			fn: func(t *testing.T) func(d Descriptor) bool {
 				return func(d Descriptor) bool {
-					if id := d.GetID(); id > 1 {
+					if id := d.ID(); id > 1 {
 						t.Errorf("unexpected ID: %v", id)
 					}
 					return true
@@ -271,7 +271,7 @@ func TestFileImage_WithDescriptors(t *testing.T) {
 			name: "ReturnFalse",
 			fn: func(t *testing.T) func(d Descriptor) bool {
 				return func(d Descriptor) bool {
-					if id := d.GetID(); id > 2 {
+					if id := d.ID(); id > 2 {
 						t.Errorf("unexpected ID: %v", id)
 					}
 					return false

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -336,17 +336,17 @@ func (f *FileImage) DescriptorsFree() uint64 { return uint64(f.h.Dfree) }
 // DescriptorsTotal returns the total number of descriptors in the image.
 func (f *FileImage) DescriptorsTotal() uint64 { return uint64(f.h.Dtotal) }
 
-// DescriptorSectionOffset returns the offset (in bytes) of the descriptors section in the image.
-func (f *FileImage) DescriptorSectionOffset() uint64 { return uint64(f.h.Descroff) }
+// DescriptorsOffset returns the offset (in bytes) of the descriptors section in the image.
+func (f *FileImage) DescriptorsOffset() uint64 { return uint64(f.h.Descroff) }
 
-// DescriptorSectionSize returns the size (in bytes) of the descriptors section in the image.
-func (f *FileImage) DescriptorSectionSize() uint64 { return uint64(f.h.Descrlen) }
+// DescriptorsSize returns the size (in bytes) of the descriptors section in the image.
+func (f *FileImage) DescriptorsSize() uint64 { return uint64(f.h.Descrlen) }
 
-// DataSectionOffset returns the offset (in bytes) of the data section in the image.
-func (f *FileImage) DataSectionOffset() uint64 { return uint64(f.h.Dataoff) }
+// DataOffset returns the offset (in bytes) of the data section in the image.
+func (f *FileImage) DataOffset() uint64 { return uint64(f.h.Dataoff) }
 
-// DataSectionSize returns the size (in bytes) of the data section in the image.
-func (f *FileImage) DataSectionSize() uint64 { return uint64(f.h.Datalen) }
+// DataSize returns the size (in bytes) of the data section in the image.
+func (f *FileImage) DataSize() uint64 { return uint64(f.h.Datalen) }
 
 // GetHeaderIntegrityReader returns an io.Reader that reads the integrity-protected fields from the
 // header of the image.

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -331,22 +331,22 @@ func (f *FileImage) CreatedAt() time.Time { return time.Unix(f.h.Ctime, 0).UTC()
 func (f *FileImage) ModifiedAt() time.Time { return time.Unix(f.h.Mtime, 0).UTC() }
 
 // DescriptorsFree returns the number of free descriptors in the image.
-func (f *FileImage) DescriptorsFree() uint64 { return uint64(f.h.Dfree) }
+func (f *FileImage) DescriptorsFree() int64 { return f.h.Dfree }
 
 // DescriptorsTotal returns the total number of descriptors in the image.
-func (f *FileImage) DescriptorsTotal() uint64 { return uint64(f.h.Dtotal) }
+func (f *FileImage) DescriptorsTotal() int64 { return f.h.Dtotal }
 
 // DescriptorsOffset returns the offset (in bytes) of the descriptors section in the image.
-func (f *FileImage) DescriptorsOffset() uint64 { return uint64(f.h.Descroff) }
+func (f *FileImage) DescriptorsOffset() int64 { return f.h.Descroff }
 
 // DescriptorsSize returns the size (in bytes) of the descriptors section in the image.
-func (f *FileImage) DescriptorsSize() uint64 { return uint64(f.h.Descrlen) }
+func (f *FileImage) DescriptorsSize() int64 { return f.h.Descrlen }
 
 // DataOffset returns the offset (in bytes) of the data section in the image.
-func (f *FileImage) DataOffset() uint64 { return uint64(f.h.Dataoff) }
+func (f *FileImage) DataOffset() int64 { return f.h.Dataoff }
 
 // DataSize returns the size (in bytes) of the data section in the image.
-func (f *FileImage) DataSize() uint64 { return uint64(f.h.Datalen) }
+func (f *FileImage) DataSize() int64 { return f.h.Datalen }
 
 // GetHeaderIntegrityReader returns an io.Reader that reads the integrity-protected fields from the
 // header of the image.


### PR DESCRIPTION
Hide `Descriptor` internals. Update names and types to improve consistency of v2 API.

Fixes #88 