### PR TITLE
Simplify GetData and GetReader

### DIFF
--- a/internal/app/siftool/info.go
+++ b/internal/app/siftool/info.go
@@ -187,7 +187,7 @@ func (a *App) Dump(path string, id uint32) error {
 			return err
 		}
 
-		_, err = io.CopyN(a.opts.out, d.GetReader(f), d.Size())
+		_, err = io.CopyN(a.opts.out, d.GetReader(), d.Size())
 		return err
 	})
 }

--- a/pkg/integrity/metadata.go
+++ b/pkg/integrity/metadata.go
@@ -130,18 +130,18 @@ func (om *objectMetadata) populateAbsoluteID(minID uint32) {
 	om.id = minID + om.RelativeID
 }
 
-// matches verifies the object in f described by od matches the metadata in om.
+// matches verifies the object described by od matches the metadata in om.
 //
 // If the data object descriptor does not match, a DescriptorIntegrityError is returned. If the
 // data object does not match, a ObjectIntegrityError is returned.
-func (om objectMetadata) matches(f *sif.FileImage, od sif.Descriptor) error {
+func (om objectMetadata) matches(od sif.Descriptor) error {
 	if ok, err := om.DescriptorDigest.matches(od.GetIntegrityReader(om.RelativeID)); err != nil {
 		return err
 	} else if !ok {
 		return &DescriptorIntegrityError{ID: od.ID()}
 	}
 
-	if ok, err := om.ObjectDigest.matches(od.GetReader(f)); err != nil {
+	if ok, err := om.ObjectDigest.matches(od.GetReader()); err != nil {
 		return err
 	} else if !ok {
 		return &ObjectIntegrityError{ID: od.ID()}
@@ -181,7 +181,7 @@ func getImageMetadata(f *sif.FileImage, minID uint32, ods []sif.Descriptor, h cr
 			return imageMetadata{}, errMinimumIDInvalid
 		}
 
-		om, err := getObjectMetadata(id-minID, od.GetIntegrityReader(id-minID), od.GetReader(f), h)
+		om, err := getObjectMetadata(id-minID, od.GetIntegrityReader(id-minID), od.GetReader(), h)
 		if err != nil {
 			return imageMetadata{}, err
 		}
@@ -259,7 +259,7 @@ func (im imageMetadata) matches(f *sif.FileImage, ods []sif.Descriptor) ([]uint3
 			return verified, err
 		}
 
-		if err := om.matches(f, od); err != nil {
+		if err := om.matches(od); err != nil {
 			return verified, err
 		}
 

--- a/pkg/integrity/select.go
+++ b/pkg/integrity/select.go
@@ -106,7 +106,7 @@ func getGroupSignatures(f *sif.FileImage, groupID uint32, legacy bool) ([]sif.De
 		sif.WithDataType(sif.DataSignature),
 		sif.WithLinkedGroupID(groupID),
 		func(od sif.Descriptor) (bool, error) {
-			b, err := od.GetData(f)
+			b, err := od.GetData()
 			if err != nil {
 				return false, err
 			}

--- a/pkg/integrity/sign_test.go
+++ b/pkg/integrity/sign_test.go
@@ -466,7 +466,7 @@ func TestGroupSigner_SignWithEntity(t *testing.T) {
 					t.Errorf("got linked id %v, want %v", got, want)
 				}
 
-				b, err := od.GetData(fi)
+				b, err := od.GetData()
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/integrity/verify.go
+++ b/pkg/integrity/verify.go
@@ -128,7 +128,7 @@ func (v *groupVerifier) fingerprints() ([][20]byte, error) {
 // of a data object descriptor fails, a DescriptorIntegrityError is returned. If verification of a
 // data object fails, a ObjectIntegrityError is returned.
 func (v *groupVerifier) verifySignature(sig sif.Descriptor, kr openpgp.KeyRing) (imageMetadata, []uint32, *openpgp.Entity, error) { // nolint:lll
-	b, err := sig.GetData(v.f)
+	b, err := sig.GetData()
 	if err != nil {
 		return imageMetadata{}, nil, nil, err
 	}
@@ -241,7 +241,7 @@ func (v *legacyGroupVerifier) fingerprints() ([][20]byte, error) {
 //
 // If verification of a data object fails, a ObjectIntegrityError is returned.
 func (v *legacyGroupVerifier) verifySignature(sig sif.Descriptor, kr openpgp.KeyRing) (*openpgp.Entity, error) {
-	b, err := sig.GetData(v.f)
+	b, err := sig.GetData()
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +270,7 @@ func (v *legacyGroupVerifier) verifySignature(sig sif.Descriptor, kr openpgp.Key
 	// Get reader covering all non-signature objects.
 	rs := make([]io.Reader, 0, len(v.ods))
 	for _, od := range v.ods {
-		rs = append(rs, od.GetReader(v.f))
+		rs = append(rs, od.GetReader())
 	}
 	r := io.MultiReader(rs...)
 
@@ -349,7 +349,7 @@ func (v *legacyObjectVerifier) fingerprints() ([][20]byte, error) {
 //
 // If verification of a data object fails, a ObjectIntegrityError is returned.
 func (v *legacyObjectVerifier) verifySignature(sig sif.Descriptor, kr openpgp.KeyRing) (*openpgp.Entity, error) {
-	b, err := sig.GetData(v.f)
+	b, err := sig.GetData()
 	if err != nil {
 		return nil, err
 	}
@@ -376,7 +376,7 @@ func (v *legacyObjectVerifier) verifySignature(sig sif.Descriptor, kr openpgp.Ke
 	}
 
 	// Verify object integrity.
-	if ok, err := d.matches(v.od.GetReader(v.f)); err != nil {
+	if ok, err := d.matches(v.od.GetReader()); err != nil {
 		return e, err
 	} else if !ok {
 		return e, &ObjectIntegrityError{ID: v.od.ID()}

--- a/pkg/sif/descriptor.go
+++ b/pkg/sif/descriptor.go
@@ -123,6 +123,7 @@ func (d rawDescriptor) isPartitionOfType(pt PartType) bool {
 // Descriptor represents the SIF descriptor type.
 type Descriptor struct {
 	raw rawDescriptor
+	r   io.ReaderAt
 }
 
 // DataType returns the type of data object.
@@ -219,18 +220,18 @@ func (d Descriptor) CryptoMessageMetadata() (FormatType, MessageType, error) {
 	return m.Formattype, m.Messagetype, nil
 }
 
-// GetData returns the data object associated with descriptor d from f.
-func (d Descriptor) GetData(f *FileImage) ([]byte, error) {
+// GetData returns the data object associated with descriptor d.
+func (d Descriptor) GetData() ([]byte, error) {
 	b := make([]byte, d.raw.Filelen)
-	if _, err := io.ReadFull(d.GetReader(f), b); err != nil {
+	if _, err := io.ReadFull(d.GetReader(), b); err != nil {
 		return nil, err
 	}
 	return b, nil
 }
 
-// GetReader returns a io.Reader that reads the data object associated with descriptor d from f.
-func (d Descriptor) GetReader(f *FileImage) io.Reader {
-	return io.NewSectionReader(f.rw, d.raw.Fileoff, d.raw.Filelen)
+// GetReader returns a io.Reader that reads the data object associated with descriptor d.
+func (d Descriptor) GetReader() io.Reader {
+	return io.NewSectionReader(d.r, d.raw.Fileoff, d.raw.Filelen)
 }
 
 // GetIntegrityReader returns an io.Reader that reads the integrity-protected fields from d.

--- a/pkg/sif/descriptor_test.go
+++ b/pkg/sif/descriptor_test.go
@@ -37,7 +37,7 @@ func TestDescriptor_GetData(t *testing.T) {
 		t.Fatalf("failed to get descriptor: %v", err)
 	}
 
-	b, err := descr.GetData(f)
+	b, err := descr.GetData()
 	if err != nil {
 		t.Fatalf("failed to get data: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestDescriptor_GetReader(t *testing.T) {
 
 	// Read data via Reader and validate data.
 	b := make([]byte, descr.Size())
-	if _, err := io.ReadFull(descr.GetReader(f), b); err != nil {
+	if _, err := io.ReadFull(descr.GetReader(), b); err != nil {
 		t.Fatalf("failed to read: %v", err)
 	}
 	if got, want := string(b[5:10]), "BEGIN"; got != want {


### PR DESCRIPTION
Add `io.ReaderAt` to `Descriptor` to simplify usage, removing `*FileImage` parameter.

Closes #91 