### PR TITLE
Test Against Latest Major Versions of Go (v1)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,15 @@ executors:
   node:
     docker:
       - image: node:16-slim
-  golang:
-    docker:
-      - image: golang:1.16
   golangci-lint:
     docker:
       - image: golangci/golangci-lint:v1.41-alpine
+  golang-previous:
+    docker:
+      - image: golang:1.15
+  golang-latest:
+    docker:
+      - image: golang:1.16
 
 jobs:
   lint-markdown:
@@ -26,8 +29,16 @@ jobs:
           name: Check for Lint
           command: markdownlint .
 
+  lint-source:
+    executor: golangci-lint
+    steps:
+      - checkout
+      - run:
+          name: Check for Lint
+          command: golangci-lint run
+
   check-go-mod:
-    executor: golang
+    executor: golang-latest
     steps:
       - checkout
       - run:
@@ -38,27 +49,25 @@ jobs:
           command: git diff --exit-code -- go.mod go.sum
 
   build-source:
-    executor: golang
+    parameters:
+      e:
+        type: executor
+    executor: << parameters.e >>
     steps:
       - checkout
       - run:
           name: Build Source
           command: ./build.sh
 
-  lint-source:
-    executor: golangci-lint
-    steps:
-      - checkout
-      - run:
-          name: Check for Lint
-          command: golangci-lint run
-
   unit-test:
-    executor: golang
+    parameters:
+      e:
+        type: executor
+    executor: << parameters.e >>
     steps:
       - checkout
       - run:
-          name: Run Tests
+          name: Run Unit Tests
           command: go test -coverprofile cover.out -race ./...
       - codecov/upload:
           file: cover.out
@@ -66,10 +75,16 @@ jobs:
 workflows:
   version: 2
 
-  build_and_test:
+  build-and-test:
     jobs:
       - lint-markdown
-      - check-go-mod
-      - build-source
       - lint-source
-      - unit-test
+      - check-go-mod
+      - build-source:
+          matrix:
+            parameters:
+              e: ["golang-previous", "golang-latest"]
+      - unit-test:
+          matrix:
+            parameters:
+              e: ["golang-previous", "golang-latest"]

--- a/pkg/sif/create_test.go
+++ b/pkg/sif/create_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
+	"io/ioutil"
 	"os"
 	"runtime"
 	"testing"
@@ -58,7 +59,7 @@ func TestDataStructs(t *testing.T) {
 }
 
 func TestCreateContainer(t *testing.T) {
-	f, err := os.CreateTemp("", "sif-test-*")
+	f, err := ioutil.TempFile("", "sif-test-*")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +158,7 @@ func TestCreateContainer(t *testing.T) {
 }
 
 func TestAddDelObject(t *testing.T) {
-	f, err := os.CreateTemp("", "sif-test-*")
+	f, err := ioutil.TempFile("", "sif-test-*")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Always test against latest two versions of Go in CI (#115). Replace usage of Go 1.16 `func`s in unit tests. Re-order jobs to simplify comparisons against `master`.