### PR TITLE
ci: updated sbom name generating template

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,6 +68,6 @@ archives:
 
 sboms:
   - documents:
-      - "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}.bom.cdx.json"
+      - '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}.bom.cdx.json'
     artifacts: binary
     args: ["$artifact", "--file", "$document", "--output", "cyclonedx-json"]


### PR DESCRIPTION
closes #202 

Fixed the sbom generating issue caused by missed part in the template. 