### PR TITLE
Deprecate v1 Module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: use github.com/sylabs/sif/v2 instead.
 module github.com/sylabs/sif
 
 go 1.17


### PR DESCRIPTION
Mark module deprecated using [module deprecation introduced in Go 1.17](https://golang.org/ref/mod#go-mod-file-module-deprecation).

Closes #117 