### PR TITLE
Go 1.19 Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,10 @@ executors:
       - image: golangci/golangci-lint:v1.46-alpine
   golang-previous:
     docker:
-      - image: golang:1.17
+      - image: golang:1.18
   golang-latest:
     docker:
-      - image: golang:1.18
+      - image: golang:1.19
 
 jobs:
   lint-markdown:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sylabs/sif/v2
 
-go 1.17
+go 1.18
 
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20220517143526-88bb52951d5b

--- a/go.sum
+++ b/go.sum
@@ -33,7 +33,6 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5U
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/pkg/integrity/digest.go
+++ b/pkg/integrity/digest.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -78,8 +78,8 @@ func newDigestReader(h crypto.Hash, r io.Reader) (digest, error) {
 // For reference, the plaintext of legacy signatures is comprised of the string "SIFHASH:\n",
 // followed by a digest value. For example:
 //
-// 	SIFHASH:
-//  2f0b3dca0ec42683d306338f68689aba29cdb83625b8cc0b8a789f8de92342495a6264b0c134e706630636bf90c6f331
+//	SIFHASH:
+//	2f0b3dca0ec42683d306338f68689aba29cdb83625b8cc0b8a789f8de92342495a6264b0c134e706630636bf90c6f331
 func newLegacyDigest(ht crypto.Hash, b []byte) (digest, error) {
 	b = bytes.TrimPrefix(b, []byte("SIFHASH:\n"))
 	b = bytes.TrimSuffix(b, []byte("\n"))

--- a/pkg/integrity/doc.go
+++ b/pkg/integrity/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -7,7 +7,7 @@
 Package integrity implements functions to add, examine, and verify digital signatures in a SIF
 image.
 
-Sign
+# Sign
 
 To add one or more digital signatures to a SIF, create a Signer, and supply a signing PGP entity:
 
@@ -23,7 +23,7 @@ Finally, to apply the signature(s):
 
 	err := s.Sign()
 
-Verify
+# Verify
 
 To examine and/or verify digital signatures in a SIF, create a Verifier:
 

--- a/pkg/sif/descriptor.go
+++ b/pkg/sif/descriptor.go
@@ -142,6 +142,7 @@ func (d Descriptor) GroupID() uint32 { return d.raw.GroupID &^ descrGroupMask }
 // LinkedID returns the object/group ID d is linked to, or zero if d does not contain a linked
 // ID. If isGroup is true, the returned id is an object group ID. Otherwise, the returned id is a
 // data object ID.
+//
 //nolint:nonamedreturns // Named returns effective as documentation.
 func (d Descriptor) LinkedID() (id uint32, isGroup bool) {
 	return d.raw.LinkedID &^ descrGroupMask, d.raw.LinkedID&descrGroupMask == descrGroupMask
@@ -163,6 +164,7 @@ func (d Descriptor) ModifiedAt() time.Time { return time.Unix(d.raw.ModifiedAt, 
 func (d Descriptor) Name() string { return strings.TrimRight(string(d.raw.Name[:]), "\000") }
 
 // PartitionMetadata gets metadata for a partition data object.
+//
 //nolint:nonamedreturns // Named returns effective as documentation.
 func (d Descriptor) PartitionMetadata() (fs FSType, pt PartType, arch string, err error) {
 	return d.raw.getPartitionMetadata()
@@ -188,6 +190,7 @@ func getHashType(ht hashType) (crypto.Hash, error) {
 }
 
 // SignatureMetadata gets metadata for a signature data object.
+//
 //nolint:nonamedreturns // Named returns effective as documentation.
 func (d Descriptor) SignatureMetadata() (ht crypto.Hash, fp []byte, err error) {
 	if got, want := d.raw.DataType, DataSignature; got != want {

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -10,69 +10,68 @@
 //
 // Layout of a SIF file (example):
 //
-//     .================================================.
-//     | GLOBAL HEADER: Sifheader                       |
-//     | - launch: "#!/usr/bin/env..."                  |
-//     | - magic: "SIF_MAGIC"                           |
-//     | - version: "1"                                 |
-//     | - arch: "4"                                    |
-//     | - uuid: b2659d4e-bd50-4ea5-bd17-eec5e54f918e   |
-//     | - ctime: 1504657553                            |
-//     | - mtime: 1504657653                            |
-//     | - ndescr: 3                                    |
-//     | - descroff: 120                                | --.
-//     | - descrlen: 432                                |   |
-//     | - dataoff: 4096                                |   |
-//     | - datalen: 619362                              |   |
-//     |------------------------------------------------| <-'
-//     | DESCR[0]: Sifdeffile                           |
-//     | - Sifcommon                                    |
-//     |   - datatype: DATA_DEFFILE                     |
-//     |   - id: 1                                      |
-//     |   - groupid: 1                                 |
-//     |   - link: NONE                                 |
-//     |   - fileoff: 4096                              | --.
-//     |   - filelen: 222                               |   |
-//     |------------------------------------------------| <-----.
-//     | DESCR[1]: Sifpartition                         |   |   |
-//     | - Sifcommon                                    |   |   |
-//     |   - datatype: DATA_PARTITION                   |   |   |
-//     |   - id: 2                                      |   |   |
-//     |   - groupid: 1                                 |   |   |
-//     |   - link: NONE                                 |   |   |
-//     |   - fileoff: 4318                              | ----. |
-//     |   - filelen: 618496                            |   | | |
-//     | - fstype: Squashfs                             |   | | |
-//     | - parttype: System                             |   | | |
-//     | - content: Linux                               |   | | |
-//     |------------------------------------------------|   | | |
-//     | DESCR[2]: Sifsignature                         |   | | |
-//     | - Sifcommon                                    |   | | |
-//     |   - datatype: DATA_SIGNATURE                   |   | | |
-//     |   - id: 3                                      |   | | |
-//     |   - groupid: NONE                              |   | | |
-//     |   - link: 2                                    | ------'
-//     |   - fileoff: 622814                            | ------.
-//     |   - filelen: 644                               |   | | |
-//     | - hashtype: SHA384                             |   | | |
-//     | - entity: @                                    |   | | |
-//     |------------------------------------------------| <-' | |
-//     | Definition file data                           |     | |
-//     | .                                              |     | |
-//     | .                                              |     | |
-//     | .                                              |     | |
-//     |------------------------------------------------| <---' |
-//     | File system partition image                    |       |
-//     | .                                              |       |
-//     | .                                              |       |
-//     | .                                              |       |
-//     |------------------------------------------------| <-----'
-//     | Signed verification data                       |
-//     | .                                              |
-//     | .                                              |
-//     | .                                              |
-//     `================================================'
-//
+//	.================================================.
+//	| GLOBAL HEADER: Sifheader                       |
+//	| - launch: "#!/usr/bin/env..."                  |
+//	| - magic: "SIF_MAGIC"                           |
+//	| - version: "1"                                 |
+//	| - arch: "4"                                    |
+//	| - uuid: b2659d4e-bd50-4ea5-bd17-eec5e54f918e   |
+//	| - ctime: 1504657553                            |
+//	| - mtime: 1504657653                            |
+//	| - ndescr: 3                                    |
+//	| - descroff: 120                                | --.
+//	| - descrlen: 432                                |   |
+//	| - dataoff: 4096                                |   |
+//	| - datalen: 619362                              |   |
+//	|------------------------------------------------| <-'
+//	| DESCR[0]: Sifdeffile                           |
+//	| - Sifcommon                                    |
+//	|   - datatype: DATA_DEFFILE                     |
+//	|   - id: 1                                      |
+//	|   - groupid: 1                                 |
+//	|   - link: NONE                                 |
+//	|   - fileoff: 4096                              | --.
+//	|   - filelen: 222                               |   |
+//	|------------------------------------------------| <-----.
+//	| DESCR[1]: Sifpartition                         |   |   |
+//	| - Sifcommon                                    |   |   |
+//	|   - datatype: DATA_PARTITION                   |   |   |
+//	|   - id: 2                                      |   |   |
+//	|   - groupid: 1                                 |   |   |
+//	|   - link: NONE                                 |   |   |
+//	|   - fileoff: 4318                              | ----. |
+//	|   - filelen: 618496                            |   | | |
+//	| - fstype: Squashfs                             |   | | |
+//	| - parttype: System                             |   | | |
+//	| - content: Linux                               |   | | |
+//	|------------------------------------------------|   | | |
+//	| DESCR[2]: Sifsignature                         |   | | |
+//	| - Sifcommon                                    |   | | |
+//	|   - datatype: DATA_SIGNATURE                   |   | | |
+//	|   - id: 3                                      |   | | |
+//	|   - groupid: NONE                              |   | | |
+//	|   - link: 2                                    | ------'
+//	|   - fileoff: 622814                            | ------.
+//	|   - filelen: 644                               |   | | |
+//	| - hashtype: SHA384                             |   | | |
+//	| - entity: @                                    |   | | |
+//	|------------------------------------------------| <-' | |
+//	| Definition file data                           |     | |
+//	| .                                              |     | |
+//	| .                                              |     | |
+//	| .                                              |     | |
+//	|------------------------------------------------| <---' |
+//	| File system partition image                    |       |
+//	| .                                              |       |
+//	| .                                              |       |
+//	| .                                              |       |
+//	|------------------------------------------------| <-----'
+//	| Signed verification data                       |
+//	| .                                              |
+//	| .                                              |
+//	| .                                              |
+//	`================================================'
 package sif
 
 import (


### PR DESCRIPTION
Test against Go 1.18 and 1.19 in CI. Bump module language version to 1.18. Reformat doc comments with `gofmt` from Go 1.19.