### PR TITLE
Improve Readability of Output

### DIFF
--- a/internal/app/siftool/info.go
+++ b/internal/app/siftool/info.go
@@ -39,18 +39,18 @@ func readableSize(size int64) string {
 func writeHeader(w io.Writer, f *sif.FileImage) error {
 	tw := tabwriter.NewWriter(w, 0, 0, 0, ' ', 0)
 
-	fmt.Fprintln(tw, "Launch:\t", strings.TrimSuffix(f.LaunchScript(), "\n"))
+	fmt.Fprintln(tw, "Launch Script:\t", strings.TrimSuffix(f.LaunchScript(), "\n"))
 	fmt.Fprintln(tw, "Version:\t", f.Version())
-	fmt.Fprintln(tw, "Arch:\t", f.PrimaryArch())
+	fmt.Fprintln(tw, "Primary Architecture:\t", f.PrimaryArch())
 	fmt.Fprintln(tw, "ID:\t", f.ID())
-	fmt.Fprintln(tw, "Ctime:\t", f.CreatedAt())
-	fmt.Fprintln(tw, "Mtime:\t", f.ModifiedAt())
-	fmt.Fprintln(tw, "Dfree:\t", f.DescriptorsFree())
-	fmt.Fprintln(tw, "Dtotal:\t", f.DescriptorsTotal())
-	fmt.Fprintln(tw, "Descoff:\t", f.DescriptorsOffset())
-	fmt.Fprintln(tw, "Descrlen:\t", readableSize(f.DescriptorsSize()))
-	fmt.Fprintln(tw, "Dataoff:\t", f.DataOffset())
-	fmt.Fprintln(tw, "Datalen:\t", readableSize(f.DataSize()))
+	fmt.Fprintln(tw, "Created At:\t", f.CreatedAt())
+	fmt.Fprintln(tw, "Modified At:\t", f.ModifiedAt())
+	fmt.Fprintln(tw, "Descriptors Free:\t", f.DescriptorsFree())
+	fmt.Fprintln(tw, "Descriptors Total:\t", f.DescriptorsTotal())
+	fmt.Fprintln(tw, "Descriptors Offset:\t", f.DescriptorsOffset())
+	fmt.Fprintln(tw, "Descriptors Size:\t", readableSize(f.DescriptorsSize()))
+	fmt.Fprintln(tw, "Data Offset:\t", f.DataOffset())
+	fmt.Fprintln(tw, "Data Size:\t", readableSize(f.DataSize()))
 
 	return tw.Flush()
 }
@@ -64,12 +64,12 @@ func (a *App) Header(path string) error {
 
 // writeList writes the list of descriptors in f to w.
 func writeList(w io.Writer, f *sif.FileImage) error {
-	fmt.Fprintln(w, "Container id:", f.ID())
-	fmt.Fprintln(w, "Created on:  ", f.CreatedAt())
-	fmt.Fprintln(w, "Modified on: ", f.ModifiedAt())
+	fmt.Fprintln(w, "ID:          ", f.ID())
+	fmt.Fprintln(w, "Created At:  ", f.CreatedAt())
+	fmt.Fprintln(w, "Modified At: ", f.ModifiedAt())
 	fmt.Fprintln(w, "----------------------------------------------------")
 
-	fmt.Fprintln(w, "Descriptor list:")
+	fmt.Fprintln(w, "Descriptors:")
 
 	fmt.Fprintf(w, "%-4s %-8s %-8s %-26s %s\n", "ID", "|GROUP", "|LINK", "|SIF POSITION (start-end)", "|TYPE")
 	fmt.Fprintln(w, ("------------------------------------------------------------------------------"))
@@ -125,43 +125,43 @@ func (a *App) List(path string) error {
 func writeInfo(w io.Writer, v sif.Descriptor) error {
 	tw := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
 
-	fmt.Fprintln(tw, "  Datatype:\t", v.DataType())
+	fmt.Fprintln(tw, "  Data Type:\t", v.DataType())
 	fmt.Fprintln(tw, "  ID:\t", v.ID())
 
 	if id := v.GroupID(); id == 0 {
-		fmt.Fprintln(tw, "  Groupid:\t", "NONE")
+		fmt.Fprintln(tw, "  Group ID:\t", "NONE")
 	} else {
-		fmt.Fprintln(tw, "  Groupid:\t", id)
+		fmt.Fprintln(tw, "  Group ID:\t", id)
 	}
 
 	switch id, isGroup := v.LinkedID(); {
 	case id == 0:
-		fmt.Fprintln(tw, "  Link:\t", "NONE")
+		fmt.Fprintln(tw, "  Linked ID:\t", "NONE")
 	case isGroup:
-		fmt.Fprintln(tw, "  Link:\t", id, "(G)")
+		fmt.Fprintln(tw, "  Linked ID:\t", id, "(G)")
 	default:
-		fmt.Fprintln(tw, "  Link:\t", id)
+		fmt.Fprintln(tw, "  Linked ID:\t", id)
 	}
 
-	fmt.Fprintln(tw, "  Fileoff:\t", v.Offset())
-	fmt.Fprintln(tw, "  Filelen:\t", v.Size())
-	fmt.Fprintln(tw, "  Ctime:\t", v.CreatedAt())
-	fmt.Fprintln(tw, "  Mtime:\t", v.ModifiedAt())
+	fmt.Fprintln(tw, "  Offset:\t", v.Offset())
+	fmt.Fprintln(tw, "  Size:\t", v.Size())
+	fmt.Fprintln(tw, "  Created At:\t", v.CreatedAt())
+	fmt.Fprintln(tw, "  Modified At:\t", v.ModifiedAt())
 	fmt.Fprintln(tw, "  Name:\t", v.Name())
 	switch v.DataType() {
 	case sif.DataPartition:
 		fs, pt, arch, _ := v.PartitionMetadata()
-		fmt.Fprintln(tw, "  Fstype:\t", fs)
-		fmt.Fprintln(tw, "  Parttype:\t", pt)
-		fmt.Fprintln(tw, "  Arch:\t", arch)
+		fmt.Fprintln(tw, "  Filesystem Type:\t", fs)
+		fmt.Fprintln(tw, "  Partition Type:\t", pt)
+		fmt.Fprintln(tw, "  Architecture:\t", arch)
 	case sif.DataSignature:
 		ht, fp, _ := v.SignatureMetadata()
-		fmt.Fprintln(tw, "  Hashtype:\t", ht)
+		fmt.Fprintln(tw, "  Hash Type:\t", ht)
 		fmt.Fprintln(tw, "  Entity:\t", fmt.Sprintf("%X", fp))
 	case sif.DataCryptoMessage:
 		ft, mt, _ := v.CryptoMessageMetadata()
-		fmt.Fprintln(tw, "  Fmttype:\t", ft)
-		fmt.Fprintln(tw, "  Msgtype:\t", mt)
+		fmt.Fprintln(tw, "  Format Type:\t", ft)
+		fmt.Fprintln(tw, "  Message Type:\t", mt)
 	}
 
 	return tw.Flush()

--- a/internal/app/siftool/testdata/TestApp_Header/Empty.golden
+++ b/internal/app/siftool/testdata/TestApp_Header/Empty.golden
@@ -1,12 +1,12 @@
-Launch:   #!/usr/bin/env run-singularity
-Version:  01
-Arch:     unknown
-ID:       3fa802cc-358b-45e3-bcc0-69dc7a45f9f8
-Ctime:    2020-05-22 19:30:59 +0000 UTC
-Mtime:    2020-05-22 19:30:59 +0000 UTC
-Dfree:    48
-Dtotal:   48
-Descoff:  4096
-Descrlen: 27 KiB
-Dataoff:  32768
-Datalen:  0 B
+Launch Script:        #!/usr/bin/env run-singularity
+Version:              01
+Primary Architecture: unknown
+ID:                   3fa802cc-358b-45e3-bcc0-69dc7a45f9f8
+Created At:           2020-05-22 19:30:59 +0000 UTC
+Modified At:          2020-05-22 19:30:59 +0000 UTC
+Descriptors Free:     48
+Descriptors Total:    48
+Descriptors Offset:   4096
+Descriptors Size:     27 KiB
+Data Offset:          32768
+Data Size:            0 B

--- a/internal/app/siftool/testdata/TestApp_Header/OneGroup.golden
+++ b/internal/app/siftool/testdata/TestApp_Header/OneGroup.golden
@@ -1,12 +1,12 @@
-Launch:   #!/usr/bin/env run-singularity
-Version:  01
-Arch:     386
-ID:       6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
-Ctime:    2020-05-22 19:30:59 +0000 UTC
-Mtime:    2020-05-22 19:30:59 +0000 UTC
-Dfree:    46
-Dtotal:   48
-Descoff:  4096
-Descrlen: 27 KiB
-Dataoff:  32768
-Datalen:  4 KiB
+Launch Script:        #!/usr/bin/env run-singularity
+Version:              01
+Primary Architecture: 386
+ID:                   6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
+Created At:           2020-05-22 19:30:59 +0000 UTC
+Modified At:          2020-05-22 19:30:59 +0000 UTC
+Descriptors Free:     46
+Descriptors Total:    48
+Descriptors Offset:   4096
+Descriptors Size:     27 KiB
+Data Offset:          32768
+Data Size:            4 KiB

--- a/internal/app/siftool/testdata/TestApp_Header/OneGroupSigned.golden
+++ b/internal/app/siftool/testdata/TestApp_Header/OneGroupSigned.golden
@@ -1,12 +1,12 @@
-Launch:   #!/usr/bin/env run-singularity
-Version:  01
-Arch:     386
-ID:       73e1c5c3-5c41-41ed-ad7c-2504d669f140
-Ctime:    2020-06-30 00:01:56 +0000 UTC
-Mtime:    2020-06-30 00:01:56 +0000 UTC
-Dfree:    45
-Dtotal:   48
-Descoff:  4096
-Descrlen: 27 KiB
-Dataoff:  32768
-Datalen:  9 KiB
+Launch Script:        #!/usr/bin/env run-singularity
+Version:              01
+Primary Architecture: 386
+ID:                   73e1c5c3-5c41-41ed-ad7c-2504d669f140
+Created At:           2020-06-30 00:01:56 +0000 UTC
+Modified At:          2020-06-30 00:01:56 +0000 UTC
+Descriptors Free:     45
+Descriptors Total:    48
+Descriptors Offset:   4096
+Descriptors Size:     27 KiB
+Data Offset:          32768
+Data Size:            9 KiB

--- a/internal/app/siftool/testdata/TestApp_Header/OneGroupSignedLegacy.golden
+++ b/internal/app/siftool/testdata/TestApp_Header/OneGroupSignedLegacy.golden
@@ -1,12 +1,12 @@
-Launch:   #!/usr/bin/env run-singularity
-Version:  01
-Arch:     386
-ID:       6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
-Ctime:    2020-05-22 19:30:59 +0000 UTC
-Mtime:    2020-06-20 20:16:39 +0000 UTC
-Dfree:    45
-Dtotal:   48
-Descoff:  4096
-Descrlen: 27 KiB
-Dataoff:  32768
-Datalen:  9 KiB
+Launch Script:        #!/usr/bin/env run-singularity
+Version:              01
+Primary Architecture: 386
+ID:                   6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
+Created At:           2020-05-22 19:30:59 +0000 UTC
+Modified At:          2020-06-20 20:16:39 +0000 UTC
+Descriptors Free:     45
+Descriptors Total:    48
+Descriptors Offset:   4096
+Descriptors Size:     27 KiB
+Data Offset:          32768
+Data Size:            9 KiB

--- a/internal/app/siftool/testdata/TestApp_Header/OneGroupSignedLegacyAll.golden
+++ b/internal/app/siftool/testdata/TestApp_Header/OneGroupSignedLegacyAll.golden
@@ -1,12 +1,12 @@
-Launch:   #!/usr/bin/env run-singularity
-Version:  01
-Arch:     386
-ID:       6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
-Ctime:    2020-05-22 19:30:59 +0000 UTC
-Mtime:    2020-06-20 20:17:15 +0000 UTC
-Dfree:    44
-Dtotal:   48
-Descoff:  4096
-Descrlen: 27 KiB
-Dataoff:  32768
-Datalen:  13 KiB
+Launch Script:        #!/usr/bin/env run-singularity
+Version:              01
+Primary Architecture: 386
+ID:                   6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
+Created At:           2020-05-22 19:30:59 +0000 UTC
+Modified At:          2020-06-20 20:17:15 +0000 UTC
+Descriptors Free:     44
+Descriptors Total:    48
+Descriptors Offset:   4096
+Descriptors Size:     27 KiB
+Data Offset:          32768
+Data Size:            13 KiB

--- a/internal/app/siftool/testdata/TestApp_Header/OneGroupSignedLegacyGroup.golden
+++ b/internal/app/siftool/testdata/TestApp_Header/OneGroupSignedLegacyGroup.golden
@@ -1,12 +1,12 @@
-Launch:   #!/usr/bin/env run-singularity
-Version:  01
-Arch:     386
-ID:       6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
-Ctime:    2020-05-22 19:30:59 +0000 UTC
-Mtime:    2020-06-20 20:16:55 +0000 UTC
-Dfree:    45
-Dtotal:   48
-Descoff:  4096
-Descrlen: 27 KiB
-Dataoff:  32768
-Datalen:  9 KiB
+Launch Script:        #!/usr/bin/env run-singularity
+Version:              01
+Primary Architecture: 386
+ID:                   6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
+Created At:           2020-05-22 19:30:59 +0000 UTC
+Modified At:          2020-06-20 20:16:55 +0000 UTC
+Descriptors Free:     45
+Descriptors Total:    48
+Descriptors Offset:   4096
+Descriptors Size:     27 KiB
+Data Offset:          32768
+Data Size:            9 KiB

--- a/internal/app/siftool/testdata/TestApp_Header/TwoGroups.golden
+++ b/internal/app/siftool/testdata/TestApp_Header/TwoGroups.golden
@@ -1,12 +1,12 @@
-Launch:   #!/usr/bin/env run-singularity
-Version:  01
-Arch:     386
-ID:       0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
-Ctime:    2020-05-22 19:30:59 +0000 UTC
-Mtime:    2020-05-22 19:30:59 +0000 UTC
-Dfree:    45
-Dtotal:   48
-Descoff:  4096
-Descrlen: 27 KiB
-Dataoff:  32768
-Datalen:  8 KiB
+Launch Script:        #!/usr/bin/env run-singularity
+Version:              01
+Primary Architecture: 386
+ID:                   0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
+Created At:           2020-05-22 19:30:59 +0000 UTC
+Modified At:          2020-05-22 19:30:59 +0000 UTC
+Descriptors Free:     45
+Descriptors Total:    48
+Descriptors Offset:   4096
+Descriptors Size:     27 KiB
+Data Offset:          32768
+Data Size:            8 KiB

--- a/internal/app/siftool/testdata/TestApp_Header/TwoGroupsSigned.golden
+++ b/internal/app/siftool/testdata/TestApp_Header/TwoGroupsSigned.golden
@@ -1,12 +1,12 @@
-Launch:   #!/usr/bin/env run-singularity
-Version:  01
-Arch:     386
-ID:       610cf3a3-18b0-4622-8b08-772d3510d7b5
-Ctime:    2020-06-30 00:01:56 +0000 UTC
-Mtime:    2020-06-30 00:01:56 +0000 UTC
-Dfree:    43
-Dtotal:   48
-Descoff:  4096
-Descrlen: 27 KiB
-Dataoff:  32768
-Datalen:  17 KiB
+Launch Script:        #!/usr/bin/env run-singularity
+Version:              01
+Primary Architecture: 386
+ID:                   610cf3a3-18b0-4622-8b08-772d3510d7b5
+Created At:           2020-06-30 00:01:56 +0000 UTC
+Modified At:          2020-06-30 00:01:56 +0000 UTC
+Descriptors Free:     43
+Descriptors Total:    48
+Descriptors Offset:   4096
+Descriptors Size:     27 KiB
+Data Offset:          32768
+Data Size:            17 KiB

--- a/internal/app/siftool/testdata/TestApp_Header/TwoGroupsSignedLegacy.golden
+++ b/internal/app/siftool/testdata/TestApp_Header/TwoGroupsSignedLegacy.golden
@@ -1,12 +1,12 @@
-Launch:   #!/usr/bin/env run-singularity
-Version:  01
-Arch:     386
-ID:       0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
-Ctime:    2020-05-22 19:30:59 +0000 UTC
-Mtime:    2020-06-20 20:16:44 +0000 UTC
-Dfree:    44
-Dtotal:   48
-Descoff:  4096
-Descrlen: 27 KiB
-Dataoff:  32768
-Datalen:  13 KiB
+Launch Script:        #!/usr/bin/env run-singularity
+Version:              01
+Primary Architecture: 386
+ID:                   0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
+Created At:           2020-05-22 19:30:59 +0000 UTC
+Modified At:          2020-06-20 20:16:44 +0000 UTC
+Descriptors Free:     44
+Descriptors Total:    48
+Descriptors Offset:   4096
+Descriptors Size:     27 KiB
+Data Offset:          32768
+Data Size:            13 KiB

--- a/internal/app/siftool/testdata/TestApp_Header/TwoGroupsSignedLegacyAll.golden
+++ b/internal/app/siftool/testdata/TestApp_Header/TwoGroupsSignedLegacyAll.golden
@@ -1,12 +1,12 @@
-Launch:   #!/usr/bin/env run-singularity
-Version:  01
-Arch:     386
-ID:       0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
-Ctime:    2020-05-22 19:30:59 +0000 UTC
-Mtime:    2020-06-20 20:17:19 +0000 UTC
-Dfree:    43
-Dtotal:   48
-Descoff:  4096
-Descrlen: 27 KiB
-Dataoff:  32768
-Datalen:  17 KiB
+Launch Script:        #!/usr/bin/env run-singularity
+Version:              01
+Primary Architecture: 386
+ID:                   0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
+Created At:           2020-05-22 19:30:59 +0000 UTC
+Modified At:          2020-06-20 20:17:19 +0000 UTC
+Descriptors Free:     43
+Descriptors Total:    48
+Descriptors Offset:   4096
+Descriptors Size:     27 KiB
+Data Offset:          32768
+Data Size:            17 KiB

--- a/internal/app/siftool/testdata/TestApp_Header/TwoGroupsSignedLegacyGroup.golden
+++ b/internal/app/siftool/testdata/TestApp_Header/TwoGroupsSignedLegacyGroup.golden
@@ -1,12 +1,12 @@
-Launch:   #!/usr/bin/env run-singularity
-Version:  01
-Arch:     386
-ID:       0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
-Ctime:    2020-05-22 19:30:59 +0000 UTC
-Mtime:    2020-06-20 20:16:58 +0000 UTC
-Dfree:    44
-Dtotal:   48
-Descoff:  4096
-Descrlen: 27 KiB
-Dataoff:  32768
-Datalen:  13 KiB
+Launch Script:        #!/usr/bin/env run-singularity
+Version:              01
+Primary Architecture: 386
+ID:                   0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
+Created At:           2020-05-22 19:30:59 +0000 UTC
+Modified At:          2020-06-20 20:16:58 +0000 UTC
+Descriptors Free:     44
+Descriptors Total:    48
+Descriptors Offset:   4096
+Descriptors Size:     27 KiB
+Data Offset:          32768
+Data Size:            13 KiB

--- a/internal/app/siftool/testdata/TestApp_Info/One.golden
+++ b/internal/app/siftool/testdata/TestApp_Info/One.golden
@@ -1,12 +1,12 @@
-  Datatype:  FS
-  ID:        1
-  Groupid:   1
-  Link:      NONE
-  Fileoff:   32768
-  Filelen:   4
-  Ctime:     2020-06-30 00:01:56 +0000 UTC
-  Mtime:     2020-06-30 00:01:56 +0000 UTC
-  Name:      .
-  Fstype:    Raw
-  Parttype:  System
-  Arch:      386
+  Data Type:        FS
+  ID:               1
+  Group ID:         1
+  Linked ID:        NONE
+  Offset:           32768
+  Size:             4
+  Created At:       2020-06-30 00:01:56 +0000 UTC
+  Modified At:      2020-06-30 00:01:56 +0000 UTC
+  Name:             .
+  Filesystem Type:  Raw
+  Partition Type:   System
+  Architecture:     386

--- a/internal/app/siftool/testdata/TestApp_Info/Three.golden
+++ b/internal/app/siftool/testdata/TestApp_Info/Three.golden
@@ -1,11 +1,11 @@
-  Datatype:  Signature
-  ID:        3
-  Groupid:   NONE
-  Link:      1 (G)
-  Fileoff:   40960
-  Filelen:   1054
-  Ctime:     2020-06-30 00:01:56 +0000 UTC
-  Mtime:     2020-06-30 00:01:56 +0000 UTC
-  Name:      
-  Hashtype:  SHA-256
-  Entity:    12045C8C0B1004D058DE4BEDA20C27EE7FF7BA84
+  Data Type:    Signature
+  ID:           3
+  Group ID:     NONE
+  Linked ID:    1 (G)
+  Offset:       40960
+  Size:         1054
+  Created At:   2020-06-30 00:01:56 +0000 UTC
+  Modified At:  2020-06-30 00:01:56 +0000 UTC
+  Name:         
+  Hash Type:    SHA-256
+  Entity:       12045C8C0B1004D058DE4BEDA20C27EE7FF7BA84

--- a/internal/app/siftool/testdata/TestApp_Info/Two.golden
+++ b/internal/app/siftool/testdata/TestApp_Info/Two.golden
@@ -1,12 +1,12 @@
-  Datatype:  FS
-  ID:        2
-  Groupid:   1
-  Link:      NONE
-  Fileoff:   36864
-  Filelen:   4
-  Ctime:     2020-06-30 00:01:56 +0000 UTC
-  Mtime:     2020-06-30 00:01:56 +0000 UTC
-  Name:      .
-  Fstype:    Squashfs
-  Parttype:  *System
-  Arch:      386
+  Data Type:        FS
+  ID:               2
+  Group ID:         1
+  Linked ID:        NONE
+  Offset:           36864
+  Size:             4
+  Created At:       2020-06-30 00:01:56 +0000 UTC
+  Modified At:      2020-06-30 00:01:56 +0000 UTC
+  Name:             .
+  Filesystem Type:  Squashfs
+  Partition Type:   *System
+  Architecture:     386

--- a/internal/app/siftool/testdata/TestApp_List/Empty.golden
+++ b/internal/app/siftool/testdata/TestApp_List/Empty.golden
@@ -1,7 +1,7 @@
-Container id: 3fa802cc-358b-45e3-bcc0-69dc7a45f9f8
-Created on:   2020-05-22 19:30:59 +0000 UTC
-Modified on:  2020-05-22 19:30:59 +0000 UTC
+ID:           3fa802cc-358b-45e3-bcc0-69dc7a45f9f8
+Created At:   2020-05-22 19:30:59 +0000 UTC
+Modified At:  2020-05-22 19:30:59 +0000 UTC
 ----------------------------------------------------
-Descriptor list:
+Descriptors:
 ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------

--- a/internal/app/siftool/testdata/TestApp_List/OneGroup.golden
+++ b/internal/app/siftool/testdata/TestApp_List/OneGroup.golden
@@ -1,8 +1,8 @@
-Container id: 6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
-Created on:   2020-05-22 19:30:59 +0000 UTC
-Modified on:  2020-05-22 19:30:59 +0000 UTC
+ID:           6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
+Created At:   2020-05-22 19:30:59 +0000 UTC
+Modified At:  2020-05-22 19:30:59 +0000 UTC
 ----------------------------------------------------
-Descriptor list:
+Descriptors:
 ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)

--- a/internal/app/siftool/testdata/TestApp_List/OneGroupSigned.golden
+++ b/internal/app/siftool/testdata/TestApp_List/OneGroupSigned.golden
@@ -1,8 +1,8 @@
-Container id: 73e1c5c3-5c41-41ed-ad7c-2504d669f140
-Created on:   2020-06-30 00:01:56 +0000 UTC
-Modified on:  2020-06-30 00:01:56 +0000 UTC
+ID:           73e1c5c3-5c41-41ed-ad7c-2504d669f140
+Created At:   2020-06-30 00:01:56 +0000 UTC
+Modified At:  2020-06-30 00:01:56 +0000 UTC
 ----------------------------------------------------
-Descriptor list:
+Descriptors:
 ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)

--- a/internal/app/siftool/testdata/TestApp_List/OneGroupSignedLegacy.golden
+++ b/internal/app/siftool/testdata/TestApp_List/OneGroupSignedLegacy.golden
@@ -1,8 +1,8 @@
-Container id: 6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
-Created on:   2020-05-22 19:30:59 +0000 UTC
-Modified on:  2020-06-20 20:16:39 +0000 UTC
+ID:           6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
+Created At:   2020-05-22 19:30:59 +0000 UTC
+Modified At:  2020-06-20 20:16:39 +0000 UTC
 ----------------------------------------------------
-Descriptor list:
+Descriptors:
 ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)

--- a/internal/app/siftool/testdata/TestApp_List/OneGroupSignedLegacyAll.golden
+++ b/internal/app/siftool/testdata/TestApp_List/OneGroupSignedLegacyAll.golden
@@ -1,8 +1,8 @@
-Container id: 6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
-Created on:   2020-05-22 19:30:59 +0000 UTC
-Modified on:  2020-06-20 20:17:15 +0000 UTC
+ID:           6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
+Created At:   2020-05-22 19:30:59 +0000 UTC
+Modified At:  2020-06-20 20:17:15 +0000 UTC
 ----------------------------------------------------
-Descriptor list:
+Descriptors:
 ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)

--- a/internal/app/siftool/testdata/TestApp_List/OneGroupSignedLegacyGroup.golden
+++ b/internal/app/siftool/testdata/TestApp_List/OneGroupSignedLegacyGroup.golden
@@ -1,8 +1,8 @@
-Container id: 6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
-Created on:   2020-05-22 19:30:59 +0000 UTC
-Modified on:  2020-06-20 20:16:55 +0000 UTC
+ID:           6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
+Created At:   2020-05-22 19:30:59 +0000 UTC
+Modified At:  2020-06-20 20:16:55 +0000 UTC
 ----------------------------------------------------
-Descriptor list:
+Descriptors:
 ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)

