### PR TITLE
Adopt Go 1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,10 @@ executors:
       - image: golangci/golangci-lint:v1.44-alpine
   golang-previous:
     docker:
-      - image: golang:1.16
+      - image: golang:1.17
   golang-latest:
     docker:
-      - image: golang:1.17
+      - image: golang:1.18
 
 jobs:
   lint-markdown:

--- a/mage.go
+++ b/mage.go
@@ -1,10 +1,9 @@
-// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/magefile.go
+++ b/magefile.go
@@ -1,10 +1,9 @@
-// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
 
 //go:build mage
-// +build mage
 
 package main
 


### PR DESCRIPTION
Bump Go versions used in CI to 1.17 and 1.18. Remove deprecated build constraint format.

Closes #125 