### PR TITLE
Integrity descriptors

### DIFF
--- a/pkg/integrity/metadata.go
+++ b/pkg/integrity/metadata.go
@@ -242,8 +242,8 @@ func (im imageMetadata) metadataForObject(id uint32) (objectMetadata, error) {
 // If the SIF global header does not match, ErrHeaderIntegrity is returned. If the data object
 // descriptor does not match, a DescriptorIntegrityError is returned. If the data object does not
 // match, a ObjectIntegrityError is returned.
-func (im imageMetadata) matches(f *sif.FileImage, ods []sif.Descriptor) ([]uint32, error) {
-	verified := make([]uint32, 0, len(ods))
+func (im imageMetadata) matches(f *sif.FileImage, ods []sif.Descriptor) ([]sif.Descriptor, error) {
+	verified := make([]sif.Descriptor, 0, len(ods))
 
 	// Verify header metadata.
 	if err := im.Header.matches(f.GetHeaderIntegrityReader()); err != nil {
@@ -252,9 +252,7 @@ func (im imageMetadata) matches(f *sif.FileImage, ods []sif.Descriptor) ([]uint3
 
 	// Verify data object metadata.
 	for _, od := range ods {
-		id := od.ID()
-
-		om, err := im.metadataForObject(id)
+		om, err := im.metadataForObject(od.ID())
 		if err != nil {
 			return verified, err
 		}
@@ -263,7 +261,7 @@ func (im imageMetadata) matches(f *sif.FileImage, ods []sif.Descriptor) ([]uint3
 			return verified, err
 		}
 
-		verified = append(verified, id)
+		verified = append(verified, od)
 	}
 
 	return verified, nil

--- a/pkg/integrity/result.go
+++ b/pkg/integrity/result.go
@@ -23,15 +23,6 @@ func (r result) Signature() sif.Descriptor {
 	return r.signature
 }
 
-// Signed returns the IDs of data objects that were signed.
-func (r result) Signed() []uint32 {
-	ids := make([]uint32, 0, len(r.im.Objects))
-	for _, om := range r.im.Objects {
-		ids = append(ids, om.id)
-	}
-	return ids
-}
-
 // Verified returns the data objects that were verified.
 func (r result) Verified() []sif.Descriptor {
 	return r.verified
@@ -58,15 +49,6 @@ type legacyResult struct {
 // Signature returns the signature object associated with the result.
 func (r legacyResult) Signature() sif.Descriptor {
 	return r.signature
-}
-
-// Signed returns the IDs of data objects that were signed.
-func (r legacyResult) Signed() []uint32 {
-	ids := make([]uint32, 0, len(r.ods))
-	for _, od := range r.ods {
-		ids = append(ids, od.ID())
-	}
-	return ids
 }
 
 // Verified returns the data objects that were verified.

--- a/pkg/integrity/result.go
+++ b/pkg/integrity/result.go
@@ -11,11 +11,11 @@ import (
 )
 
 type result struct {
-	signature sif.Descriptor  // Signature object.
-	im        imageMetadata   // Metadata from signature.
-	verified  []uint32        // IDs of verified objects.
-	e         *openpgp.Entity // Signing entity.
-	err       error           // Verify error (nil if successful).
+	signature sif.Descriptor   // Signature object.
+	im        imageMetadata    // Metadata from signature.
+	verified  []sif.Descriptor // Verified objects.
+	e         *openpgp.Entity  // Signing entity.
+	err       error            // Verify error (nil if successful).
 }
 
 // Signature returns the signature object associated with the result.
@@ -32,8 +32,8 @@ func (r result) Signed() []uint32 {
 	return ids
 }
 
-// Verified returns the IDs of data objects that were verified.
-func (r result) Verified() []uint32 {
+// Verified returns the data objects that were verified.
+func (r result) Verified() []sif.Descriptor {
 	return r.verified
 }
 
@@ -50,7 +50,7 @@ func (r result) Error() error {
 
 type legacyResult struct {
 	signature sif.Descriptor   // Signature object.
-	ods       []sif.Descriptor // Descriptors of signed objects.
+	ods       []sif.Descriptor // Signed objects.
 	e         *openpgp.Entity  // Signing entity.
 	err       error            // Verify error (nil if successful).
 }
@@ -63,18 +63,18 @@ func (r legacyResult) Signature() sif.Descriptor {
 // Signed returns the IDs of data objects that were signed.
 func (r legacyResult) Signed() []uint32 {
 	ids := make([]uint32, 0, len(r.ods))
-	for _, om := range r.ods {
-		ids = append(ids, om.ID())
+	for _, od := range r.ods {
+		ids = append(ids, od.ID())
 	}
 	return ids
 }
 
-// Verified returns the IDs of data objects that were verified.
-func (r legacyResult) Verified() []uint32 {
+// Verified returns the data objects that were verified.
+func (r legacyResult) Verified() []sif.Descriptor {
 	if r.err != nil {
 		return nil
 	}
-	return r.Signed()
+	return r.ods
 }
 
 // Entity returns the signing entity, or nil if the signing entity could not be determined.

--- a/pkg/integrity/result.go
+++ b/pkg/integrity/result.go
@@ -11,15 +11,15 @@ import (
 )
 
 type result struct {
-	signature uint32          // ID of signature object.
+	signature sif.Descriptor  // Signature object.
 	im        imageMetadata   // Metadata from signature.
 	verified  []uint32        // IDs of verified objects.
 	e         *openpgp.Entity // Signing entity.
 	err       error           // Verify error (nil if successful).
 }
 
-// Signature returns the ID of the signature object associated with the result.
-func (r result) Signature() uint32 {
+// Signature returns the signature object associated with the result.
+func (r result) Signature() sif.Descriptor {
 	return r.signature
 }
 
@@ -49,14 +49,14 @@ func (r result) Error() error {
 }
 
 type legacyResult struct {
-	signature uint32           // ID of signature object.
+	signature sif.Descriptor   // Signature object.
 	ods       []sif.Descriptor // Descriptors of signed objects.
 	e         *openpgp.Entity  // Signing entity.
 	err       error            // Verify error (nil if successful).
 }
 
-// Signature returns the ID of the signature object associated with the result.
-func (r legacyResult) Signature() uint32 {
+// Signature returns the signature object associated with the result.
+func (r legacyResult) Signature() sif.Descriptor {
 	return r.signature
 }
 

--- a/pkg/integrity/verify.go
+++ b/pkg/integrity/verify.go
@@ -60,8 +60,8 @@ func (e *SignatureNotValidError) Is(target error) bool {
 
 // VerifyResult is the interface that each verification result implements.
 type VerifyResult interface {
-	// Signature returns the ID of the signature object associated with the result.
-	Signature() uint32
+	// Signature returns the signature object associated with the result.
+	Signature() sif.Descriptor
 
 	// Signed returns the IDs of data objects that were signed.
 	Signed() []uint32
@@ -193,7 +193,7 @@ func (v *groupVerifier) verifyWithKeyRing(kr openpgp.KeyRing) error {
 
 		// Call verify callback, if applicable.
 		if v.cb != nil {
-			r := result{signature: sig.ID(), im: im, verified: verified, e: e, err: err}
+			r := result{signature: sig, im: im, verified: verified, e: e, err: err}
 			if ignoreError := v.cb(r); ignoreError {
 				err = nil
 			}
@@ -302,7 +302,7 @@ func (v *legacyGroupVerifier) verifyWithKeyRing(kr openpgp.KeyRing) error {
 
 		// Call verify callback, if applicable.
 		if v.cb != nil {
-			r := legacyResult{signature: sig.ID(), ods: v.ods, e: e, err: err}
+			r := legacyResult{signature: sig, ods: v.ods, e: e, err: err}
 			if ignoreError := v.cb(r); ignoreError {
 				err = nil
 			}
@@ -403,7 +403,7 @@ func (v *legacyObjectVerifier) verifyWithKeyRing(kr openpgp.KeyRing) error {
 
 		// Call verify callback, if applicable.
 		if v.cb != nil {
-			r := legacyResult{signature: sig.ID(), ods: []sif.Descriptor{v.od}, e: e, err: err}
+			r := legacyResult{signature: sig, ods: []sif.Descriptor{v.od}, e: e, err: err}
 			if ignoreError := v.cb(r); ignoreError {
 				err = nil
 			}

--- a/pkg/integrity/verify.go
+++ b/pkg/integrity/verify.go
@@ -66,8 +66,8 @@ type VerifyResult interface {
 	// Signed returns the IDs of data objects that were signed.
 	Signed() []uint32
 
-	// Verified returns the IDs of data objects that were verified.
-	Verified() []uint32
+	// Verified returns the data objects that were verified.
+	Verified() []sif.Descriptor
 
 	// Entity returns the signing entity, or nil if the signing entity could not be determined.
 	Entity() *openpgp.Entity
@@ -127,7 +127,7 @@ func (v *groupVerifier) fingerprints() ([][20]byte, error) {
 // If verification of the SIF global header fails, ErrHeaderIntegrity is returned. If verification
 // of a data object descriptor fails, a DescriptorIntegrityError is returned. If verification of a
 // data object fails, a ObjectIntegrityError is returned.
-func (v *groupVerifier) verifySignature(sig sif.Descriptor, kr openpgp.KeyRing) (imageMetadata, []uint32, *openpgp.Entity, error) { // nolint:lll
+func (v *groupVerifier) verifySignature(sig sif.Descriptor, kr openpgp.KeyRing) (imageMetadata, []sif.Descriptor, *openpgp.Entity, error) { // nolint:lll
 	b, err := sig.GetData()
 	if err != nil {
 		return imageMetadata{}, nil, nil, err

--- a/pkg/integrity/verify.go
+++ b/pkg/integrity/verify.go
@@ -63,9 +63,6 @@ type VerifyResult interface {
 	// Signature returns the signature object associated with the result.
 	Signature() sif.Descriptor
 
-	// Signed returns the IDs of data objects that were signed.
-	Signed() []uint32
-
 	// Verified returns the data objects that were verified.
 	Verified() []sif.Descriptor
 

--- a/pkg/integrity/verify_test.go
+++ b/pkg/integrity/verify_test.go
@@ -223,8 +223,13 @@ func TestGroupVerifier_verifyWithKeyRing(t *testing.T) {
 						t.Errorf("got signed %v, want %v", got, want)
 					}
 
-					if got, want := r.Verified(), tt.wantCBVerified; !reflect.DeepEqual(got, want) {
-						t.Errorf("got verified %v, want %v", got, want)
+					if got, want := len(r.Verified()), len(tt.wantCBVerified); got != want {
+						t.Fatalf("got %v verified objects, want %v", got, want)
+					}
+					for i, od := range r.Verified() {
+						if got, want := od.ID(), tt.wantCBVerified[i]; got != want {
+							t.Errorf("got verified ID %v, want %v", got, want)
+						}
 					}
 
 					if got, want := r.Entity(), tt.wantCBEntity; got != want {
@@ -431,8 +436,13 @@ func TestLegacyGroupVerifier_verifyWithKeyRing(t *testing.T) {
 						t.Errorf("got signed %v, want %v", got, want)
 					}
 
-					if got, want := r.Verified(), tt.wantCBVerified; !reflect.DeepEqual(got, want) {
-						t.Errorf("got verified %v, want %v", got, want)
+					if got, want := len(r.Verified()), len(tt.wantCBVerified); got != want {
+						t.Fatalf("got %v verified objects, want %v", got, want)
+					}
+					for i, od := range r.Verified() {
+						if got, want := od.ID(), tt.wantCBVerified[i]; got != want {
+							t.Errorf("got verified ID %v, want %v", got, want)
+						}
 					}
 
 					if got, want := r.Entity(), tt.wantCBEntity; got != want {
@@ -648,8 +658,13 @@ func TestLegacyObjectVerifier_verifyWithKeyRing(t *testing.T) {
 						t.Errorf("got signed %v, want %v", got, want)
 					}
 
-					if got, want := r.Verified(), tt.wantCBVerified; !reflect.DeepEqual(got, want) {
-						t.Errorf("got verified %v, want %v", got, want)
+					if got, want := len(r.Verified()), len(tt.wantCBVerified); got != want {
+						t.Fatalf("got %v verified objects, want %v", got, want)
+					}
+					for i, od := range r.Verified() {
+						if got, want := od.ID(), tt.wantCBVerified[i]; got != want {
+							t.Errorf("got verified ID %v, want %v", got, want)
+						}
 					}
 
 					if got, want := r.Entity(), tt.wantCBEntity; got != want {

--- a/pkg/integrity/verify_test.go
+++ b/pkg/integrity/verify_test.go
@@ -112,7 +112,6 @@ func TestGroupVerifier_verifyWithKeyRing(t *testing.T) {
 		subsetOK        bool
 		kr              openpgp.KeyRing
 		wantCBSignature uint32
-		wantCBSigned    []uint32
 		wantCBVerified  []uint32
 		wantCBEntity    *openpgp.Entity
 		wantCBErr       error
@@ -153,7 +152,6 @@ func TestGroupVerifier_verifyWithKeyRing(t *testing.T) {
 			wantCBSignature: 3,
 			wantCBErr:       &SignatureNotValidError{ID: 3, Err: pgperrors.ErrUnknownIssuer},
 			wantErr:         nil,
-			wantCBSigned:    []uint32{},
 		},
 		{
 			name:      "OneGroupSigned",
@@ -170,7 +168,6 @@ func TestGroupVerifier_verifyWithKeyRing(t *testing.T) {
 			objectIDs:       []uint32{1, 2},
 			kr:              kr,
 			wantCBSignature: 3,
-			wantCBSigned:    []uint32{1, 2},
 			wantCBVerified:  []uint32{1, 2},
 			wantCBEntity:    e,
 		},
@@ -191,7 +188,6 @@ func TestGroupVerifier_verifyWithKeyRing(t *testing.T) {
 			subsetOK:        true,
 			kr:              kr,
 			wantCBSignature: 3,
-			wantCBSigned:    []uint32{1, 2},
 			wantCBVerified:  []uint32{1},
 			wantCBEntity:    e,
 		},
@@ -217,10 +213,6 @@ func TestGroupVerifier_verifyWithKeyRing(t *testing.T) {
 				cb = func(r VerifyResult) bool {
 					if got, want := r.Signature().ID(), tt.wantCBSignature; got != want {
 						t.Errorf("got signature %v, want %v", got, want)
-					}
-
-					if got, want := r.Signed(), tt.wantCBSigned; !reflect.DeepEqual(got, want) {
-						t.Errorf("got signed %v, want %v", got, want)
 					}
 
 					if got, want := len(r.Verified()), len(tt.wantCBVerified); got != want {
@@ -351,7 +343,6 @@ func TestLegacyGroupVerifier_verifyWithKeyRing(t *testing.T) {
 		groupID         uint32
 		kr              openpgp.KeyRing
 		wantCBSignature uint32
-		wantCBSigned    []uint32
 		wantCBVerified  []uint32
 		wantCBEntity    *openpgp.Entity
 		wantCBErr       error
@@ -379,7 +370,6 @@ func TestLegacyGroupVerifier_verifyWithKeyRing(t *testing.T) {
 			groupID:         1,
 			kr:              openpgp.EntityList{},
 			wantCBSignature: 3,
-			wantCBSigned:    []uint32{1, 2},
 			wantCBErr:       pgperrors.ErrUnknownIssuer,
 			wantErr:         nil,
 		},
@@ -396,7 +386,6 @@ func TestLegacyGroupVerifier_verifyWithKeyRing(t *testing.T) {
 			groupID:         1,
 			kr:              kr,
 			wantCBSignature: 3,
-			wantCBSigned:    []uint32{1, 2},
 			wantCBVerified:  []uint32{1, 2},
 			wantCBEntity:    e,
 		},
@@ -413,7 +402,6 @@ func TestLegacyGroupVerifier_verifyWithKeyRing(t *testing.T) {
 			groupID:         1,
 			kr:              kr,
 			wantCBSignature: 3,
-			wantCBSigned:    []uint32{1, 2},
 			wantCBVerified:  []uint32{1, 2},
 			wantCBEntity:    e,
 		},
@@ -430,10 +418,6 @@ func TestLegacyGroupVerifier_verifyWithKeyRing(t *testing.T) {
 				cb = func(r VerifyResult) bool {
 					if got, want := r.Signature().ID(), tt.wantCBSignature; got != want {
 						t.Errorf("got signature %v, want %v", got, want)
-					}
-
-					if got, want := r.Signed(), tt.wantCBSigned; !reflect.DeepEqual(got, want) {
-						t.Errorf("got signed %v, want %v", got, want)
 					}
 
 					if got, want := len(r.Verified()), len(tt.wantCBVerified); got != want {
@@ -573,7 +557,6 @@ func TestLegacyObjectVerifier_verifyWithKeyRing(t *testing.T) {
 		id              uint32
 		kr              openpgp.KeyRing
 		wantCBSignature uint32
-		wantCBSigned    []uint32
 		wantCBVerified  []uint32
 		wantCBEntity    *openpgp.Entity
 		wantCBErr       error
@@ -601,7 +584,6 @@ func TestLegacyObjectVerifier_verifyWithKeyRing(t *testing.T) {
 			id:              1,
 			kr:              openpgp.EntityList{},
 			wantCBSignature: 3,
-			wantCBSigned:    []uint32{1},
 			wantCBErr:       pgperrors.ErrUnknownIssuer,
 			wantErr:         nil,
 		},
@@ -618,7 +600,6 @@ func TestLegacyObjectVerifier_verifyWithKeyRing(t *testing.T) {
 			id:              1,
 			kr:              kr,
 			wantCBSignature: 3,
-			wantCBSigned:    []uint32{1},
 			wantCBVerified:  []uint32{1},
 			wantCBEntity:    e,
 		},
@@ -635,7 +616,6 @@ func TestLegacyObjectVerifier_verifyWithKeyRing(t *testing.T) {
 			id:              1,
 			kr:              kr,
 			wantCBSignature: 3,
-			wantCBSigned:    []uint32{1},
 			wantCBVerified:  []uint32{1},
 			wantCBEntity:    e,
 		},
@@ -652,10 +632,6 @@ func TestLegacyObjectVerifier_verifyWithKeyRing(t *testing.T) {
 				cb = func(r VerifyResult) bool {
 					if got, want := r.Signature().ID(), tt.wantCBSignature; got != want {
 						t.Errorf("got signature %v, want %v", got, want)
-					}
-
-					if got, want := r.Signed(), tt.wantCBSigned; !reflect.DeepEqual(got, want) {
-						t.Errorf("got signed %v, want %v", got, want)
 					}
 
 					if got, want := len(r.Verified()), len(tt.wantCBVerified); got != want {

--- a/pkg/integrity/verify_test.go
+++ b/pkg/integrity/verify_test.go
@@ -211,9 +211,11 @@ func TestGroupVerifier_verifyWithKeyRing(t *testing.T) {
 
 			// Test callback functionality, if requested.
 			var cb VerifyCallback
+
+			//nolint:dupl
 			if tt.testCallback {
 				cb = func(r VerifyResult) bool {
-					if got, want := r.Signature(), tt.wantCBSignature; got != want {
+					if got, want := r.Signature().ID(), tt.wantCBSignature; got != want {
 						t.Errorf("got signature %v, want %v", got, want)
 					}
 
@@ -417,9 +419,11 @@ func TestLegacyGroupVerifier_verifyWithKeyRing(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Test callback functionality, if requested.
 			var cb VerifyCallback
+
+			//nolint:dupl
 			if tt.testCallback {
 				cb = func(r VerifyResult) bool {
-					if got, want := r.Signature(), tt.wantCBSignature; got != want {
+					if got, want := r.Signature().ID(), tt.wantCBSignature; got != want {
 						t.Errorf("got signature %v, want %v", got, want)
 					}
 
@@ -632,9 +636,11 @@ func TestLegacyObjectVerifier_verifyWithKeyRing(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Test callback functionality, if requested.
 			var cb VerifyCallback
+
+			//nolint:dupl
 			if tt.testCallback {
 				cb = func(r VerifyResult) bool {
-					if got, want := r.Signature(), tt.wantCBSignature; got != want {
+					if got, want := r.Signature().ID(), tt.wantCBSignature; got != want {
 						t.Errorf("got signature %v, want %v", got, want)
 					}
 


### PR DESCRIPTION
Simplify `VerifyResult interface`. Return `type sif.Descriptor` from `Signature()` and `Verified()`, and remove `Signed()`.

Closes #107 