### PR TITLE
ci: remove rowserrcheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,7 +40,6 @@ linters:
     - prealloc
     - reassign
     - revive
-    - rowserrcheck
     - staticcheck
     - tenv
     - typecheck


### PR DESCRIPTION
Remove [rowserrcheck](https://github.com/jingyugao/rowserrcheck) linter, which is disabled by `golangci-lint` because it lacks support for generics.