### PR TITLE
Document VerifyResult

### DIFF
--- a/pkg/integrity/result.go
+++ b/pkg/integrity/result.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sylabs/sif/v2/pkg/sif"
 )
 
+// VerifyResult describes the results of an individual signature validation.
 type VerifyResult struct {
 	sig      sif.Descriptor
 	verified []sif.Descriptor


### PR DESCRIPTION
Add missing documentation for `type VerifyResult`.