### PR TITLE
Bump golangci-lint to v1.50

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:18-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.49-alpine
+      - image: golangci/golangci-lint:v1.50-alpine
   golang-previous:
     docker:
       - image: golang:1.18

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - depguard
     - dogsled
     - dupl
+    - dupword
     - errcheck
     - errchkjson
     - errname

--- a/pkg/sif/create.go
+++ b/pkg/sif/create.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -104,7 +104,7 @@ func (f *FileImage) writeDescriptors() error {
 	return binary.Write(f.rw, binary.LittleEndian, f.rds)
 }
 
-// writeHeader writes the the global header in f to backing storage.
+// writeHeader writes the global header in f to backing storage.
 func (f *FileImage) writeHeader() error {
 	if _, err := f.rw.Seek(0, io.SeekStart); err != nil {
 		return err


### PR DESCRIPTION
Bump `golangci-lint` to v1.50. Enable `dupword` linter.