### PR TITLE
Improve Output for Mage Commands

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -89,7 +89,7 @@ func (Test) Unit() error {
 		return err
 	}
 
-	return sh.RunWith(c.Env(), mg.GoCmd(), c.Args()...)
+	return sh.RunWithV(c.Env(), mg.GoCmd(), c.Args()...)
 }
 
 type Cover mg.Namespace
@@ -108,5 +108,5 @@ func (Cover) Unit(path string) error {
 		return err
 	}
 
-	return sh.RunWith(c.Env(), mg.GoCmd(), c.Args()...)
+	return sh.RunWithV(c.Env(), mg.GoCmd(), c.Args()...)
 }


### PR DESCRIPTION
Output `stdout` for `mage cover:unit`/`mage test:unit`.