### PR TITLE
Bump Go to 1.17 (v1)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,10 @@ executors:
       - image: golangci/golangci-lint:v1.41-alpine
   golang-previous:
     docker:
-      - image: golang:1.15
+      - image: golang:1.16
   golang-latest:
     docker:
-      - image: golang:1.16
+      - image: golang:1.17
 
 jobs:
   lint-markdown:

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,17 @@
 module github.com/sylabs/sif
 
-go 1.15
+go 1.17
 
 require (
 	github.com/satori/go.uuid v1.2.1-0.20180404165556-75cca531ea76
 	github.com/sebdah/goldie/v2 v2.5.3
 	github.com/spf13/cobra v1.2.1
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sergi/go-diff v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 )

--- a/pkg/integrity/main_test.go
+++ b/pkg/integrity/main_test.go
@@ -8,7 +8,6 @@ package integrity
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,7 +34,7 @@ func tempFileFrom(path string) (tf *os.File, err error) {
 		pattern = fmt.Sprintf("*.%s", ext)
 	}
 
-	tf, err = ioutil.TempFile("", pattern)
+	tf, err = os.CreateTemp("", pattern)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sif/create_test.go
+++ b/pkg/sif/create_test.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"testing"
@@ -59,7 +58,7 @@ func TestDataStructs(t *testing.T) {
 }
 
 func TestCreateContainer(t *testing.T) {
-	f, err := ioutil.TempFile("", "sif-test-*")
+	f, err := os.CreateTemp("", "sif-test-*")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,7 +157,7 @@ func TestCreateContainer(t *testing.T) {
 }
 
 func TestAddDelObject(t *testing.T) {
-	f, err := ioutil.TempFile("", "sif-test-*")
+	f, err := os.CreateTemp("", "sif-test-*")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sif/load_test.go
+++ b/pkg/sif/load_test.go
@@ -8,7 +8,6 @@ package sif
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -214,9 +213,9 @@ func TestLoadContainerFpMock(t *testing.T) {
 	// (e.g. Seek, Read, Sync or Truncate reporting errors).
 
 	// Load a valid SIF file to test the happy path.
-	content, err := ioutil.ReadFile("testdata/testcontainer2.sif")
+	content, err := os.ReadFile("testdata/testcontainer2.sif")
 	if err != nil {
-		t.Error(`ioutil.ReadFile("testdata/testcontainer2.sif"):`, err)
+		t.Error(`os.ReadFile("testdata/testcontainer2.sif"):`, err)
 	}
 
 	fp := &mockSifReadWriter{
@@ -236,9 +235,9 @@ func TestLoadContainerFpMock(t *testing.T) {
 
 func TestLoadContainerInvalidMagic(t *testing.T) {
 	// Load a valid SIF file ...
-	content, err := ioutil.ReadFile("testdata/testcontainer2.sif")
+	content, err := os.ReadFile("testdata/testcontainer2.sif")
 	if err != nil {
-		t.Error(`ioutil.ReadFile("testdata/testcontainer2.sif"):`, err)
+		t.Error(`os.ReadFile("testdata/testcontainer2.sif"):`, err)
 	}
 
 	// ... and edit the magic to make it invalid. Instead of
@@ -261,9 +260,9 @@ func TestLoadContainerInvalidMagic(t *testing.T) {
 }
 
 func TestLoadContainerReader(t *testing.T) {
-	content, err := ioutil.ReadFile("testdata/testcontainer2.sif")
+	content, err := os.ReadFile("testdata/testcontainer2.sif")
 	if err != nil {
-		t.Error(`ioutil.ReadFile("testdata/testcontainer2.sif"):`, err)
+		t.Error(`os.ReadFile("testdata/testcontainer2.sif"):`, err)
 	}
 
 	// short read on the descriptor list, make sure it still work


### PR DESCRIPTION
Bump `go.mod` language version to 1.17 to take advantage of [lazy loading](https://golang.org/ref/mod#lazy-loading). Bump CI Go version range to 1.16-1.17. Remove use of deprecated `ioutil` package.