### PR TITLE
Bump golangci-lint to v1.49

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:18-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.48-alpine
+      - image: golangci/golangci-lint:v1.49-alpine
   golang-previous:
     docker:
       - image: golang:1.18

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,6 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
-    - deadcode
     - decorder
     - depguard
     - dogsled
@@ -30,6 +29,7 @@ linters:
     - govet
     - grouper
     - ineffassign
+    - interfacebloat
     - ireturn
     - lll
     - maintidx
@@ -38,16 +38,15 @@ linters:
     - nolintlint
     - nonamedreturns
     - prealloc
+    - reassign
     - revive
     - rowserrcheck
     - staticcheck
-    - structcheck
     - tenv
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
 
 linters-settings:


### PR DESCRIPTION
Disable deprecated `deadcode`, `structcheck` and `varcheck` linters. Add `interfacebloat` and `reassign` linters.