--- a/internal/app/siftool/testdata/TestApp_List/TwoGroups.golden
+++ b/internal/app/siftool/testdata/TestApp_List/TwoGroups.golden
@@ -1,8 +1,8 @@
-Container id: 0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
-Created on:   2020-05-22 19:30:59 +0000 UTC
-Modified on:  2020-05-22 19:30:59 +0000 UTC
+ID:           0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
+Created At:   2020-05-22 19:30:59 +0000 UTC
+Modified At:  2020-05-22 19:30:59 +0000 UTC
 ----------------------------------------------------
-Descriptor list:
+Descriptors:
 ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)

--- a/internal/app/siftool/testdata/TestApp_List/TwoGroupsSigned.golden
+++ b/internal/app/siftool/testdata/TestApp_List/TwoGroupsSigned.golden
@@ -1,8 +1,8 @@
-Container id: 610cf3a3-18b0-4622-8b08-772d3510d7b5
-Created on:   2020-06-30 00:01:56 +0000 UTC
-Modified on:  2020-06-30 00:01:56 +0000 UTC
+ID:           610cf3a3-18b0-4622-8b08-772d3510d7b5
+Created At:   2020-06-30 00:01:56 +0000 UTC
+Modified At:  2020-06-30 00:01:56 +0000 UTC
 ----------------------------------------------------
