### PR TITLE
Fix OptLinkedID Documentation

### DIFF
--- a/pkg/sif/descriptor_input.go
+++ b/pkg/sif/descriptor_input.go
@@ -46,8 +46,7 @@ func OptGroupID(groupID uint32) DescriptorInputOpt {
 	}
 }
 
-// OptLinkedID specifies that the data object is linked to the data object group with the specified
-// ID.
+// OptLinkedID specifies that the data object is linked to the data object with the specified ID.
 func OptLinkedID(id uint32) DescriptorInputOpt {
 	return func(_ DataType, opts *descriptorOpts) error {
 		if id == 0 {


### PR DESCRIPTION
Fix `OptLinkedID` documentation to clarify it is used to specify a data object (not data object group).