### PR TITLE
Simplify Integrity Reader

### DIFF
--- a/pkg/integrity/metadata.go
+++ b/pkg/integrity/metadata.go
@@ -135,7 +135,7 @@ func (om *objectMetadata) populateAbsoluteID(minID uint32) {
 // If the data object descriptor does not match, a DescriptorIntegrityError is returned. If the
 // data object does not match, a ObjectIntegrityError is returned.
 func (om objectMetadata) matches(od sif.Descriptor) error {
-	if ok, err := om.DescriptorDigest.matches(od.GetIntegrityReader(om.RelativeID)); err != nil {
+	if ok, err := om.DescriptorDigest.matches(od.GetIntegrityReader()); err != nil {
 		return err
 	} else if !ok {
 		return &DescriptorIntegrityError{ID: od.ID()}
@@ -181,7 +181,7 @@ func getImageMetadata(f *sif.FileImage, minID uint32, ods []sif.Descriptor, h cr
 			return imageMetadata{}, errMinimumIDInvalid
 		}
 
-		om, err := getObjectMetadata(id-minID, od.GetIntegrityReader(id-minID), od.GetReader(), h)
+		om, err := getObjectMetadata(id-minID, od.GetIntegrityReader(), od.GetReader(), h)
 		if err != nil {
 			return imageMetadata{}, err
 		}

--- a/pkg/sif/create.go
+++ b/pkg/sif/create.go
@@ -93,6 +93,11 @@ func (f *FileImage) writeDataObject(di DescriptorInput) error {
 		f.h.Arch = p.Arch
 	}
 
+	// Update minimum object ID map.
+	if minID, ok := f.minIDs[d.Groupid]; !ok || d.ID < minID {
+		f.minIDs[d.Groupid] = d.ID
+	}
+
 	if err := writeDataObject(f.rw, di, d); err != nil {
 		return err
 	}
@@ -180,9 +185,10 @@ func createContainer(rw ReadWriter, co createOpts) (*FileImage, error) {
 	copy(h.Version[:], CurrentVersion.bytes())
 
 	f := &FileImage{
-		rw:  rw,
-		h:   h,
-		rds: make([]rawDescriptor, descrNumEntries),
+		rw:     rw,
+		h:      h,
+		rds:    make([]rawDescriptor, descrNumEntries),
+		minIDs: make(map[uint32]uint32),
 	}
 
 	if _, err := f.rw.Seek(dataStartOffset, io.SeekStart); err != nil {

--- a/pkg/sif/create_test.go
+++ b/pkg/sif/create_test.go
@@ -215,11 +215,11 @@ func TestSetPrimPart(t *testing.T) {
 	inputs := []DescriptorInput{di1, di2}
 
 	fimg := &FileImage{
+		rw: &Buffer{},
 		h: header{
 			Dfree:  int64(len(inputs)),
 			Dtotal: int64(len(inputs)),
 		},
-		rw:  &Buffer{},
 		rds: make([]rawDescriptor, len(inputs)),
 	}
 

--- a/pkg/sif/create_test.go
+++ b/pkg/sif/create_test.go
@@ -220,7 +220,8 @@ func TestSetPrimPart(t *testing.T) {
 			Dfree:  int64(len(inputs)),
 			Dtotal: int64(len(inputs)),
 		},
-		rds: make([]rawDescriptor, len(inputs)),
+		rds:    make([]rawDescriptor, len(inputs)),
+		minIDs: make(map[uint32]uint32),
 	}
 
 	for i := range inputs {

--- a/pkg/sif/descriptor.go
+++ b/pkg/sif/descriptor.go
@@ -122,8 +122,11 @@ func (d rawDescriptor) isPartitionOfType(pt PartType) bool {
 
 // Descriptor represents the SIF descriptor type.
 type Descriptor struct {
-	raw rawDescriptor
-	r   io.ReaderAt
+	r io.ReaderAt // Backing storage.
+
+	raw rawDescriptor // Raw descriptor from image.
+
+	relativeID uint32 // ID relative to minimum ID of object group.
 }
 
 // DataType returns the type of data object.

--- a/pkg/sif/descriptor.go
+++ b/pkg/sif/descriptor.go
@@ -238,11 +238,11 @@ func (d Descriptor) GetReader() io.Reader {
 }
 
 // GetIntegrityReader returns an io.Reader that reads the integrity-protected fields from d.
-func (d Descriptor) GetIntegrityReader(relativeID uint32) io.Reader {
+func (d Descriptor) GetIntegrityReader() io.Reader {
 	fields := []interface{}{
 		d.raw.Datatype,
 		d.raw.Used,
-		relativeID,
+		d.relativeID,
 		d.raw.Link,
 		d.raw.Filelen,
 		d.raw.Ctime,

--- a/pkg/sif/descriptor_test.go
+++ b/pkg/sif/descriptor_test.go
@@ -376,14 +376,17 @@ func TestDescriptor_GetIntegrityReader(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			d := Descriptor{raw: rd}
+			d := Descriptor{
+				raw:        rd,
+				relativeID: tt.relativeID,
+			}
 			if tt.modFunc != nil {
 				tt.modFunc(&d.raw)
 			}
 
 			b := bytes.Buffer{}
 
-			if _, err := io.Copy(&b, d.GetIntegrityReader(tt.relativeID)); err != nil {
+			if _, err := io.Copy(&b, d.GetIntegrityReader()); err != nil {
 				t.Fatal(err)
 			}
 

--- a/pkg/sif/load.go
+++ b/pkg/sif/load.go
@@ -28,6 +28,17 @@ func isValidSif(f *FileImage) error {
 	return nil
 }
 
+// populateMinIDs populates the minIDs field of f.
+func (f *FileImage) populateMinIDs() {
+	f.minIDs = make(map[uint32]uint32)
+	f.WithDescriptors(func(d Descriptor) bool {
+		if minID, ok := f.minIDs[d.raw.Groupid]; !ok || d.ID() < minID {
+			f.minIDs[d.raw.Groupid] = d.ID()
+		}
+		return false
+	})
+}
+
 // loadContainer loads a SIF image from rw.
 func loadContainer(rw ReadWriter) (*FileImage, error) {
 	f := FileImage{rw: rw}
@@ -56,6 +67,8 @@ func loadContainer(rw ReadWriter) (*FileImage, error) {
 	if err != nil {
 		return nil, fmt.Errorf("reading descriptors: %w", err)
 	}
+
+	f.populateMinIDs()
 
 	return &f, nil
 }

--- a/pkg/sif/select.go
+++ b/pkg/sif/select.go
@@ -92,8 +92,9 @@ func WithPartitionType(pt PartType) DescriptorSelectorFunc {
 // descriptorFromRaw populates a Descriptor from rd.
 func (f *FileImage) descriptorFromRaw(rd *rawDescriptor) Descriptor {
 	return Descriptor{
-		raw: *rd,
-		r:   f.rw,
+		raw:        *rd,
+		r:          f.rw,
+		relativeID: rd.ID - f.minIDs[rd.Groupid],
 	}
 }
 

--- a/pkg/sif/select_test.go
+++ b/pkg/sif/select_test.go
@@ -35,6 +35,10 @@ func TestFileImage_GetDescriptors(t *testing.T) {
 		},
 	}
 
+	f := &FileImage{rds: ds}
+
+	f.populateMinIDs()
+
 	tests := []struct {
 		name    string
 		fns     []DescriptorSelectorFunc
@@ -115,14 +119,13 @@ func TestFileImage_GetDescriptors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fimg := &FileImage{rds: ds}
-
-			ds, err := fimg.GetDescriptors(tt.fns...)
+			ds, err := f.GetDescriptors(tt.fns...)
 			if got, want := err, tt.wantErr; !errors.Is(got, want) {
 				t.Fatalf("got error %v, want %v", got, want)
 			}
+
 			if got, want := len(ds), len(tt.wantIDs); got != want {
-				t.Errorf("got %v IDs, want %v", got, want)
+				t.Fatalf("got %v IDs, want %v", got, want)
 			}
 			for i := range ds {
 				if got, want := ds[i].ID(), tt.wantIDs[i]; got != want {
@@ -170,6 +173,10 @@ func TestFileImage_GetDescriptor(t *testing.T) {
 		},
 	}
 
+	f := &FileImage{rds: ds}
+
+	f.populateMinIDs()
+
 	tests := []struct {
 		name    string
 		fns     []DescriptorSelectorFunc
@@ -214,12 +221,11 @@ func TestFileImage_GetDescriptor(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fimg := &FileImage{rds: ds}
-
-			d, err := fimg.GetDescriptor(tt.fns...)
+			d, err := f.GetDescriptor(tt.fns...)
 			if got, want := err, tt.wantErr; !errors.Is(got, want) {
 				t.Fatalf("got error %v, want %v", got, want)
 			}
+
 			if got, want := d.ID(), tt.wantID; got != want {
 				t.Errorf("got ID %v, want %v", got, want)
 			}

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -310,6 +310,8 @@ type FileImage struct {
 
 	h   header          // Raw global header from image.
 	rds []rawDescriptor // Raw descriptors from image.
+
+	minIDs map[uint32]uint32 // Minimum object IDs for each group ID.
 }
 
 // LaunchScript returns the image launch script.

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -306,10 +306,10 @@ type ReadWriter interface {
 
 // FileImage describes the representation of a SIF file in memory.
 type FileImage struct {
-	h          header
-	rw         ReadWriter
-	rds        []rawDescriptor
-	primPartID uint32
+	rw ReadWriter // Backing storage for image.
+
+	h   header          // Raw global header from image.
+	rds []rawDescriptor // Raw descriptors from image.
 }
 
 // LaunchScript returns the image launch script.


### PR DESCRIPTION
Remove `relativeID` param from `(Descriptor).GetIntegrityReader` to simplify usage. Remove `primPartID` from `FileImage`.