-Descriptor list:
+Descriptors:
 ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)

--- a/internal/app/siftool/testdata/TestApp_List/TwoGroupsSignedLegacy.golden
+++ b/internal/app/siftool/testdata/TestApp_List/TwoGroupsSignedLegacy.golden
@@ -1,8 +1,8 @@
-Container id: 0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
-Created on:   2020-05-22 19:30:59 +0000 UTC
-Modified on:  2020-06-20 20:16:44 +0000 UTC
+ID:           0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
+Created At:   2020-05-22 19:30:59 +0000 UTC
+Modified At:  2020-06-20 20:16:44 +0000 UTC
 ----------------------------------------------------
-Descriptor list:
+Descriptors:
 ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)

--- a/internal/app/siftool/testdata/TestApp_List/TwoGroupsSignedLegacyAll.golden
+++ b/internal/app/siftool/testdata/TestApp_List/TwoGroupsSignedLegacyAll.golden
@@ -1,8 +1,8 @@
-Container id: 0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
-Created on:   2020-05-22 19:30:59 +0000 UTC
-Modified on:  2020-06-20 20:17:19 +0000 UTC
+ID:           0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
+Created At:   2020-05-22 19:30:59 +0000 UTC
+Modified At:  2020-06-20 20:17:19 +0000 UTC
 ----------------------------------------------------
