### PR TITLE
Add RISC-V Architecture

### DIFF
--- a/pkg/sif/arch.go
+++ b/pkg/sif/arch.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -18,6 +18,7 @@ var (
 	hdrArchMIPS64   archType = [...]byte{'0', '9', '\x00'}
 	hdrArchMIPS64le archType = [...]byte{'1', '0', '\x00'}
 	hdrArchS390x    archType = [...]byte{'1', '1', '\x00'}
+	hdrArchRISCV64  archType = [...]byte{'1', '2', '\x00'}
 )
 
 type archType [3]byte
@@ -36,6 +37,7 @@ func getSIFArch(arch string) archType {
 		"mips64":   hdrArchMIPS64,
 		"mips64le": hdrArchMIPS64le,
 		"s390x":    hdrArchS390x,
+		"riscv64":  hdrArchRISCV64,
 	}
 
 	t, ok := archMap[arch]
@@ -59,6 +61,7 @@ func (t archType) GoArch() string {
 		hdrArchMIPS64:   "mips64",
 		hdrArchMIPS64le: "mips64le",
 		hdrArchS390x:    "s390x",
+		hdrArchRISCV64:  "riscv64",
 	}
 
 	arch, ok := archMap[t]

--- a/pkg/siftool/add.go
+++ b/pkg/siftool/add.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -66,7 +66,7 @@ func addFlags(fs *pflag.FlagSet) {
   1-386,       2-amd64,     3-arm,
   4-arm64,     5-ppc64,     6-ppc64le,
   7-mips,      8-mipsle,    9-mips64,
-  10-mips64le, 11-s390x`)
+  10-mips64le, 11-s390x,    12-riscv64`)
 	signHash = fs.Int32("signhash", 0, `the signature hash used (with -datatype 5-Signature)
 [NEEDED, no default]:
   1-SHA256,      2-SHA384,      3-SHA512,
@@ -130,6 +130,8 @@ func getArch() string {
 		return "mips64le"
 	case 11:
 		return "s390x"
+	case 12:
+		return "riscv64"
 	default:
 		return "unknown"
 	}

--- a/pkg/siftool/testdata/TestAddCommands/Add/out.golden
+++ b/pkg/siftool/testdata/TestAddCommands/Add/out.golden
@@ -24,7 +24,7 @@ Flags:
                               1-386,       2-amd64,     3-arm,
                               4-arm64,     5-ppc64,     6-ppc64le,
                               7-mips,      8-mipsle,    9-mips64,
-                              10-mips64le, 11-s390x
+                              10-mips64le, 11-s390x,    12-riscv64
       --partfs int32        the filesystem used (with -datatype 4-Partition)
                             [NEEDED, no default]:
                               1-Squash,    2-Ext3,      3-ImmuObj,


### PR DESCRIPTION
Add `riscv64` architecture to `archType` mapping functions. Add corresponding option to `--partarch` flag of `add` command.

Closes #181 