### PR TITLE
Bump Linter to 1.42 (v2)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:16-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.41-alpine
+      - image: golangci/golangci-lint:v1.42-alpine
   golang-previous:
     docker:
       - image: golang:1.16

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - dogsled
     - dupl
     - errcheck
+    - errname
     - exportloopref
     - gochecknoinits
     - gocritic


### PR DESCRIPTION
Bump `golangci-lint` to 1.42. Enable `errname` linter.