-Descriptor list:
+Descriptors:
 ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)

--- a/internal/app/siftool/testdata/TestApp_List/TwoGroupsSignedLegacyGroup.golden
+++ b/internal/app/siftool/testdata/TestApp_List/TwoGroupsSignedLegacyGroup.golden
@@ -1,8 +1,8 @@
-Container id: 0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
-Created on:   2020-05-22 19:30:59 +0000 UTC
-Modified on:  2020-06-20 20:16:58 +0000 UTC
+ID:           0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
+Created At:   2020-05-22 19:30:59 +0000 UTC
+Modified At:  2020-06-20 20:16:58 +0000 UTC
 ----------------------------------------------------
-Descriptor list:
+Descriptors:
 ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)

--- a/pkg/siftool/testdata/Test_command_getHeader/Empty/out.golden
+++ b/pkg/siftool/testdata/Test_command_getHeader/Empty/out.golden
@@ -1,12 +1,12 @@
-Launch:   #!/usr/bin/env run-singularity
-Version:  01
-Arch:     unknown
-ID:       3fa802cc-358b-45e3-bcc0-69dc7a45f9f8
-Ctime:    2020-05-22 19:30:59 +0000 UTC
-Mtime:    2020-05-22 19:30:59 +0000 UTC
-Dfree:    48
-Dtotal:   48
-Descoff:  4096
-Descrlen: 27 KiB
-Dataoff:  32768
-Datalen:  0 B
+Launch Script:        #!/usr/bin/env run-singularity
+Version:              01
+Primary Architecture: unknown
+ID:                   3fa802cc-358b-45e3-bcc0-69dc7a45f9f8
+Created At:           2020-05-22 19:30:59 +0000 UTC
+Modified At:          2020-05-22 19:30:59 +0000 UTC
+Descriptors Free:     48
+Descriptors Total:    48
+Descriptors Offset:   4096
+Descriptors Size:     27 KiB
+Data Offset:          32768
+Data Size:            0 B

