### PR TITLE
CreateContainer(AtPath)

### DIFF
--- a/internal/app/siftool/modif.go
+++ b/internal/app/siftool/modif.go
@@ -16,7 +16,7 @@ import (
 
 // New creates a new empty SIF file.
 func (*App) New(path string) error {
-	f, err := sif.CreateContainer(path)
+	f, err := sif.CreateContainerAtPath(path)
 	if err != nil {
 		return err
 	}

--- a/pkg/integrity/sign_test.go
+++ b/pkg/integrity/sign_test.go
@@ -436,9 +436,9 @@ func TestGroupSigner_SignWithEntity(t *testing.T) {
 					t.Fatal(err)
 				}
 				defer os.Remove(tf.Name())
-				tf.Close()
+				defer tf.Close()
 
-				fi, err := sif.CreateContainer(tf.Name(),
+				fi, err := sif.CreateContainer(tf,
 					sif.OptCreateWithDescriptors(di),
 				)
 				if err != nil {

--- a/pkg/integrity/testdata/gen_sifs.go
+++ b/pkg/integrity/testdata/gen_sifs.go
@@ -131,7 +131,7 @@ func generateImages() error {
 
 		path := filepath.Join("images", image.path)
 
-		f, err := sif.CreateContainer(path, sif.OptCreateWithDescriptors(dis...))
+		f, err := sif.CreateContainerAtPath(path, sif.OptCreateWithDescriptors(dis...))
 		if err != nil {
 			return err
 		}

--- a/pkg/sif/create_test.go
+++ b/pkg/sif/create_test.go
@@ -56,20 +56,20 @@ func TestDataStructs(t *testing.T) {
 }
 
 func TestCreateContainer(t *testing.T) {
-	f, err := os.CreateTemp("", "sif-test-*")
+	tf, err := os.CreateTemp("", "sif-test-*")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(f.Name())
-	f.Close()
+	defer os.Remove(tf.Name())
+	defer tf.Close()
 
 	// test container creation without any input descriptors
-	fimg, err := CreateContainer(f.Name())
+	f, err := CreateContainer(tf)
 	if err != nil {
 		t.Fatalf("failed to create container: %v", err)
 	}
 
-	if err := fimg.UnloadContainer(); err != nil {
+	if err := f.UnloadContainer(); err != nil {
 		t.Errorf("failed to unload container: %v", err)
 	}
 
@@ -99,7 +99,7 @@ func TestCreateContainer(t *testing.T) {
 	}
 
 	// test container creation with two partition input descriptors
-	fimg, err = CreateContainer(f.Name(),
+	f, err = CreateContainerAtPath(tf.Name(),
 		OptCreateWithDescriptors(definput, parinput),
 		OptCreateWithTime(testTime),
 	)
@@ -107,7 +107,7 @@ func TestCreateContainer(t *testing.T) {
 		t.Fatalf("failed to create container: %v", err)
 	}
 
-	if err := fimg.UnloadContainer(); err != nil {
+	if err := f.UnloadContainer(); err != nil {
 		t.Errorf("failed to unload container: %v", err)
 	}
 }


### PR DESCRIPTION
Modify `CreateContainer` to take a `ReadWriter`. Add `CreateContainerAtPath` to create using filesystem operations. These mirror `LoadContainer` and `LoadContainerFromPath`.