### PR TITLE
ErrNoObjects from GetDescriptor(s)

### DIFF
--- a/pkg/integrity/sign_test.go
+++ b/pkg/integrity/sign_test.go
@@ -133,10 +133,10 @@ func TestNewGroupSigner(t *testing.T) {
 			wantErr: sif.ErrInvalidGroupID,
 		},
 		{
-			name:    "GroupNotFound",
+			name:    "NoObjects",
 			fi:      emptyImage,
 			groupID: 1,
-			wantErr: errGroupNotFound,
+			wantErr: sif.ErrNoObjects,
 		},
 		{
 			name:    "NoObjectsSpecified",
@@ -144,6 +144,12 @@ func TestNewGroupSigner(t *testing.T) {
 			groupID: 1,
 			opts:    []groupSignerOpt{optSignGroupObjects()},
 			wantErr: errNoObjectsSpecified,
+		},
+		{
+			name:    "GroupNotFound",
+			fi:      twoGroupImage,
+			groupID: 3,
+			wantErr: errGroupNotFound,
 		},
 		{
 			name:        "Group1",
@@ -553,9 +559,15 @@ func TestOptSignObjects(t *testing.T) {
 			wantErr:       sif.ErrInvalidObjectID,
 		},
 		{
-			name:          "ObjectNotFound",
+			name:          "NoObjects",
 			inputFileName: "empty.sif",
 			ids:           []uint32{1},
+			wantErr:       sif.ErrNoObjects,
+		},
+		{
+			name:          "ObjectNotFound",
+			inputFileName: "one-group.sif",
+			ids:           []uint32{3},
 			wantErr:       sif.ErrObjectNotFound,
 		},
 		{

--- a/pkg/integrity/verify_test.go
+++ b/pkg/integrity/verify_test.go
@@ -736,15 +736,21 @@ func TestNewVerifier(t *testing.T) {
 			wantErr: sif.ErrInvalidGroupID,
 		},
 		{
-			name:    "GroupNotFound",
+			name:    "NoObjects",
 			fi:      emptyImage,
 			opts:    []VerifierOpt{OptVerifyWithKeyRing(kr), OptVerifyGroup(1)},
+			wantErr: sif.ErrNoObjects,
+		},
+		{
+			name:    "GroupNotFound",
+			fi:      oneGroupImage,
+			opts:    []VerifierOpt{OptVerifyWithKeyRing(kr), OptVerifyGroup(2)},
 			wantErr: errGroupNotFound,
 		},
 		{
 			name:    "GroupNotFoundLegacy",
-			fi:      emptyImage,
-			opts:    []VerifierOpt{OptVerifyWithKeyRing(kr), OptVerifyGroup(1), OptVerifyLegacy()},
+			fi:      oneGroupImage,
+			opts:    []VerifierOpt{OptVerifyWithKeyRing(kr), OptVerifyGroup(2), OptVerifyLegacy()},
 			wantErr: errGroupNotFound,
 		},
 		{
@@ -755,14 +761,14 @@ func TestNewVerifier(t *testing.T) {
 		},
 		{
 			name:    "ObjectNotFound",
-			fi:      emptyImage,
-			opts:    []VerifierOpt{OptVerifyObject(1)},
+			fi:      oneGroupImage,
+			opts:    []VerifierOpt{OptVerifyObject(3)},
 			wantErr: sif.ErrObjectNotFound,
 		},
 		{
 			name:    "ObjectNotFoundLegacy",
-			fi:      emptyImage,
-			opts:    []VerifierOpt{OptVerifyObject(1), OptVerifyLegacy()},
+			fi:      oneGroupImage,
+			opts:    []VerifierOpt{OptVerifyObject(3), OptVerifyLegacy()},
 			wantErr: sif.ErrObjectNotFound,
 		},
 		{

--- a/pkg/sif/create.go
+++ b/pkg/sif/create.go
@@ -82,11 +82,7 @@ func (f *FileImage) writeDataObject(di DescriptorInput) error {
 	// If this is a primary partition, verify there isn't another primary partition, and update the
 	// architecture in the global header.
 	if p, ok := di.opts.extra.(partition); ok && p.Parttype == PartPrimSys {
-		ds, err := f.GetDescriptors(WithPartitionType(PartPrimSys))
-		if err != nil {
-			return err
-		}
-		if len(ds) > 0 {
+		if ds, err := f.GetDescriptors(WithPartitionType(PartPrimSys)); err == nil && len(ds) > 0 {
 			return fmt.Errorf("only 1 FS data object may be a primary partition")
 		}
 

--- a/pkg/sif/select_test.go
+++ b/pkg/sif/select_test.go
@@ -35,7 +35,12 @@ func TestFileImage_GetDescriptors(t *testing.T) {
 		},
 	}
 
-	f := &FileImage{rds: ds}
+	f := &FileImage{
+		rds: ds,
+		h: header{
+			Dtotal: int64(len(ds)),
+		},
+	}
 
 	f.populateMinIDs()
 
@@ -173,7 +178,12 @@ func TestFileImage_GetDescriptor(t *testing.T) {
 		},
 	}
 
-	f := &FileImage{rds: ds}
+	f := &FileImage{
+		rds: ds,
+		h: header{
+			Dtotal: int64(len(ds)),
+		},
+	}
 
 	f.populateMinIDs()
 


### PR DESCRIPTION
When `GetDescriptor`/`GetDescriptors` is called on an image with no descriptors, the returned error can be confusing. For example, when a `DescriptorSelectorFunc` is used with an invalid argument against an image with no descriptors, `ErrObjectNotFound` would be returned. `ErrNoObjects` allows the caller to differentiate this case, and display a more descriptive error.