### PR TITLE
Release with GoReleaser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,14 @@ jobs:
       - codecov/upload:
           file: cover.out
 
+  release-test:
+    executor: golang
+    steps:
+      - checkout
+      - run:
+          name: Test Release
+          command: curl -sL https://git.io/goreleaser | bash -s -- --snapshot --skip-publish
+
 workflows:
   version: 2
 
@@ -73,3 +81,4 @@ workflows:
       - check-go-mod
       - build-source
       - unit-test
+      - release-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
 workflows:
   version: 2
 
-  build_and_test:
+  build-and-test:
     jobs:
       - lint-markdown
       - lint-source

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,14 @@ jobs:
           name: Test Release
           command: curl -sL https://git.io/goreleaser | bash -s -- --snapshot --skip-publish
 
+  publish-release:
+    executor: golang
+    steps:
+      - checkout
+      - run:
+          name: Publish Release
+          command: curl -sL https://git.io/goreleaser | bash
+
 workflows:
   version: 2
 
@@ -82,3 +90,13 @@ workflows:
       - build-source
       - unit-test
       - release-test
+
+  tagged-release:
+    jobs:
+      - publish-release:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
+          context: github-release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,44 @@
+project_name: siftool
+
+release:
+  github:
+    owner: sylabs
+    name: sif
+
+builds:
+  - binary: siftool
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 6
+      - 7
+    env:
+      - CGO_ENABLED=0
+    ldflags: '-s -w -X main.version={{ .Version }} -X main.commit={{ .FullCommit }} -X main.date={{ .CommitDate }} -X main.builtBy=goreleaser'
+    main: ./cmd/siftool
+    mod_timestamp: '{{ .CommitTimestamp }}'
+
+archives:
+  - format: tar.gz
+    wrap_in_directory: true
+    name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    files:
+      - README.md
+
+checksum:
+  name_template: '{{ .ProjectName }}-{{ .Version }}-checksums.txt'
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^dev:'
+      - '^docs:'
+      - '^test:'
+      - '^Merge branch'
+      - '^Merge pull request'


### PR DESCRIPTION
Add GoReleaser config. Add `release-test` job to `build_and_test` workflow. Add `tagged-release` workflow, with `publish-release` job. Rename `build_and_test` workflow to `build-and-test` for consistency.

Closes #99 