### PR TITLE
Bump Go to 1.17 (v2)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,10 @@ executors:
       - image: golangci/golangci-lint:v1.41-alpine
   golang-previous:
     docker:
-      - image: golang:1.15
+      - image: golang:1.16
   golang-latest:
     docker:
-      - image: golang:1.16
+      - image: golang:1.17
 
 jobs:
   lint-markdown:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sylabs/sif/v2
 
-go 1.15
+go 1.17
 
 require (
 	github.com/blang/semver/v4 v4.0.0
@@ -11,4 +11,24 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
+)
+
+require (
+	github.com/Microsoft/go-winio v0.4.16 // indirect
+	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 // indirect
+	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/go-git/gcfg v1.5.0 // indirect
+	github.com/go-git/go-billy/v5 v5.3.1 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sergi/go-diff v1.1.0 // indirect
+	github.com/xanzy/ssh-agent v0.3.0 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -83,7 +83,6 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -521,7 +520,6 @@ golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/internal/app/siftool/modif_test.go
+++ b/internal/app/siftool/modif_test.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"crypto"
 	"errors"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -22,7 +21,7 @@ func TestApp_New(t *testing.T) {
 		t.Fatalf("failed to create app: %v", err)
 	}
 
-	tf, err := ioutil.TempFile("", "sif-test-*")
+	tf, err := os.CreateTemp("", "sif-test-*")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +76,7 @@ func TestApp_Add(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tf, err := ioutil.TempFile("", "sif-test-*")
+			tf, err := os.CreateTemp("", "sif-test-*")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -102,7 +101,7 @@ func TestApp_Del(t *testing.T) {
 		t.Fatalf("failed to create app: %v", err)
 	}
 
-	tf, err := ioutil.TempFile("", "sif-test-*")
+	tf, err := os.CreateTemp("", "sif-test-*")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -129,7 +128,7 @@ func TestApp_Setprim(t *testing.T) {
 		t.Fatalf("failed to create app: %v", err)
 	}
 
-	tf, err := ioutil.TempFile("", "sif-test-*")
+	tf, err := os.CreateTemp("", "sif-test-*")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/integrity/main_test.go
+++ b/pkg/integrity/main_test.go
@@ -8,7 +8,6 @@ package integrity
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,7 +34,7 @@ func tempFileFrom(path string) (tf *os.File, err error) {
 		pattern = fmt.Sprintf("*.%s", ext)
 	}
 
-	tf, err = ioutil.TempFile("", pattern)
+	tf, err = os.CreateTemp("", pattern)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/integrity/metadata_test.go
+++ b/pkg/integrity/metadata_test.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,7 +23,7 @@ import (
 )
 
 func TestGetHeaderMetadata(t *testing.T) {
-	b, err := ioutil.ReadFile(filepath.Join("testdata", "sources", "header.bin"))
+	b, err := os.ReadFile(filepath.Join("testdata", "sources", "header.bin"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,14 +67,14 @@ func TestGetHeaderMetadata(t *testing.T) {
 func TestGetObjectMetadata(t *testing.T) {
 	// Byte stream that represents integrity-protected fields of an arbitrary descriptor with
 	// relative ID of zero.
-	rid0, err := ioutil.ReadFile(filepath.Join("testdata", "sources", "descr-rid0.bin"))
+	rid0, err := os.ReadFile(filepath.Join("testdata", "sources", "descr-rid0.bin"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Byte stream that represents integrity-protected fields of an arbitrary descriptor with
 	// relative ID of one.
-	rid1, err := ioutil.ReadFile(filepath.Join("testdata", "sources", "descr-rid1.bin"))
+	rid1, err := os.ReadFile(filepath.Join("testdata", "sources", "descr-rid1.bin"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/integrity/sign_test.go
+++ b/pkg/integrity/sign_test.go
@@ -8,7 +8,6 @@ package integrity
 import (
 	"crypto"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -432,7 +431,7 @@ func TestGroupSigner_SignWithEntity(t *testing.T) {
 			}
 
 			if err == nil {
-				tf, err := ioutil.TempFile("", "*")
+				tf, err := os.CreateTemp("", "*")
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/sif/create_test.go
+++ b/pkg/sif/create_test.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -57,7 +56,7 @@ func TestDataStructs(t *testing.T) {
 }
 
 func TestCreateContainer(t *testing.T) {
-	tf, err := ioutil.TempFile("", "sif-test-*")
+	tf, err := os.CreateTemp("", "sif-test-*")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +113,7 @@ func TestCreateContainer(t *testing.T) {
 }
 
 func TestAddDelObject(t *testing.T) {
-	f, err := ioutil.TempFile("", "sif-test-*")
+	f, err := os.CreateTemp("", "sif-test-*")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sif/load_test.go
+++ b/pkg/sif/load_test.go
@@ -6,7 +6,6 @@
 package sif
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -98,9 +97,9 @@ func TestLoadContainerFpMock(t *testing.T) {
 	// (e.g. Seek, ReadAt or Truncate reporting errors).
 
 	// Load a valid SIF file to test the happy path.
-	content, err := ioutil.ReadFile("testdata/testcontainer2.sif")
+	content, err := os.ReadFile("testdata/testcontainer2.sif")
 	if err != nil {
-		t.Error(`ioutil.ReadFile("testdata/testcontainer2.sif"):`, err)
+		t.Error(`os.ReadFile("testdata/testcontainer2.sif"):`, err)
 	}
 
 	rw := NewBuffer(content)
@@ -117,9 +116,9 @@ func TestLoadContainerFpMock(t *testing.T) {
 
 func TestLoadContainerInvalidMagic(t *testing.T) {
 	// Load a valid SIF file ...
-	content, err := ioutil.ReadFile("testdata/testcontainer2.sif")
+	content, err := os.ReadFile("testdata/testcontainer2.sif")
 	if err != nil {
-		t.Error(`ioutil.ReadFile("testdata/testcontainer2.sif"):`, err)
+		t.Error(`os.ReadFile("testdata/testcontainer2.sif"):`, err)
 	}
 
 	// ... and edit the magic to make it invalid. Instead of

--- a/pkg/siftool/new_test.go
+++ b/pkg/siftool/new_test.go
@@ -6,7 +6,6 @@
 package siftool
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -22,7 +21,7 @@ func Test_command_getNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tf, err := ioutil.TempFile("", "sif-test-*")
+			tf, err := os.CreateTemp("", "sif-test-*")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/siftool/siftool_test.go
+++ b/pkg/siftool/siftool_test.go
@@ -6,7 +6,6 @@ package siftool
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,7 +19,7 @@ import (
 var corpus = filepath.Join("..", "integrity", "testdata", "images")
 
 func makeTestSIF(t *testing.T, withDataObject bool) string {
-	tf, err := ioutil.TempFile("", "sif-test-*")
+	tf, err := os.CreateTemp("", "sif-test-*")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Bump `go.mod` language version to 1.17 to take advantage of [lazy loading](https://golang.org/ref/mod#lazy-loading). Bump CI Go version range to 1.16-1.17. Remove use of deprecated `ioutil` package.