--- a/pkg/siftool/testdata/Test_command_getHeader/OneGroup/out.golden
+++ b/pkg/siftool/testdata/Test_command_getHeader/OneGroup/out.golden
@@ -1,12 +1,12 @@
-Launch:   #!/usr/bin/env run-singularity
-Version:  01
-Arch:     386
-ID:       6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
-Ctime:    2020-05-22 19:30:59 +0000 UTC
-Mtime:    2020-05-22 19:30:59 +0000 UTC
-Dfree:    46
-Dtotal:   48
-Descoff:  4096
-Descrlen: 27 KiB
-Dataoff:  32768
-Datalen:  4 KiB
+Launch Script:        #!/usr/bin/env run-singularity
+Version:              01
+Primary Architecture: 386
+ID:                   6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
+Created At:           2020-05-22 19:30:59 +0000 UTC
+Modified At:          2020-05-22 19:30:59 +0000 UTC
+Descriptors Free:     46
+Descriptors Total:    48
+Descriptors Offset:   4096
+Descriptors Size:     27 KiB
+Data Offset:          32768
+Data Size:            4 KiB

--- a/pkg/siftool/testdata/Test_command_getHeader/OneGroupSigned/out.golden
+++ b/pkg/siftool/testdata/Test_command_getHeader/OneGroupSigned/out.golden
@@ -1,12 +1,12 @@
-Launch:   #!/usr/bin/env run-singularity
-Version:  01
-Arch:     386
-ID:       73e1c5c3-5c41-41ed-ad7c-2504d669f140
-Ctime:    2020-06-30 00:01:56 +0000 UTC
-Mtime:    2020-06-30 00:01:56 +0000 UTC
-Dfree:    45
-Dtotal:   48
-Descoff:  4096
-Descrlen: 27 KiB
-Dataoff:  32768
-Datalen:  9 KiB
+Launch Script:        #!/usr/bin/env run-singularity
+Version:              01
+Primary Architecture: 386
+ID:                   73e1c5c3-5c41-41ed-ad7c-2504d669f140
+Created At:           2020-06-30 00:01:56 +0000 UTC
+Modified At:          2020-06-30 00:01:56 +0000 UTC
+Descriptors Free:     45
+Descriptors Total:    48
+Descriptors Offset:   4096
+Descriptors Size:     27 KiB
+Data Offset:          32768
+Data Size:            9 KiB

