### PR TITLE
Fix OptObjectAlignment(0) Panic

### DIFF
--- a/pkg/sif/create.go
+++ b/pkg/sif/create.go
@@ -23,7 +23,7 @@ func nextAligned(offset int64, alignment int) int64 {
 	align64 := uint64(alignment)
 	offset64 := uint64(offset)
 
-	if offset64%align64 != 0 {
+	if align64 != 0 && offset64%align64 != 0 {
 		offset64 = (offset64 & ^(align64 - 1)) + align64
 	}
 

--- a/pkg/sif/create_test.go
+++ b/pkg/sif/create_test.go
@@ -25,6 +25,8 @@ func TestNextAligned(t *testing.T) {
 		align    int
 		expected int64
 	}{
+		{name: "align 0 to 0", offset: 0, align: 0, expected: 0},
+		{name: "align 1 to 0", offset: 1, align: 0, expected: 1},
 		{name: "align 0 to 1024", offset: 0, align: 1024, expected: 0},
 		{name: "align 1 to 1024", offset: 1, align: 1024, expected: 1024},
 		{name: "align 1023 to 1024", offset: 1023, align: 1024, expected: 1024},


### PR DESCRIPTION
Fix `nextAligned` to handle case where `alignment` is zero. Extend unit test to cover this case.

Closes #143 