### PR TITLE
Reproducible Builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,7 @@ builds:
       - 7
     env:
       - CGO_ENABLED=0
+    flags: '-trimpath'
     ldflags: '-s -w -X main.version={{ .Version }} -X main.commit={{ .FullCommit }} -X main.date={{ .CommitDate }} -X main.builtBy=goreleaser'
     main: ./cmd/siftool
     mod_timestamp: '{{ .CommitTimestamp }}'

--- a/cmd/siftool/siftool.go
+++ b/cmd/siftool/siftool.go
@@ -33,10 +33,6 @@ func writeVersion(w io.Writer) error {
 
 	fmt.Fprintf(tw, "Version:\t%v\n", version)
 
-	if date != "" {
-		fmt.Fprintf(tw, "Built:\t%v\n", date)
-	}
-
 	if builtBy != "" {
 		fmt.Fprintf(tw, "By:\t%v\n", builtBy)
 	}
@@ -47,6 +43,10 @@ func writeVersion(w io.Writer) error {
 		} else {
 			fmt.Fprintf(tw, "Commit:\t%v (%v)\n", commit, state)
 		}
+	}
+
+	if date != "" {
+		fmt.Fprintf(tw, "Date:\t%v\n", date)
 	}
 
 	fmt.Fprintf(tw, "Runtime:\t%v (%v/%v)\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)

--- a/magefile.go
+++ b/magefile.go
@@ -30,19 +30,22 @@ var Aliases = map[string]interface{}{
 
 // ldFlags returns linker flags to pass to various Go commands.
 func ldFlags() string {
-	vals := []string{
-		"-X", "main.builtBy=mage",
-		"-X", fmt.Sprintf("main.date=%v", time.Now().UTC().Format(time.RFC3339)),
-	}
+	vals := []string{"-X", "main.builtBy=mage"}
 
 	// Attempt to get git details.
 	if d, err := git.Describe("."); err == nil {
-		vals = append(vals, "-X", fmt.Sprintf("main.commit=%v", d.Reference().Hash()))
+		vals = append(vals, "-X", fmt.Sprintf("main.commit=%v", d.CommitHash()))
 
 		if d.IsClean() {
-			vals = append(vals, "-X", "main.state=clean")
+			vals = append(vals,
+				"-X", fmt.Sprintf("main.date=%v", d.CommitTime().UTC().Format(time.RFC3339)),
+				"-X", "main.state=clean",
+			)
 		} else {
-			vals = append(vals, "-X", "main.state=dirty")
+			vals = append(vals,
+				"-X", fmt.Sprintf("main.date=%v", time.Now().UTC().Format(time.RFC3339)),
+				"-X", "main.state=dirty",
+			)
 		}
 
 		if v, err := d.Version(); err == nil {
@@ -52,6 +55,8 @@ func ldFlags() string {
 		}
 	} else {
 		fmt.Fprintf(os.Stderr, "warning: failed to describe git HEAD: %v\n", err)
+
+		vals = append(vals, "-X", fmt.Sprintf("main.date=%v", time.Now().UTC().Format(time.RFC3339)))
 	}
 
 	return strings.Join(vals, " ")

--- a/magefile.go
+++ b/magefile.go
@@ -71,7 +71,7 @@ func (ns Build) All() {
 
 // Source compiles all source code.
 func (Build) Source() error {
-	return sh.Run(mg.GoCmd(), "build", "-ldflags", ldFlags(), "./...")
+	return sh.Run(mg.GoCmd(), "build", "-trimpath", "-ldflags", ldFlags(), "./...")
 }
 
 type Install mg.Namespace
@@ -83,7 +83,7 @@ func (ns Install) All() {
 
 // Bin installs binary to GOBIN.
 func (Install) Bin() error {
-	return sh.Run(mg.GoCmd(), "install", "-ldflags", ldFlags(), "./cmd/siftool")
+	return sh.Run(mg.GoCmd(), "install", "-trimpath", "-ldflags", ldFlags(), "./cmd/siftool")
 }
 
 type Test mg.Namespace

--- a/magefile.go
+++ b/magefile.go
@@ -28,6 +28,11 @@ var Aliases = map[string]interface{}{
 	"test":    Test.All,
 }
 
+// env returns the environment to use when running Go commands.
+func env() map[string]string {
+	return map[string]string{"CGO_ENABLED": "0"}
+}
+
 // ldFlags returns linker flags to pass to various Go commands.
 func ldFlags() string {
 	vals := []string{"-s", "-w", "-X", "main.builtBy=mage"}
@@ -71,7 +76,7 @@ func (ns Build) All() {
 
 // Source compiles all source code.
 func (Build) Source() error {
-	return sh.Run(mg.GoCmd(), "build", "-trimpath", "-ldflags", ldFlags(), "./...")
+	return sh.RunWith(env(), mg.GoCmd(), "build", "-trimpath", "-ldflags", ldFlags(), "./...")
 }
 
 type Install mg.Namespace
@@ -83,7 +88,7 @@ func (ns Install) All() {
 
 // Bin installs binary to GOBIN.
 func (Install) Bin() error {
-	return sh.Run(mg.GoCmd(), "install", "-trimpath", "-ldflags", ldFlags(), "./cmd/siftool")
+	return sh.RunWith(env(), mg.GoCmd(), "install", "-trimpath", "-ldflags", ldFlags(), "./cmd/siftool")
 }
 
 type Test mg.Namespace

--- a/magefile.go
+++ b/magefile.go
@@ -30,7 +30,7 @@ var Aliases = map[string]interface{}{
 
 // ldFlags returns linker flags to pass to various Go commands.
 func ldFlags() string {
-	vals := []string{"-X", "main.builtBy=mage"}
+	vals := []string{"-s", "-w", "-X", "main.builtBy=mage"}
 
 	// Attempt to get git details.
 	if d, err := git.Describe("."); err == nil {


### PR DESCRIPTION
Refactor `github.com/sylabs/sif/v2/internal/pkg/git` to expose `(*Description).CommitTime`. Remove `(*Description).Reference()` and add `(*Description).CommitHash()` in its place.

Ensure builds are reproducible by:

- Using `(*Description).CommitTime` as `main.date` for `mage` builds when the working directory is clean.
- Disabling CGO in `mage` builds.
- Use `-trimpath` in `mage`/`goreleaser` builds.

Harmonize linker flags used by `mage`/`goreleaser` by adding `-s -w` to `mage` build/install commands.

Use `Date:` rather than `Built:` in `siftool version` output to clarify semantics of this value (in clean builds, `main.date` is the commit date rather than the build date.

Closes #156 