### PR TITLE
CI Updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   node:
     docker:
-      - image: node:16-slim
+      - image: node:17-slim
   golangci-lint:
     docker:
       - image: golangci/golangci-lint:v1.43-alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:17-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.43-alpine
+      - image: golangci/golangci-lint:v1.44-alpine
   golang-previous:
     docker:
       - image: golang:1.16

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,12 +8,15 @@ linters:
     - asciicheck
     - bidichk
     - bodyclose
+    - containedctx
     - contextcheck
     - deadcode
+    - decorder
     - depguard
     - dogsled
     - dupl
     - errcheck
+    - errchkjson
     - errname
     - errorlint
     - exportloopref
@@ -29,9 +32,11 @@ linters:
     - gosec
     - gosimple
     - govet
+    - grouper
     - ineffassign
     - ireturn
     - lll
+    - maintidx
     - misspell
     - nilnil
     - nolintlint

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,8 +16,8 @@ builds:
       - arm
       - arm64
     goarm:
-      - 6
-      - 7
+      - '6'
+      - '7'
     env:
       - CGO_ENABLED=0
     flags: '-trimpath'
@@ -27,7 +27,7 @@ builds:
 
 archives:
   - format: tar.gz
-    wrap_in_directory: true
+    wrap_in_directory: 'true'
     name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     files:
       - README.md

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # LICENSE
 
-Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
Bump `node` to v17, and `golangci-lint` to v1.44. Use correct types in `goreleaser` config.