### PR TITLE
Use "Local" Time Location

### DIFF
--- a/internal/app/siftool/info.go
+++ b/internal/app/siftool/info.go
@@ -43,8 +43,8 @@ func writeHeader(w io.Writer, f *sif.FileImage) error {
 	fmt.Fprintln(tw, "Version:\t", f.Version())
 	fmt.Fprintln(tw, "Primary Architecture:\t", f.PrimaryArch())
 	fmt.Fprintln(tw, "ID:\t", f.ID())
-	fmt.Fprintln(tw, "Created At:\t", f.CreatedAt())
-	fmt.Fprintln(tw, "Modified At:\t", f.ModifiedAt())
+	fmt.Fprintln(tw, "Created At:\t", f.CreatedAt().UTC())
+	fmt.Fprintln(tw, "Modified At:\t", f.ModifiedAt().UTC())
 	fmt.Fprintln(tw, "Descriptors Free:\t", f.DescriptorsFree())
 	fmt.Fprintln(tw, "Descriptors Total:\t", f.DescriptorsTotal())
 	fmt.Fprintln(tw, "Descriptors Offset:\t", f.DescriptorsOffset())
@@ -65,8 +65,8 @@ func (a *App) Header(path string) error {
 // writeList writes the list of descriptors in f to w.
 func writeList(w io.Writer, f *sif.FileImage) error {
 	fmt.Fprintln(w, "ID:          ", f.ID())
-	fmt.Fprintln(w, "Created At:  ", f.CreatedAt())
-	fmt.Fprintln(w, "Modified At: ", f.ModifiedAt())
+	fmt.Fprintln(w, "Created At:  ", f.CreatedAt().UTC())
+	fmt.Fprintln(w, "Modified At: ", f.ModifiedAt().UTC())
 	fmt.Fprintln(w, "----------------------------------------------------")
 
 	fmt.Fprintln(w, "Descriptors:")
@@ -145,8 +145,8 @@ func writeInfo(w io.Writer, v sif.Descriptor) error {
 
 	fmt.Fprintln(tw, "  Offset:\t", v.Offset())
 	fmt.Fprintln(tw, "  Size:\t", v.Size())
-	fmt.Fprintln(tw, "  Created At:\t", v.CreatedAt())
-	fmt.Fprintln(tw, "  Modified At:\t", v.ModifiedAt())
+	fmt.Fprintln(tw, "  Created At:\t", v.CreatedAt().UTC())
+	fmt.Fprintln(tw, "  Modified At:\t", v.ModifiedAt().UTC())
 	fmt.Fprintln(tw, "  Name:\t", v.Name())
 	switch v.DataType() {
 	case sif.DataPartition:

--- a/pkg/sif/descriptor.go
+++ b/pkg/sif/descriptor.go
@@ -153,10 +153,10 @@ func (d Descriptor) Offset() int64 { return d.raw.Offset }
 func (d Descriptor) Size() int64 { return d.raw.Size }
 
 // CreatedAt returns the creation time of the data object.
-func (d Descriptor) CreatedAt() time.Time { return time.Unix(d.raw.CreatedAt, 0).UTC() }
+func (d Descriptor) CreatedAt() time.Time { return time.Unix(d.raw.CreatedAt, 0) }
 
 // ModifiedAt returns the modification time of the data object.
-func (d Descriptor) ModifiedAt() time.Time { return time.Unix(d.raw.ModifiedAt, 0).UTC() }
+func (d Descriptor) ModifiedAt() time.Time { return time.Unix(d.raw.ModifiedAt, 0) }
 
 // Name returns the name of the data object.
 func (d Descriptor) Name() string { return strings.TrimRight(string(d.raw.Name[:]), "\000") }

--- a/pkg/sif/descriptor_input.go
+++ b/pkg/sif/descriptor_input.go
@@ -247,8 +247,8 @@ func (di DescriptorInput) fillDescriptor(d *rawDescriptor) error {
 	d.DataType = di.dt
 	d.GroupID = di.opts.groupID | descrGroupMask
 	d.LinkedID = di.opts.linkID
-	d.CreatedAt = di.opts.t.UTC().Unix()
-	d.ModifiedAt = di.opts.t.UTC().Unix()
+	d.CreatedAt = di.opts.t.Unix()
+	d.ModifiedAt = di.opts.t.Unix()
 	d.UID = 0
 	d.GID = 0
 

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -325,10 +325,10 @@ func (f *FileImage) PrimaryArch() string { return f.h.Arch.GoArch() }
 func (f *FileImage) ID() string { return f.h.ID.String() }
 
 // CreatedAt returns the creation time of the image.
-func (f *FileImage) CreatedAt() time.Time { return time.Unix(f.h.CreatedAt, 0).UTC() }
+func (f *FileImage) CreatedAt() time.Time { return time.Unix(f.h.CreatedAt, 0) }
 
 // ModifiedAt returns the last modification time of the image.
-func (f *FileImage) ModifiedAt() time.Time { return time.Unix(f.h.ModifiedAt, 0).UTC() }
+func (f *FileImage) ModifiedAt() time.Time { return time.Unix(f.h.ModifiedAt, 0) }
 
 // DescriptorsFree returns the number of free descriptors in the image.
 func (f *FileImage) DescriptorsFree() int64 { return f.h.DescriptorsFree }


### PR DESCRIPTION
Return times in local timezone from `CreatedAt`/`ModifiedAt` methods. Continue using UTC to display dates in `siftool` command output.

Closes #138 