### PR TITLE
Bump golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:17-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.45-alpine
+      - image: golangci/golangci-lint:v1.46-alpine
   golang-previous:
     docker:
       - image: golang:1.17

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,7 @@ linters:
     - misspell
     - nilnil
     - nolintlint
+    - nonamedreturns
     - prealloc
     - revive
     - rowserrcheck

--- a/internal/app/siftool/file.go
+++ b/internal/app/siftool/file.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -12,7 +12,7 @@ import (
 )
 
 // withFileImage calls fn with a FileImage loaded from path.
-func withFileImage(path string, writable bool, fn func(*sif.FileImage) error) (err error) {
+func withFileImage(path string, writable bool, fn func(*sif.FileImage) error) error {
 	flag := os.O_RDONLY
 	if writable {
 		flag = os.O_RDWR
@@ -22,11 +22,12 @@ func withFileImage(path string, writable bool, fn func(*sif.FileImage) error) (e
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if uerr := f.UnloadContainer(); uerr != nil && err == nil {
-			err = uerr
-		}
-	}()
 
-	return fn(f)
+	err = fn(f)
+
+	if uerr := f.UnloadContainer(); err == nil {
+		err = uerr
+	}
+
+	return err
 }

--- a/pkg/integrity/select.go
+++ b/pkg/integrity/select.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -152,7 +152,9 @@ func getGroupMinObjectID(f *sif.FileImage, groupID uint32) (uint32, error) {
 
 // getGroupIDs returns all identifiers for the groups contained in f, sorted by ID. If no groups
 // are present, errNoGroupsFound is returned.
-func getGroupIDs(f *sif.FileImage) (groupIDs []uint32, err error) {
+func getGroupIDs(f *sif.FileImage) ([]uint32, error) {
+	var groupIDs []uint32
+
 	f.WithDescriptors(func(od sif.Descriptor) bool {
 		if groupID := od.GroupID(); groupID != 0 {
 			groupIDs = insertSorted(groupIDs, groupID)
@@ -161,10 +163,10 @@ func getGroupIDs(f *sif.FileImage) (groupIDs []uint32, err error) {
 	})
 
 	if len(groupIDs) == 0 {
-		err = errNoGroupsFound
+		return nil, errNoGroupsFound
 	}
 
-	return groupIDs, err
+	return groupIDs, nil
 }
 
 // getFingerprints returns a sorted list of unique fingerprints contained in sigs.

--- a/pkg/sif/buffer.go
+++ b/pkg/sif/buffer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -25,7 +25,7 @@ func NewBuffer(buf []byte) *Buffer {
 var errNegativeOffset = errors.New("negative offset")
 
 // ReadAt implements the io.ReaderAt interface.
-func (b *Buffer) ReadAt(p []byte, off int64) (n int, err error) {
+func (b *Buffer) ReadAt(p []byte, off int64) (int, error) {
 	if off < 0 {
 		return 0, errNegativeOffset
 	}
@@ -34,17 +34,17 @@ func (b *Buffer) ReadAt(p []byte, off int64) (n int, err error) {
 		return 0, io.EOF
 	}
 
-	n = copy(p, b.buf[off:])
+	n := copy(p, b.buf[off:])
 	if n < len(p) {
-		err = io.EOF
+		return n, io.EOF
 	}
-	return n, err
+	return n, nil
 }
 
 var errNegativePosition = errors.New("negative position")
 
 // Write implements the io.Writer interface.
-func (b *Buffer) Write(p []byte) (n int, err error) {
+func (b *Buffer) Write(p []byte) (int, error) {
 	if b.pos < 0 {
 		return 0, errNegativePosition
 	}
@@ -53,7 +53,7 @@ func (b *Buffer) Write(p []byte) (n int, err error) {
 		b.buf = append(b.buf, make([]byte, need-have)...)
 	}
 
-	n = copy(b.buf[b.pos:], p)
+	n := copy(b.buf[b.pos:], p)
 	b.pos += int64(n)
 	return n, nil
 }

--- a/pkg/sif/descriptor.go
+++ b/pkg/sif/descriptor.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -96,7 +96,7 @@ func (d *rawDescriptor) setExtra(v interface{}) error {
 }
 
 // getPartitionMetadata gets metadata for a partition data object.
-func (d rawDescriptor) getPartitionMetadata() (fs FSType, pt PartType, arch string, err error) {
+func (d rawDescriptor) getPartitionMetadata() (FSType, PartType, string, error) {
 	if got, want := d.DataType, DataPartition; got != want {
 		return 0, 0, "", &unexpectedDataTypeError{got, []DataType{want}}
 	}
@@ -142,6 +142,7 @@ func (d Descriptor) GroupID() uint32 { return d.raw.GroupID &^ descrGroupMask }
 // LinkedID returns the object/group ID d is linked to, or zero if d does not contain a linked
 // ID. If isGroup is true, the returned id is an object group ID. Otherwise, the returned id is a
 // data object ID.
+//nolint:nonamedreturns // Named returns effective as documentation.
 func (d Descriptor) LinkedID() (id uint32, isGroup bool) {
 	return d.raw.LinkedID &^ descrGroupMask, d.raw.LinkedID&descrGroupMask == descrGroupMask
 }
@@ -162,6 +163,7 @@ func (d Descriptor) ModifiedAt() time.Time { return time.Unix(d.raw.ModifiedAt, 
 func (d Descriptor) Name() string { return strings.TrimRight(string(d.raw.Name[:]), "\000") }
 
 // PartitionMetadata gets metadata for a partition data object.
+//nolint:nonamedreturns // Named returns effective as documentation.
 func (d Descriptor) PartitionMetadata() (fs FSType, pt PartType, arch string, err error) {
 	return d.raw.getPartitionMetadata()
 }
@@ -186,6 +188,7 @@ func getHashType(ht hashType) (crypto.Hash, error) {
 }
 
 // SignatureMetadata gets metadata for a signature data object.
+//nolint:nonamedreturns // Named returns effective as documentation.
 func (d Descriptor) SignatureMetadata() (ht crypto.Hash, fp []byte, err error) {
 	if got, want := d.raw.DataType, DataSignature; got != want {
 		return ht, fp, &unexpectedDataTypeError{got, []DataType{want}}


### PR DESCRIPTION
Bump `golangci-lint` to 1.46. Enable `nonamedreturns` and refactor/`nolint` as appropriate.