### PR TITLE
Use Wrapped Errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - gocritic
     - godot
     - godox
+    - goerr113
     - gofumpt
     - goimports
     - gomodguard

--- a/internal/pkg/git/git.go
+++ b/internal/pkg/git/git.go
@@ -128,6 +128,8 @@ func (d *Description) Reference() *plumbing.Reference {
 	return d.ref
 }
 
+var errTagNotFound = errors.New("semantic version tag not found")
+
 // Version returns a semantic version based on d. If d is tagged directly, the parsed version is
 // returned. Otherwise, a version is derived that preserves semantic precedence.
 //
@@ -137,7 +139,7 @@ func (d *Description) Reference() *plumbing.Reference {
 //  - If d.tag.Name = "v0.1.3" and d.n = 0, 0.1.3 is returned.
 func (d *Description) Version() (semver.Version, error) {
 	if d.v == nil {
-		return semver.Version{}, errors.New("no semver tags found")
+		return semver.Version{}, errTagNotFound
 	}
 
 	// If this version wasn't tagged directly, modify tag.

--- a/pkg/sif/create.go
+++ b/pkg/sif/create.go
@@ -276,7 +276,7 @@ func CreateContainerAtPath(path string, opts ...CreateOpt) (*FileImage, error) {
 func zeroData(fimg *FileImage, descr *rawDescriptor) error {
 	// first, move to data object offset
 	if _, err := fimg.rw.Seek(descr.Offset, io.SeekStart); err != nil {
-		return fmt.Errorf("seeking to data object offset: %s", err)
+		return err
 	}
 
 	var zero [4096]byte
@@ -288,7 +288,7 @@ func zeroData(fimg *FileImage, descr *rawDescriptor) error {
 		}
 
 		if _, err := fimg.rw.Write(zero[:upbound]); err != nil {
-			return fmt.Errorf("writing 0's to data object")
+			return err
 		}
 		n -= 4096
 		if n <= 0 {
@@ -311,15 +311,11 @@ func resetDescriptor(fimg *FileImage, index int) error {
 
 	// first, move to descriptor offset
 	if _, err := fimg.rw.Seek(offset, io.SeekStart); err != nil {
-		return fmt.Errorf("seeking to descriptor: %s", err)
+		return err
 	}
 
 	var emptyDesc rawDescriptor
-	if err := binary.Write(fimg.rw, binary.LittleEndian, emptyDesc); err != nil {
-		return fmt.Errorf("binary writing empty descriptor: %s", err)
-	}
-
-	return nil
+	return binary.Write(fimg.rw, binary.LittleEndian, emptyDesc)
 }
 
 // addOpts accumulates object add options.

--- a/pkg/sif/descriptor_input.go
+++ b/pkg/sif/descriptor_input.go
@@ -7,6 +7,7 @@ package sif
 
 import (
 	"crypto"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -131,6 +132,8 @@ func OptCryptoMessageMetadata(ft FormatType, mt MessageType) DescriptorInputOpt 
 	}
 }
 
+var errUnknownArchitcture = errors.New("unknown architecture")
+
 // OptPartitionMetadata sets metadata for a partition data object. The filesystem type is set to
 // fs, the partition type is set to pt, and the CPU architecture is set to arch. The value of arch
 // should be the architecture as represented by the Go runtime.
@@ -144,7 +147,7 @@ func OptPartitionMetadata(fs FSType, pt PartType, arch string) DescriptorInputOp
 
 		sifarch := getSIFArch(arch)
 		if sifarch == hdrArchUnknown {
-			return fmt.Errorf("unknown architecture: %v", arch)
+			return fmt.Errorf("%w: %v", errUnknownArchitcture, arch)
 		}
 
 		p := partition{

--- a/pkg/sif/select.go
+++ b/pkg/sif/select.go
@@ -195,9 +195,11 @@ func (f *FileImage) withDescriptors(selectFn DescriptorSelectorFunc, onMatchFn f
 	return nil
 }
 
+var errAbort = errors.New("abort")
+
 // abortOnMatch is a semantic convenience function that always returns a non-nil error, which can
 // be used as a no-op matchFn.
-func abortOnMatch(*rawDescriptor) error { return errors.New("") }
+func abortOnMatch(*rawDescriptor) error { return errAbort }
 
 // WithDescriptors calls fn with each in-use descriptor in f, until fn returns true.
 func (f *FileImage) WithDescriptors(fn func(d Descriptor) bool) {

--- a/pkg/siftool/del.go
+++ b/pkg/siftool/del.go
@@ -26,7 +26,7 @@ func (c *command) getDel() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := strconv.ParseUint(args[0], 10, 32)
 			if err != nil {
-				return fmt.Errorf("while converting input descriptor id: %s", err)
+				return fmt.Errorf("while converting id: %w", err)
 			}
 
 			return c.app.Del(args[1], uint32(id))

--- a/pkg/siftool/dump.go
+++ b/pkg/siftool/dump.go
@@ -27,7 +27,7 @@ func (c *command) getDump() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := strconv.ParseUint(args[0], 10, 32)
 			if err != nil {
-				return fmt.Errorf("while converting input descriptor id: %s", err)
+				return fmt.Errorf("while converting id: %w", err)
 			}
 
 			return c.app.Dump(args[1], uint32(id))

--- a/pkg/siftool/info.go
+++ b/pkg/siftool/info.go
@@ -28,7 +28,7 @@ func (c *command) getInfo() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := strconv.ParseUint(args[0], 10, 32)
 			if err != nil {
-				return fmt.Errorf("while converting input descriptor id: %s", err)
+				return fmt.Errorf("while converting id: %w", err)
 			}
 
 			return c.app.Info(args[1], uint32(id))

--- a/pkg/siftool/setprim.go
+++ b/pkg/siftool/setprim.go
@@ -26,7 +26,7 @@ func (c *command) getSetPrim() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := strconv.ParseUint(args[0], 10, 32)
 			if err != nil {
-				return fmt.Errorf("while converting input descriptor id: %s", err)
+				return fmt.Errorf("while converting id: %w", err)
 			}
 
 			return c.app.Setprim(args[1], uint32(id))

--- a/test/gen_sifs.go
+++ b/test/gen_sifs.go
@@ -7,7 +7,7 @@ package main
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"log"
 	"os"
 	"path/filepath"
@@ -22,6 +22,8 @@ func fixedTime() time.Time {
 	return time.Date(2020, 6, 30, 0, 1, 56, 0, time.UTC)
 }
 
+var errUnexpectedNumEntities = errors.New("unexpected number of entities")
+
 func getEntity() (*openpgp.Entity, error) {
 	f, err := os.Open(filepath.Join("keys", "private.asc"))
 	if err != nil {
@@ -34,8 +36,8 @@ func getEntity() (*openpgp.Entity, error) {
 		return nil, err
 	}
 
-	if got, want := len(el), 1; got != want {
-		return nil, fmt.Errorf("got %v entities, want %v", got, want)
+	if len(el) != 1 {
+		return nil, errUnexpectedNumEntities
 	}
 	return el[0], nil
 }


### PR DESCRIPTION
Use Go 1.13 wrapped errors. Enable `goerr113` linter to ease maintenance.