--- a/pkg/siftool/testdata/Test_command_getHeader/OneGroupSignedLegacy/out.golden
+++ b/pkg/siftool/testdata/Test_command_getHeader/OneGroupSignedLegacy/out.golden
@@ -1,12 +1,12 @@
-Launch:   #!/usr/bin/env run-singularity
-Version:  01
-Arch:     386
-ID:       6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
-Ctime:    2020-05-22 19:30:59 +0000 UTC
-Mtime:    2020-06-20 20:16:39 +0000 UTC
-Dfree:    45
-Dtotal:   48
-Descoff:  4096
-Descrlen: 27 KiB
-Dataoff:  32768
-Datalen:  9 KiB
+Launch Script:        #!/usr/bin/env run-singularity
+Version:              01
+Primary Architecture: 386
+ID:                   6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
+Created At:           2020-05-22 19:30:59 +0000 UTC
+Modified At:          2020-06-20 20:16:39 +0000 UTC
+Descriptors Free:     45
+Descriptors Total:    48
+Descriptors Offset:   4096
+Descriptors Size:     27 KiB
+Data Offset:          32768
+Data Size:            9 KiB

--- a/pkg/siftool/testdata/Test_command_getHeader/OneGroupSignedLegacyAll/out.golden
+++ b/pkg/siftool/testdata/Test_command_getHeader/OneGroupSignedLegacyAll/out.golden
@@ -1,12 +1,12 @@
-Launch:   #!/usr/bin/env run-singularity
-Version:  01
-Arch:     386
-ID:       6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
-Ctime:    2020-05-22 19:30:59 +0000 UTC
-Mtime:    2020-06-20 20:17:15 +0000 UTC
-Dfree:    44
-Dtotal:   48
-Descoff:  4096
-Descrlen: 27 KiB
-Dataoff:  32768
-Datalen:  13 KiB
+Launch Script:        #!/usr/bin/env run-singularity
+Version:              01
+Primary Architecture: 386
+ID:                   6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
+Created At:           2020-05-22 19:30:59 +0000 UTC
+Modified At:          2020-06-20 20:17:15 +0000 UTC
+Descriptors Free:     44
+Descriptors Total:    48
+Descriptors Offset:   4096
+Descriptors Size:     27 KiB
+Data Offset:          32768
+Data Size:            13 KiB

--- a/pkg/siftool/testdata/Test_command_getHeader/OneGroupSignedLegacyGroup/out.golden
+++ b/pkg/siftool/testdata/Test_command_getHeader/OneGroupSignedLegacyGroup/out.golden
@@ -1,12 +1,12 @@
-Launch:   #!/usr/bin/env run-singularity
-Version:  01
-Arch:     386
-ID:       6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
-Ctime:    2020-05-22 19:30:59 +0000 UTC
-Mtime:    2020-06-20 20:16:55 +0000 UTC
-Dfree:    45
-Dtotal:   48
-Descoff:  4096
-Descrlen: 27 KiB
-Dataoff:  32768
-Datalen:  9 KiB
+Launch Script:        #!/usr/bin/env run-singularity
+Version:              01
+Primary Architecture: 386
+ID:                   6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
+Created At:           2020-05-22 19:30:59 +0000 UTC
+Modified At:          2020-06-20 20:16:55 +0000 UTC
+Descriptors Free:     45
+Descriptors Total:    48
+Descriptors Offset:   4096
+Descriptors Size:     27 KiB
+Data Offset:          32768
+Data Size:            9 KiB

--- a/pkg/siftool/testdata/Test_command_getHeader/TwoGroups/out.golden
+++ b/pkg/siftool/testdata/Test_command_getHeader/TwoGroups/out.golden
@@ -1,12 +1,12 @@
-Launch:   #!/usr/bin/env run-singularity
-Version:  01
-Arch:     386
-ID:       0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
-Ctime:    2020-05-22 19:30:59 +0000 UTC
-Mtime:    2020-05-22 19:30:59 +0000 UTC
-Dfree:    45
-Dtotal:   48
-Descoff:  4096
-Descrlen: 27 KiB
-Dataoff:  32768
-Datalen:  8 KiB
+Launch Script:        #!/usr/bin/env run-singularity
+Version:              01
+Primary Architecture: 386
+ID:                   0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
+Created At:           2020-05-22 19:30:59 +0000 UTC
+Modified At:          2020-05-22 19:30:59 +0000 UTC
+Descriptors Free:     45
+Descriptors Total:    48
+Descriptors Offset:   4096
+Descriptors Size:     27 KiB
+Data Offset:          32768
+Data Size:            8 KiB

--- a/pkg/siftool/testdata/Test_command_getHeader/TwoGroupsSigned/out.golden
+++ b/pkg/siftool/testdata/Test_command_getHeader/TwoGroupsSigned/out.golden
@@ -1,12 +1,12 @@
-Launch:   #!/usr/bin/env run-singularity
-Version:  01
-Arch:     386
-ID:       610cf3a3-18b0-4622-8b08-772d3510d7b5
-Ctime:    2020-06-30 00:01:56 +0000 UTC
-Mtime:    2020-06-30 00:01:56 +0000 UTC
-Dfree:    43
-Dtotal:   48
-Descoff:  4096
-Descrlen: 27 KiB
-Dataoff:  32768
-Datalen:  17 KiB
+Launch Script:        #!/usr/bin/env run-singularity
+Version:              01
+Primary Architecture: 386
+ID:                   610cf3a3-18b0-4622-8b08-772d3510d7b5
+Created At:           2020-06-30 00:01:56 +0000 UTC
+Modified At:          2020-06-30 00:01:56 +0000 UTC
+Descriptors Free:     43
+Descriptors Total:    48
+Descriptors Offset:   4096
+Descriptors Size:     27 KiB
+Data Offset:          32768
+Data Size:            17 KiB

--- a/pkg/siftool/testdata/Test_command_getHeader/TwoGroupsSignedLegacy/out.golden
+++ b/pkg/siftool/testdata/Test_command_getHeader/TwoGroupsSignedLegacy/out.golden
@@ -1,12 +1,12 @@
-Launch:   #!/usr/bin/env run-singularity
-Version:  01
-Arch:     386
-ID:       0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
-Ctime:    2020-05-22 19:30:59 +0000 UTC
-Mtime:    2020-06-20 20:16:44 +0000 UTC
-Dfree:    44
-Dtotal:   48
-Descoff:  4096
-Descrlen: 27 KiB
-Dataoff:  32768
-Datalen:  13 KiB
+Launch Script:        #!/usr/bin/env run-singularity
+Version:              01
+Primary Architecture: 386
+ID:                   0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
+Created At:           2020-05-22 19:30:59 +0000 UTC
+Modified At:          2020-06-20 20:16:44 +0000 UTC
+Descriptors Free:     44
+Descriptors Total:    48
+Descriptors Offset:   4096
+Descriptors Size:     27 KiB
+Data Offset:          32768
+Data Size:            13 KiB

