### PR TITLE
Update golangci-lint and Enable New Linters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:16-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.42-alpine
+      - image: golangci/golangci-lint:v1.43-alpine
   golang-previous:
     docker:
       - image: golang:1.16

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,9 @@ linters:
   disable-all: true
   enable:
     - asciicheck
+    - bidichk
     - bodyclose
+    - contextcheck
     - deadcode
     - depguard
     - dogsled
@@ -28,14 +30,17 @@ linters:
     - gosimple
     - govet
     - ineffassign
+    - ireturn
     - lll
     - misspell
+    - nilnil
     - nolintlint
     - prealloc
     - revive
     - rowserrcheck
     - staticcheck
     - structcheck
+    - tenv
     - typecheck
     - unconvert
     - unparam


### PR DESCRIPTION
Bump `golangci-lint` to v1.43 and enable `bidichk`, `contextcheck`, `ireturn`, `nilnil` and `tenv` linters.