### PR TITLE
Add New Format Build Constraints

### DIFF
--- a/git.go
+++ b/git.go
@@ -3,6 +3,7 @@
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build mage
 // +build mage
 
 package main

--- a/mage.go
+++ b/mage.go
@@ -3,6 +3,7 @@
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build ignore
 // +build ignore
 
 package main

--- a/magefile.go
+++ b/magefile.go
@@ -3,6 +3,7 @@
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build mage
 // +build mage
 
 package main

--- a/version.go
+++ b/version.go
@@ -3,6 +3,7 @@
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
+//go:build mage
 // +build mage
 
 package main


### PR DESCRIPTION
Add `//go:build` format build constraints [introduced in Go 1.17](https://golang.org/doc/go1.17#build-lines). Keep `// +build` format build constraints during the format transition.