--- a/pkg/siftool/testdata/Test_command_getHeader/TwoGroupsSignedLegacyAll/out.golden
+++ b/pkg/siftool/testdata/Test_command_getHeader/TwoGroupsSignedLegacyAll/out.golden
@@ -1,12 +1,12 @@
-Launch:   #!/usr/bin/env run-singularity
-Version:  01
-Arch:     386
-ID:       0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
-Ctime:    2020-05-22 19:30:59 +0000 UTC
-Mtime:    2020-06-20 20:17:19 +0000 UTC
-Dfree:    43
-Dtotal:   48
-Descoff:  4096
-Descrlen: 27 KiB
-Dataoff:  32768
-Datalen:  17 KiB
+Launch Script:        #!/usr/bin/env run-singularity
+Version:              01
+Primary Architecture: 386
+ID:                   0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
+Created At:           2020-05-22 19:30:59 +0000 UTC
+Modified At:          2020-06-20 20:17:19 +0000 UTC
+Descriptors Free:     43
+Descriptors Total:    48
+Descriptors Offset:   4096
+Descriptors Size:     27 KiB
+Data Offset:          32768
+Data Size:            17 KiB

--- a/pkg/siftool/testdata/Test_command_getHeader/TwoGroupsSignedLegacyGroup/out.golden
+++ b/pkg/siftool/testdata/Test_command_getHeader/TwoGroupsSignedLegacyGroup/out.golden
@@ -1,12 +1,12 @@
-Launch:   #!/usr/bin/env run-singularity
-Version:  01
-Arch:     386
-ID:       0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
-Ctime:    2020-05-22 19:30:59 +0000 UTC
-Mtime:    2020-06-20 20:16:58 +0000 UTC
-Dfree:    44
-Dtotal:   48
-Descoff:  4096
-Descrlen: 27 KiB
-Dataoff:  32768
-Datalen:  13 KiB
+Launch Script:        #!/usr/bin/env run-singularity
+Version:              01
+Primary Architecture: 386
+ID:                   0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
+Created At:           2020-05-22 19:30:59 +0000 UTC
+Modified At:          2020-06-20 20:16:58 +0000 UTC
+Descriptors Free:     44
+Descriptors Total:    48
+Descriptors Offset:   4096
+Descriptors Size:     27 KiB
+Data Offset:          32768
+Data Size:            13 KiB

--- a/pkg/siftool/testdata/Test_command_getInfo/One/out.golden
+++ b/pkg/siftool/testdata/Test_command_getInfo/One/out.golden
@@ -1,12 +1,12 @@
-  Datatype:  FS
-  ID:        1
-  Groupid:   1
-  Link:      NONE
-  Fileoff:   32768
-  Filelen:   4
-  Ctime:     2020-06-30 00:01:56 +0000 UTC
-  Mtime:     2020-06-30 00:01:56 +0000 UTC
-  Name:      .
-  Fstype:    Raw
-  Parttype:  System
-  Arch:      386
+  Data Type:        FS
+  ID:               1
+  Group ID:         1
+  Linked ID:        NONE
+  Offset:           32768
+  Size:             4
+  Created At:       2020-06-30 00:01:56 +0000 UTC
+  Modified At:      2020-06-30 00:01:56 +0000 UTC
+  Name:             .
+  Filesystem Type:  Raw
+  Partition Type:   System
+  Architecture:     386

--- a/pkg/siftool/testdata/Test_command_getInfo/Three/out.golden
+++ b/pkg/siftool/testdata/Test_command_getInfo/Three/out.golden
@@ -1,11 +1,11 @@
-  Datatype:  Signature
-  ID:        3
-  Groupid:   NONE
-  Link:      1 (G)
-  Fileoff:   40960
-  Filelen:   1054
-  Ctime:     2020-06-30 00:01:56 +0000 UTC
-  Mtime:     2020-06-30 00:01:56 +0000 UTC
-  Name:      
-  Hashtype:  SHA-256
-  Entity:    12045C8C0B1004D058DE4BEDA20C27EE7FF7BA84
+  Data Type:    Signature
+  ID:           3
+  Group ID:     NONE
+  Linked ID:    1 (G)
+  Offset:       40960
+  Size:         1054
+  Created At:   2020-06-30 00:01:56 +0000 UTC
+  Modified At:  2020-06-30 00:01:56 +0000 UTC
+  Name:         
+  Hash Type:    SHA-256
+  Entity:       12045C8C0B1004D058DE4BEDA20C27EE7FF7BA84

--- a/pkg/siftool/testdata/Test_command_getInfo/Two/out.golden
+++ b/pkg/siftool/testdata/Test_command_getInfo/Two/out.golden
@@ -1,12 +1,12 @@
-  Datatype:  FS
-  ID:        2
-  Groupid:   1
-  Link:      NONE
-  Fileoff:   36864
-  Filelen:   4
-  Ctime:     2020-06-30 00:01:56 +0000 UTC
-  Mtime:     2020-06-30 00:01:56 +0000 UTC
-  Name:      .
-  Fstype:    Squashfs
-  Parttype:  *System
-  Arch:      386
+  Data Type:        FS
+  ID:               2
+  Group ID:         1
+  Linked ID:        NONE
+  Offset:           36864
+  Size:             4
+  Created At:       2020-06-30 00:01:56 +0000 UTC
+  Modified At:      2020-06-30 00:01:56 +0000 UTC
+  Name:             .
+  Filesystem Type:  Squashfs
+  Partition Type:   *System
+  Architecture:     386

--- a/pkg/siftool/testdata/Test_command_getList/Empty/out.golden
+++ b/pkg/siftool/testdata/Test_command_getList/Empty/out.golden
@@ -1,7 +1,7 @@
-Container id: 3fa802cc-358b-45e3-bcc0-69dc7a45f9f8
-Created on:   2020-05-22 19:30:59 +0000 UTC
-Modified on:  2020-05-22 19:30:59 +0000 UTC
+ID:           3fa802cc-358b-45e3-bcc0-69dc7a45f9f8
+Created At:   2020-05-22 19:30:59 +0000 UTC
+Modified At:  2020-05-22 19:30:59 +0000 UTC
 ----------------------------------------------------
-Descriptor list:
+Descriptors:
 ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------

--- a/pkg/siftool/testdata/Test_command_getList/OneGroup/out.golden
+++ b/pkg/siftool/testdata/Test_command_getList/OneGroup/out.golden
@@ -1,8 +1,8 @@
-Container id: 6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
-Created on:   2020-05-22 19:30:59 +0000 UTC
-Modified on:  2020-05-22 19:30:59 +0000 UTC
+ID:           6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
+Created At:   2020-05-22 19:30:59 +0000 UTC
+Modified At:  2020-05-22 19:30:59 +0000 UTC
 ----------------------------------------------------
