### PR TITLE
Add OptCloseOnUnload

### DIFF
--- a/pkg/sif/create_test.go
+++ b/pkg/sif/create_test.go
@@ -65,7 +65,7 @@ func TestCreateContainer(t *testing.T) {
 	defer tf.Close()
 
 	// test container creation without any input descriptors
-	f, err := CreateContainer(tf)
+	f, err := CreateContainer(tf, OptCreateWithCloseOnUnload(true))
 	if err != nil {
 		t.Fatalf("failed to create container: %v", err)
 	}

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -311,7 +311,8 @@ type FileImage struct {
 	h   header          // Raw global header from image.
 	rds []rawDescriptor // Raw descriptors from image.
 
-	minIDs map[uint32]uint32 // Minimum object IDs for each group ID.
+	closeOnUnload bool              // Close rw on Unload.
+	minIDs        map[uint32]uint32 // Minimum object IDs for each group ID.
 }
 
 // LaunchScript returns the image launch script.


### PR DESCRIPTION
Add `OptCreateWithCloseOnUnload` and `OptLoadWithCloseOnUnload`, which allows the caller to specify whether the supplied `ReadWriter` should be closed when `UnloadContainer` is called. Improve unit tests for `LoadContainerFromPath` and `LoadContainer`.