-Descriptor list:
+Descriptors:
 ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)

--- a/pkg/siftool/testdata/Test_command_getList/OneGroupSigned/out.golden
+++ b/pkg/siftool/testdata/Test_command_getList/OneGroupSigned/out.golden
@@ -1,8 +1,8 @@
-Container id: 73e1c5c3-5c41-41ed-ad7c-2504d669f140
-Created on:   2020-06-30 00:01:56 +0000 UTC
-Modified on:  2020-06-30 00:01:56 +0000 UTC
+ID:           73e1c5c3-5c41-41ed-ad7c-2504d669f140
+Created At:   2020-06-30 00:01:56 +0000 UTC
+Modified At:  2020-06-30 00:01:56 +0000 UTC
 ----------------------------------------------------
-Descriptor list:
+Descriptors:
 ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)

--- a/pkg/siftool/testdata/Test_command_getList/OneGroupSignedLegacy/out.golden
+++ b/pkg/siftool/testdata/Test_command_getList/OneGroupSignedLegacy/out.golden
@@ -1,8 +1,8 @@
-Container id: 6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
-Created on:   2020-05-22 19:30:59 +0000 UTC
-Modified on:  2020-06-20 20:16:39 +0000 UTC
+ID:           6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
+Created At:   2020-05-22 19:30:59 +0000 UTC
+Modified At:  2020-06-20 20:16:39 +0000 UTC
 ----------------------------------------------------
-Descriptor list:
+Descriptors:
 ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)

--- a/pkg/siftool/testdata/Test_command_getList/OneGroupSignedLegacyAll/out.golden
+++ b/pkg/siftool/testdata/Test_command_getList/OneGroupSignedLegacyAll/out.golden
@@ -1,8 +1,8 @@
-Container id: 6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
-Created on:   2020-05-22 19:30:59 +0000 UTC
-Modified on:  2020-06-20 20:17:15 +0000 UTC
+ID:           6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
+Created At:   2020-05-22 19:30:59 +0000 UTC
+Modified At:  2020-06-20 20:17:15 +0000 UTC
 ----------------------------------------------------
-Descriptor list:
+Descriptors:
 ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)

--- a/pkg/siftool/testdata/Test_command_getList/OneGroupSignedLegacyGroup/out.golden
+++ b/pkg/siftool/testdata/Test_command_getList/OneGroupSignedLegacyGroup/out.golden
@@ -1,8 +1,8 @@
-Container id: 6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
-Created on:   2020-05-22 19:30:59 +0000 UTC
-Modified on:  2020-06-20 20:16:55 +0000 UTC
+ID:           6ecc76b7-a497-4f7f-9ebd-8da2a04c6be1
+Created At:   2020-05-22 19:30:59 +0000 UTC
+Modified At:  2020-06-20 20:16:55 +0000 UTC
 ----------------------------------------------------
-Descriptor list:
+Descriptors:
 ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)

--- a/pkg/siftool/testdata/Test_command_getList/TwoGroups/out.golden
+++ b/pkg/siftool/testdata/Test_command_getList/TwoGroups/out.golden
@@ -1,8 +1,8 @@
-Container id: 0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
-Created on:   2020-05-22 19:30:59 +0000 UTC
-Modified on:  2020-05-22 19:30:59 +0000 UTC
+ID:           0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
+Created At:   2020-05-22 19:30:59 +0000 UTC
+Modified At:  2020-05-22 19:30:59 +0000 UTC
 ----------------------------------------------------
-Descriptor list:
+Descriptors:
 ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)

--- a/pkg/siftool/testdata/Test_command_getList/TwoGroupsSigned/out.golden
+++ b/pkg/siftool/testdata/Test_command_getList/TwoGroupsSigned/out.golden
@@ -1,8 +1,8 @@
-Container id: 610cf3a3-18b0-4622-8b08-772d3510d7b5
-Created on:   2020-06-30 00:01:56 +0000 UTC
-Modified on:  2020-06-30 00:01:56 +0000 UTC
+ID:           610cf3a3-18b0-4622-8b08-772d3510d7b5
+Created At:   2020-06-30 00:01:56 +0000 UTC
+Modified At:  2020-06-30 00:01:56 +0000 UTC
 ----------------------------------------------------
-Descriptor list:
+Descriptors:
 ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)

--- a/pkg/siftool/testdata/Test_command_getList/TwoGroupsSignedLegacy/out.golden
+++ b/pkg/siftool/testdata/Test_command_getList/TwoGroupsSignedLegacy/out.golden
@@ -1,8 +1,8 @@
-Container id: 0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
-Created on:   2020-05-22 19:30:59 +0000 UTC
-Modified on:  2020-06-20 20:16:44 +0000 UTC
+ID:           0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
+Created At:   2020-05-22 19:30:59 +0000 UTC
+Modified At:  2020-06-20 20:16:44 +0000 UTC
 ----------------------------------------------------
-Descriptor list:
+Descriptors:
 ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)

--- a/pkg/siftool/testdata/Test_command_getList/TwoGroupsSignedLegacyAll/out.golden
+++ b/pkg/siftool/testdata/Test_command_getList/TwoGroupsSignedLegacyAll/out.golden
@@ -1,8 +1,8 @@
-Container id: 0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
-Created on:   2020-05-22 19:30:59 +0000 UTC
-Modified on:  2020-06-20 20:17:19 +0000 UTC
+ID:           0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
+Created At:   2020-05-22 19:30:59 +0000 UTC
+Modified At:  2020-06-20 20:17:19 +0000 UTC
 ----------------------------------------------------
-Descriptor list:
+Descriptors:
 ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)

--- a/pkg/siftool/testdata/Test_command_getList/TwoGroupsSignedLegacyGroup/out.golden
+++ b/pkg/siftool/testdata/Test_command_getList/TwoGroupsSignedLegacyGroup/out.golden
@@ -1,8 +1,8 @@
-Container id: 0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
-Created on:   2020-05-22 19:30:59 +0000 UTC
-Modified on:  2020-06-20 20:16:58 +0000 UTC
+ID:           0b19ec2c-0b08-46c9-95ae-fa88cd9e48a1
+Created At:   2020-05-22 19:30:59 +0000 UTC
+Modified At:  2020-06-20 20:16:58 +0000 UTC
 ----------------------------------------------------
-Descriptor list:
+Descriptors:
 ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
 ------------------------------------------------------------------------------
 1    |1       |NONE    |32768-32772               |FS (Raw/System/386)


### PR DESCRIPTION
Rather than using field names of legacy SIF types, use human-readable values in textual output of `header`, `list`, and `info` commands.