### PR TITLE
Refactor verifyTask

### DIFF
--- a/pkg/integrity/clearsign.go
+++ b/pkg/integrity/clearsign.go
@@ -8,7 +8,6 @@ package integrity
 import (
 	"bytes"
 	"crypto"
-	"encoding/json"
 	"errors"
 	"io"
 	"time"
@@ -20,22 +19,13 @@ import (
 
 var errClearsignedMsgNotFound = errors.New("clearsigned message not found")
 
-// Hash functions specified for OpenPGP in RFC4880, excluding those that are not currently
-// recommended by NIST.
-var supportedPGPAlgorithms = []crypto.Hash{
-	crypto.SHA224,
-	crypto.SHA256,
-	crypto.SHA384,
-	crypto.SHA512,
-}
-
 type clearsignEncoder struct {
 	e      *openpgp.Entity
 	config *packet.Config
 }
 
-// newClearsignEncoder returns an encoder that signs messages in clear-sign format using entity e. If
-// timeFunc is not nil, it is used to generate signature timestamps.
+// newClearsignEncoder returns an encoder that signs messages in clear-sign format using entity e.
+// If timeFunc is not nil, it is used to generate signature timestamps.
 func newClearsignEncoder(e *openpgp.Entity, timeFunc func() time.Time) *clearsignEncoder {
 	return &clearsignEncoder{
 		e: e,
@@ -58,53 +48,52 @@ func (en *clearsignEncoder) signMessage(w io.Writer, r io.Reader) (crypto.Hash, 
 	return en.config.Hash(), err
 }
 
-// verifyAndDecodeJSON reads the first clearsigned message in data, verifies its signature, and
-// returns the signing entity any suffix of data which follows the message. The plaintext is
-// unmarshalled to v (if not nil).
-func verifyAndDecodeJSON(data []byte, v interface{}, kr openpgp.KeyRing) (*openpgp.Entity, []byte, error) {
-	// Decode clearsign block and check signature.
-	e, plaintext, rest, err := verifyAndDecode(data, kr)
+type clearsignDecoder struct {
+	kr openpgp.KeyRing
+}
+
+// newClearsignDecoder returns a decoder that verifies messages in clear-signe format using key
+// material from kr.
+func newClearsignDecoder(kr openpgp.KeyRing) *clearsignDecoder {
+	return &clearsignDecoder{
+		kr: kr,
+	}
+}
+
+// verifyMessage reads a message from r, verifies its signature, and returns the message contents.
+// On success, the signing entity is set in vr.
+func (de *clearsignDecoder) verifyMessage(r io.Reader, h crypto.Hash, vr *VerifyResult) ([]byte, error) {
+	data, err := io.ReadAll(r)
 	if err != nil {
-		return e, rest, err
+		return nil, err
 	}
 
-	// Unmarshal plaintext, if requested.
-	if v != nil {
-		err = json.Unmarshal(plaintext, v)
-	}
-	return e, rest, err
-}
-
-// verifyAndDecode reads the first clearsigned message in data, verifies its signature, and returns
-// the signing entity, plaintext and suffix of data which follows the message.
-func verifyAndDecode(data []byte, kr openpgp.KeyRing) (*openpgp.Entity, []byte, []byte, error) {
-	// Decode clearsign block.
-	b, rest := clearsign.Decode(data)
-	if b == nil {
-		return nil, nil, rest, errClearsignedMsgNotFound
-	}
-
-	// Check signature.
-	e, err := openpgp.CheckDetachedSignatureAndHash(
-		kr,
-		bytes.NewReader(b.Bytes),
-		b.ArmoredSignature.Body,
-		supportedPGPAlgorithms,
-		nil,
-	)
-	return e, b.Plaintext, rest, err
-}
-
-// isLegacySignature reads the first clearsigned message in data, and returns true if the plaintext
-// contains a legacy signature.
-func isLegacySignature(data []byte) (bool, error) {
 	// Decode clearsign block.
 	b, _ := clearsign.Decode(data)
 	if b == nil {
-		return false, errClearsignedMsgNotFound
+		return nil, errClearsignedMsgNotFound
 	}
 
-	// The plaintext of legacy signatures always begins with "SIFHASH", and non-legacy signatures
-	// never do, as they are JSON.
-	return bytes.HasPrefix(b.Plaintext, []byte("SIFHASH:\n")), nil
+	// Hash functions specified for OpenPGP in RFC4880, excluding those that are not currently
+	// recommended by NIST.
+	expectedHashes := []crypto.Hash{
+		crypto.SHA224,
+		crypto.SHA256,
+		crypto.SHA384,
+		crypto.SHA512,
+	}
+
+	// Check signature.
+	vr.e, err = openpgp.CheckDetachedSignatureAndHash(
+		de.kr,
+		bytes.NewReader(b.Bytes),
+		b.ArmoredSignature.Body,
+		expectedHashes,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return b.Plaintext, err
 }

--- a/pkg/integrity/clearsign.go
+++ b/pkg/integrity/clearsign.go
@@ -46,16 +46,16 @@ func newClearsignEncoder(e *openpgp.Entity, timeFunc func() time.Time) *clearsig
 }
 
 // signMessage signs the message from r in clear-sign format, and writes the result to w. On
-// success, the hash function and fingerprint of the signing key are returned.
-func (s *clearsignEncoder) signMessage(w io.Writer, r io.Reader) (crypto.Hash, []byte, error) {
-	plaintext, err := clearsign.Encode(w, s.e.PrivateKey, s.config)
+// success, the hash function is returned.
+func (en *clearsignEncoder) signMessage(w io.Writer, r io.Reader) (crypto.Hash, error) {
+	plaintext, err := clearsign.Encode(w, en.e.PrivateKey, en.config)
 	if err != nil {
-		return 0, nil, err
+		return 0, err
 	}
 	defer plaintext.Close()
 
 	_, err = io.Copy(plaintext, r)
-	return s.config.Hash(), s.e.PrimaryKey.Fingerprint, err
+	return en.config.Hash(), err
 }
 
 // verifyAndDecodeJSON reads the first clearsigned message in data, verifies its signature, and

--- a/pkg/integrity/clearsign.go
+++ b/pkg/integrity/clearsign.go
@@ -52,7 +52,7 @@ type clearsignDecoder struct {
 	kr openpgp.KeyRing
 }
 
-// newClearsignDecoder returns a decoder that verifies messages in clear-signe format using key
+// newClearsignDecoder returns a decoder that verifies messages in clear-sign format using key
 // material from kr.
 func newClearsignDecoder(kr openpgp.KeyRing) *clearsignDecoder {
 	return &clearsignDecoder{

--- a/pkg/integrity/clearsign_test.go
+++ b/pkg/integrity/clearsign_test.go
@@ -9,7 +9,6 @@ import (
 	"bufio"
 	"bytes"
 	"crypto"
-	"encoding/json"
 	"errors"
 	"io"
 	"reflect"
@@ -22,10 +21,8 @@ import (
 	"github.com/sebdah/goldie/v2"
 )
 
-type testType struct {
-	One int
-	Two int
-}
+var testMessage = `{"One":1,"Two":2}
+`
 
 func Test_clearsignEncoder_signMessage(t *testing.T) {
 	e := getTestEntity(t)
@@ -36,20 +33,17 @@ func Test_clearsignEncoder_signMessage(t *testing.T) {
 	tests := []struct {
 		name     string
 		en       *clearsignEncoder
-		r        io.Reader
 		wantErr  bool
 		wantHash crypto.Hash
 	}{
 		{
 			name:    "EncryptedKey",
 			en:      newClearsignEncoder(encrypted, fixedTime),
-			r:       strings.NewReader(`{"One":1,"Two":2}`),
 			wantErr: true,
 		},
 		{
 			name:     "OK",
 			en:       newClearsignEncoder(e, fixedTime),
-			r:        strings.NewReader(`{"One":1,"Two":2}`),
 			wantHash: crypto.SHA256,
 		},
 	}
@@ -59,7 +53,7 @@ func Test_clearsignEncoder_signMessage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := bytes.Buffer{}
 
-			ht, err := tt.en.signMessage(&b, tt.r)
+			ht, err := tt.en.signMessage(&b, strings.NewReader(testMessage))
 			if got, want := err, tt.wantErr; (got != nil) != want {
 				t.Fatalf("got error %v, wantErr %v", got, want)
 			}
@@ -76,15 +70,8 @@ func Test_clearsignEncoder_signMessage(t *testing.T) {
 	}
 }
 
-func TestVerifyAndDecodeJSON(t *testing.T) {
+func Test_clearsignDecoder_verifyMessage(t *testing.T) {
 	e := getTestEntity(t)
-
-	testValue := testType{1, 2}
-
-	testMessage, err := json.Marshal(testValue)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	// This is used to corrupt the plaintext.
 	corruptClearsign := func(w io.Writer, s string) error {
@@ -120,22 +107,63 @@ func TestVerifyAndDecodeJSON(t *testing.T) {
 	tests := []struct {
 		name       string
 		hash       crypto.Hash
-		el         openpgp.EntityList
 		corrupter  func(w io.Writer, s string) error
-		output     interface{}
+		de         *clearsignDecoder
 		wantErr    error
 		wantEntity *openpgp.Entity
 	}{
-		{name: "ErrUnknownIssuer", el: openpgp.EntityList{}, wantErr: pgperrors.ErrUnknownIssuer},
-		{name: "CorruptedClearsign", el: openpgp.EntityList{e}, corrupter: corruptClearsign},
-		{name: "CorruptedSignature", el: openpgp.EntityList{e}, corrupter: corruptSignature},
-		{name: "VerifyOnly", el: openpgp.EntityList{e}, wantEntity: e},
-		{name: "DefaultHash", el: openpgp.EntityList{e}, output: &testType{}, wantEntity: e},
-		{name: "SHA1", hash: crypto.SHA1, el: openpgp.EntityList{e}, wantErr: pgperrors.StructuralError("hash algorithm mismatch with cleartext message headers")}, //nolint:lll
-		{name: "SHA224", hash: crypto.SHA224, el: openpgp.EntityList{e}, output: &testType{}, wantEntity: e},
-		{name: "SHA256", hash: crypto.SHA256, el: openpgp.EntityList{e}, output: &testType{}, wantEntity: e},
-		{name: "SHA384", hash: crypto.SHA384, el: openpgp.EntityList{e}, output: &testType{}, wantEntity: e},
-		{name: "SHA512", hash: crypto.SHA512, el: openpgp.EntityList{e}, output: &testType{}, wantEntity: e},
+		{
+			name:    "UnknownIssuer",
+			de:      newClearsignDecoder(openpgp.EntityList{}),
+			wantErr: pgperrors.ErrUnknownIssuer,
+		},
+		{
+			name:      "CorruptedClearsign",
+			corrupter: corruptClearsign,
+			de:        newClearsignDecoder(openpgp.EntityList{e}),
+			wantErr:   pgperrors.SignatureError("hash tag doesn't match"),
+		},
+		{
+			name:      "CorruptedSignature",
+			corrupter: corruptSignature,
+			de:        newClearsignDecoder(openpgp.EntityList{e}),
+			wantErr:   pgperrors.StructuralError("signature subpacket truncated"),
+		},
+		{
+			name:       "DefaultHash",
+			de:         newClearsignDecoder(openpgp.EntityList{e}),
+			wantEntity: e,
+		},
+		{
+			name:    "SHA1",
+			hash:    crypto.SHA1,
+			de:      newClearsignDecoder(openpgp.EntityList{e}),
+			wantErr: pgperrors.StructuralError("hash algorithm mismatch with cleartext message headers"),
+		},
+		{
+			name:       "SHA224",
+			hash:       crypto.SHA224,
+			de:         newClearsignDecoder(openpgp.EntityList{e}),
+			wantEntity: e,
+		},
+		{
+			name:       "SHA256",
+			hash:       crypto.SHA256,
+			de:         newClearsignDecoder(openpgp.EntityList{e}),
+			wantEntity: e,
+		},
+		{
+			name:       "SHA384",
+			hash:       crypto.SHA384,
+			de:         newClearsignDecoder(openpgp.EntityList{e}),
+			wantEntity: e,
+		},
+		{
+			name:       "SHA512",
+			hash:       crypto.SHA512,
+			de:         newClearsignDecoder(openpgp.EntityList{e}),
+			wantEntity: e,
+		},
 	}
 
 	for _, tt := range tests {
@@ -143,14 +171,15 @@ func TestVerifyAndDecodeJSON(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := bytes.Buffer{}
 
-			cs := clearsignEncoder{
+			// Sign and encode message.
+			en := clearsignEncoder{
 				e: e,
 				config: &packet.Config{
 					DefaultHash: tt.hash,
 					Time:        fixedTime,
 				},
 			}
-			_, err := cs.signMessage(&b, bytes.NewReader(testMessage))
+			h, err := en.signMessage(&b, strings.NewReader(testMessage))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -164,31 +193,20 @@ func TestVerifyAndDecodeJSON(t *testing.T) {
 				}
 			}
 
-			// Verify and decode.
-			e, rest, err := verifyAndDecodeJSON(b.Bytes(), tt.output, tt.el)
+			// Decode and verify message.
+			var vr VerifyResult
+			message, err := tt.de.verifyMessage(bytes.NewReader(b.Bytes()), h, &vr)
 
-			// Shouldn't be any trailing bytes.
-			if n := len(rest); n != 0 {
-				t.Errorf("%v trailing bytes", n)
-			}
-
-			// Verify the error (if any) is appropriate.
-			if tt.corrupter == nil {
-				if got, want := err, tt.wantErr; !errors.Is(got, want) {
-					t.Fatalf("got error %v, want %v", got, want)
-				}
-			} else if err == nil {
-				t.Errorf("got nil error despite corruption")
+			if got, want := err, tt.wantErr; !errors.Is(got, want) {
+				t.Fatalf("got error %v, want %v", got, want)
 			}
 
 			if err == nil {
-				if tt.output != nil {
-					if got, want := tt.output, &testValue; !reflect.DeepEqual(got, want) {
-						t.Errorf("got value %v, want %v", got, want)
-					}
+				if got, want := string(message), testMessage; got != want {
+					t.Errorf("got message %v, want %v", got, want)
 				}
 
-				if got, want := e, tt.wantEntity; !reflect.DeepEqual(got, want) {
+				if got, want := vr.e, tt.wantEntity; !reflect.DeepEqual(got, want) {
 					t.Errorf("got entity %+v, want %+v", got, want)
 				}
 			}

--- a/pkg/integrity/clearsign_test.go
+++ b/pkg/integrity/clearsign_test.go
@@ -39,7 +39,6 @@ func Test_clearsignEncoder_signMessage(t *testing.T) {
 		r        io.Reader
 		wantErr  bool
 		wantHash crypto.Hash
-		wantFP   []byte
 	}{
 		{
 			name:    "EncryptedKey",
@@ -52,7 +51,6 @@ func Test_clearsignEncoder_signMessage(t *testing.T) {
 			en:       newClearsignEncoder(e, fixedTime),
 			r:        strings.NewReader(`{"One":1,"Two":2}`),
 			wantHash: crypto.SHA256,
-			wantFP:   e.PrimaryKey.Fingerprint,
 		},
 	}
 
@@ -61,7 +59,7 @@ func Test_clearsignEncoder_signMessage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := bytes.Buffer{}
 
-			ht, fp, err := tt.en.signMessage(&b, tt.r)
+			ht, err := tt.en.signMessage(&b, tt.r)
 			if got, want := err, tt.wantErr; (got != nil) != want {
 				t.Fatalf("got error %v, wantErr %v", got, want)
 			}
@@ -69,10 +67,6 @@ func Test_clearsignEncoder_signMessage(t *testing.T) {
 			if err == nil {
 				if got, want := ht, tt.wantHash; got != want {
 					t.Errorf("got hash %v, want %v", got, want)
-				}
-
-				if got, want := fp, tt.wantFP; !bytes.Equal(got, want) {
-					t.Errorf("got fingerprint %v, want %v", got, want)
 				}
 
 				g := goldie.New(t, goldie.WithTestNameForDir(true))
@@ -156,7 +150,7 @@ func TestVerifyAndDecodeJSON(t *testing.T) {
 					Time:        fixedTime,
 				},
 			}
-			_, _, err := cs.signMessage(&b, bytes.NewReader(testMessage))
+			_, err := cs.signMessage(&b, bytes.NewReader(testMessage))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/integrity/select.go
+++ b/pkg/integrity/select.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/ProtonMail/go-crypto/openpgp/clearsign"
 	"github.com/sylabs/sif/v2/pkg/sif"
 )
 
@@ -97,6 +98,19 @@ func getObjectSignatures(f *sif.FileImage, id uint32) ([]sif.Descriptor, error) 
 	return sigs, nil
 }
 
+// isLegacySignature returns true if data contains a legacy signature.
+func isLegacySignature(data []byte) bool {
+	// Legacy signatures always encoded in clear-sign format.
+	b, _ := clearsign.Decode(data)
+	if b == nil {
+		return false
+	}
+
+	// The plaintext of legacy signatures always begins with "SIFHASH", and non-legacy signatures
+	// never do, as they are JSON.
+	return bytes.HasPrefix(b.Plaintext, []byte("SIFHASH:\n"))
+}
+
 // getGroupSignatures returns descriptors in f that contain signature objects linked to the object
 // group with identifier groupID. If legacy is true, only legacy signatures are considered.
 // Otherwise, only non-legacy signatures are considered. If no such signatures are found, a
@@ -112,8 +126,7 @@ func getGroupSignatures(f *sif.FileImage, groupID uint32, legacy bool) ([]sif.De
 				return false, err
 			}
 
-			isLegacy, err := isLegacySignature(b)
-			return isLegacy == legacy, err
+			return isLegacySignature(b) == legacy, err
 		},
 	)
 	if err != nil {

--- a/pkg/integrity/sign.go
+++ b/pkg/integrity/sign.go
@@ -29,9 +29,9 @@ var (
 var ErrNoKeyMaterial = errors.New("key material not provided")
 
 type encoder interface {
-	// signMessage signs the message from r, and writes the result to w. On success, the hash
-	// function and fingerprint of the signing key are returned.
-	signMessage(w io.Writer, r io.Reader) (ht crypto.Hash, fp []byte, err error)
+	// signMessage signs the message from r, and writes the result to w. On success, the signature
+	// hash function is returned.
+	signMessage(w io.Writer, r io.Reader) (ht crypto.Hash, err error)
 }
 
 type groupSigner struct {
@@ -40,6 +40,7 @@ type groupSigner struct {
 	id     uint32           // Group ID.
 	ods    []sif.Descriptor // Descriptors of object(s) to sign.
 	mdHash crypto.Hash      // Hash type for metadata.
+	fp     []byte           // Fingerprint of signing entity.
 }
 
 // groupSignerOpt are used to configure gs.
@@ -75,12 +76,23 @@ func optSignGroupMetadataHash(h crypto.Hash) groupSignerOpt {
 	}
 }
 
+// optSignGroupFingerprint sets fp as the fingerprint of the signing entity.
+func optSignGroupFingerprint(fp []byte) groupSignerOpt {
+	return func(gs *groupSigner) error {
+		gs.fp = fp
+		return nil
+	}
+}
+
 // newGroupSigner returns a new groupSigner to add a digital signature using en for the specified
 // group to f, according to opts.
 //
 // By default, all data objects in the group will be signed. To override this behavior, use
 // optSignGroupObjects(). To override the default metadata hash algorithm, use
 // optSignGroupMetadataHash().
+//
+// By default, the fingerprint of the signing entity is not set. To override this behavior, use
+// optSignGroupFingerprint.
 func newGroupSigner(en encoder, f *sif.FileImage, groupID uint32, opts ...groupSignerOpt) (*groupSigner, error) {
 	if groupID == 0 {
 		return nil, sif.ErrInvalidGroupID
@@ -157,7 +169,7 @@ func (gs *groupSigner) sign() (sif.DescriptorInput, error) {
 
 	// Sign image metadata.
 	b := bytes.Buffer{}
-	ht, fp, err := gs.en.signMessage(&b, bytes.NewReader(enc))
+	ht, err := gs.en.signMessage(&b, bytes.NewReader(enc))
 	if err != nil {
 		return sif.DescriptorInput{}, fmt.Errorf("failed to sign message: %w", err)
 	}
@@ -166,7 +178,7 @@ func (gs *groupSigner) sign() (sif.DescriptorInput, error) {
 	return sif.NewDescriptorInput(sif.DataSignature, &b,
 		sif.OptNoGroup(),
 		sif.OptLinkedGroupID(gs.id),
-		sif.OptSignatureMetadata(ht, fp),
+		sif.OptSignatureMetadata(ht, gs.fp),
 	)
 }
 
@@ -301,18 +313,21 @@ func NewSigner(f *sif.FileImage, opts ...SignerOpt) (*Signer, error) {
 		opts: so,
 	}
 
+	var commonOpts []groupSignerOpt
+
 	// Get message encoder.
 	var en encoder
 	switch {
 	case so.e != nil:
 		en = newClearsignEncoder(so.e, so.timeFunc)
+		commonOpts = append(commonOpts, optSignGroupFingerprint(so.e.PrimaryKey.Fingerprint))
 	default:
 		return nil, fmt.Errorf("integrity: %w", ErrNoKeyMaterial)
 	}
 
 	// Add signer for each groupID.
 	for _, groupID := range so.groupIDs {
-		gs, err := newGroupSigner(en, f, groupID)
+		gs, err := newGroupSigner(en, f, groupID, commonOpts...)
 		if err != nil {
 			return nil, fmt.Errorf("integrity: %w", err)
 		}
@@ -322,7 +337,10 @@ func NewSigner(f *sif.FileImage, opts ...SignerOpt) (*Signer, error) {
 	// Add signer(s) for each list of object IDs.
 	for _, ids := range so.objectIDs {
 		err := withGroupedObjects(f, ids, func(groupID uint32, ids []uint32) error {
-			gs, err := newGroupSigner(en, f, groupID, optSignGroupObjects(ids...))
+			opts := commonOpts
+			opts = append(opts, optSignGroupObjects(ids...))
+
+			gs, err := newGroupSigner(en, f, groupID, opts...)
 			if err != nil {
 				return err
 			}
@@ -343,7 +361,7 @@ func NewSigner(f *sif.FileImage, opts ...SignerOpt) (*Signer, error) {
 		}
 
 		for _, id := range ids {
-			gs, err := newGroupSigner(en, f, id)
+			gs, err := newGroupSigner(en, f, id, commonOpts...)
 			if err != nil {
 				return nil, fmt.Errorf("integrity: %w", err)
 			}

--- a/pkg/integrity/verify.go
+++ b/pkg/integrity/verify.go
@@ -7,7 +7,9 @@ package integrity
 
 import (
 	"bytes"
+	"crypto"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -67,7 +69,6 @@ type VerifyCallback func(r VerifyResult) (ignoreError bool)
 
 type groupVerifier struct {
 	f        *sif.FileImage   // SIF image to verify.
-	cb       VerifyCallback   // Verification callback.
 	groupID  uint32           // Object group ID.
 	ods      []sif.Descriptor // Object descriptors.
 	subsetOK bool             // If true, permit ods to be a subset of the objects in signatures.
@@ -75,8 +76,8 @@ type groupVerifier struct {
 
 // newGroupVerifier constructs a new group verifier, optionally limited to objects described by
 // ods. If no descriptors are supplied, verify all objects in group.
-func newGroupVerifier(f *sif.FileImage, cb VerifyCallback, groupID uint32, ods ...sif.Descriptor) (*groupVerifier, error) { //nolint:lll
-	v := groupVerifier{f: f, cb: cb, groupID: groupID, ods: ods}
+func newGroupVerifier(f *sif.FileImage, groupID uint32, ods ...sif.Descriptor) (*groupVerifier, error) {
+	v := groupVerifier{f: f, groupID: groupID, ods: ods}
 
 	if len(ods) == 0 {
 		ods, err := getGroupObjects(f, groupID)
@@ -91,163 +92,114 @@ func newGroupVerifier(f *sif.FileImage, cb VerifyCallback, groupID uint32, ods .
 	return &v, nil
 }
 
-// fingerprints returns a sorted list of unique fingerprints of entities that have signed the
-// objects specified by v.
-func (v *groupVerifier) fingerprints() ([][]byte, error) {
-	sigs, err := getGroupSignatures(v.f, v.groupID, false)
-	if errors.Is(err, &SignatureNotFoundError{}) {
-		return nil, nil
-	} else if err != nil {
-		return nil, err
-	}
-	return getFingerprints(sigs)
+// signatures returns descriptors in f that contain signature objects linked to the objects
+// specified by v. If no such signatures are found, a SignatureNotFoundError is returned.
+func (v *groupVerifier) signatures() ([]sif.Descriptor, error) {
+	return getGroupSignatures(v.f, v.groupID, false)
 }
 
-// verifySignature verifies the objects specified by v against signature sig using keyring kr.
+// verifySignature performs cryptographic validation of the digital signature contained in sig
+// using decoder de, populating vr as appropriate.
 //
 // If an invalid signature is encountered, a SignatureNotValidError is returned.
 //
 // If verification of the SIF global header fails, ErrHeaderIntegrity is returned. If verification
 // of a data object descriptor fails, a DescriptorIntegrityError is returned. If verification of a
 // data object fails, a ObjectIntegrityError is returned.
-func (v *groupVerifier) verifySignature(sig sif.Descriptor, kr openpgp.KeyRing) ([]sif.Descriptor, *openpgp.Entity, error) { //nolint:lll
-	b, err := sig.GetData()
+func (v *groupVerifier) verifySignature(sig sif.Descriptor, de decoder, vr *VerifyResult) error {
+	ht, fp, err := sig.SignatureMetadata()
 	if err != nil {
-		return nil, nil, err
+		return err
 	}
 
-	// Verify signature and decode image metadata.
-	var im imageMetadata
-	e, _, err := verifyAndDecodeJSON(b, &im, kr)
+	// Verify signature and decode message.
+	b, err := de.verifyMessage(sig.GetReader(), ht, vr)
 	if err != nil {
-		return nil, e, &SignatureNotValidError{ID: sig.ID(), Err: err}
+		return &SignatureNotValidError{ID: sig.ID(), Err: err}
+	}
+
+	// Unmarshal image metadata.
+	var im imageMetadata
+	if err = json.Unmarshal(b, &im); err != nil {
+		return &SignatureNotValidError{ID: sig.ID(), Err: err}
 	}
 
 	// Get minimum object ID in group, and use this to populate absolute object IDs in im.
 	minID, err := getGroupMinObjectID(v.f, v.groupID)
 	if err != nil {
-		return nil, e, err
+		return err
 	}
 	im.populateAbsoluteObjectIDs(minID)
 
 	// Ensure signing entity matches fingerprint in descriptor.
-	_, fp, err := sig.SignatureMetadata()
-	if err != nil {
-		return nil, e, err
-	}
-	if !bytes.Equal(e.PrimaryKey.Fingerprint, fp) {
-		return nil, e, errFingerprintMismatch
+	if e := vr.e; e != nil && !bytes.Equal(e.PrimaryKey.Fingerprint, fp) {
+		return errFingerprintMismatch
 	}
 
 	// If an object subset is not permitted, verify our set of IDs match exactly what is in the
 	// image metadata.
 	if !v.subsetOK {
 		if err := im.objectIDsMatch(v.ods); err != nil {
-			return nil, e, err
-		}
-	}
-
-	// Verify header and object integrity.
-	verified, err := im.matches(v.f, v.ods)
-	if err != nil {
-		return verified, e, err
-	}
-
-	return verified, e, nil
-}
-
-// verifyWithKeyRing performs verification of the objects specified by v using keyring kr.
-//
-// If no signatures are found for the object group specified by v, a SignatureNotFoundError is
-// returned. If an invalid signature is encountered, a SignatureNotValidError is returned.
-//
-// If verification of the SIF global header fails, ErrHeaderIntegrity is returned. If verification
-// of a data object descriptor fails, a DescriptorIntegrityError is returned. If verification of a
-// data object fails, a ObjectIntegrityError is returned.
-func (v *groupVerifier) verifyWithKeyRing(kr openpgp.KeyRing) error {
-	// Obtain all signatures related to group.
-	sigs, err := getGroupSignatures(v.f, v.groupID, false)
-	if err != nil {
-		return err
-	}
-
-	for _, sig := range sigs {
-		verified, e, err := v.verifySignature(sig, kr)
-
-		// Call verify callback, if applicable.
-		if v.cb != nil {
-			r := VerifyResult{sig: sig, verified: verified, e: e, err: err}
-			if ignoreError := v.cb(r); ignoreError {
-				err = nil
-			}
-		}
-
-		if err != nil {
 			return err
 		}
 	}
 
-	return nil
+	// Verify header and object integrity.
+	vr.verified, err = im.matches(v.f, v.ods)
+	return err
 }
 
 type legacyGroupVerifier struct {
 	f       *sif.FileImage   // SIF image to verify.
-	cb      VerifyCallback   // Verification callback.
 	groupID uint32           // Object group ID.
 	ods     []sif.Descriptor // Object descriptors.
 }
 
 // newLegacyGroupVerifier constructs a new legacy group verifier.
-func newLegacyGroupVerifier(f *sif.FileImage, cb VerifyCallback, groupID uint32) (*legacyGroupVerifier, error) {
+func newLegacyGroupVerifier(f *sif.FileImage, groupID uint32) (*legacyGroupVerifier, error) {
 	ods, err := getGroupObjects(f, groupID)
 	if err != nil {
 		return nil, err
 	}
-	return &legacyGroupVerifier{f: f, cb: cb, groupID: groupID, ods: ods}, nil
+
+	return &legacyGroupVerifier{f: f, groupID: groupID, ods: ods}, nil
 }
 
-// fingerprints returns a sorted list of unique fingerprints of entities that have signed the
-// objects specified by v.
-func (v *legacyGroupVerifier) fingerprints() ([][]byte, error) {
-	sigs, err := getGroupSignatures(v.f, v.groupID, true)
-	if errors.Is(err, &SignatureNotFoundError{}) {
-		return nil, nil
-	} else if err != nil {
-		return nil, err
-	}
-	return getFingerprints(sigs)
+// signatures returns descriptors in f that contain signature objects linked to the objects
+// specified by v. If no such signatures are found, a SignatureNotFoundError is returned.
+func (v *legacyGroupVerifier) signatures() ([]sif.Descriptor, error) {
+	return getGroupSignatures(v.f, v.groupID, true)
 }
 
-// verifySignature verifies the objects specified by v against signature sig using keyring kr.
+// verifySignature performs cryptographic validation of the digital signature contained in sig
+// using decoder de, populating vr as appropriate.
 //
 // If an invalid signature is encountered, a SignatureNotValidError is returned.
 //
 // If verification of a data object fails, a ObjectIntegrityError is returned.
-func (v *legacyGroupVerifier) verifySignature(sig sif.Descriptor, kr openpgp.KeyRing) (*openpgp.Entity, error) {
-	b, err := sig.GetData()
+func (v *legacyGroupVerifier) verifySignature(sig sif.Descriptor, de decoder, vr *VerifyResult) error {
+	// Verify signature and decode message.
+	b, err := de.verifyMessage(sig.GetReader(), crypto.SHA256, vr)
 	if err != nil {
-		return nil, err
+		return &SignatureNotValidError{ID: sig.ID(), Err: err}
 	}
 
-	// Verify signature and decode plaintext.
-	e, b, _, err := verifyAndDecode(b, kr)
+	ht, fp, err := sig.SignatureMetadata()
 	if err != nil {
-		return e, &SignatureNotValidError{ID: sig.ID(), Err: err}
+		return err
 	}
 
 	// Ensure signing entity matches fingerprint in descriptor.
-	ht, fp, err := sig.SignatureMetadata()
-	if err != nil {
-		return e, err
-	}
-	if !bytes.Equal(e.PrimaryKey.Fingerprint, fp) {
-		return e, errFingerprintMismatch
+	if e := vr.e; e != nil {
+		if !bytes.Equal(e.PrimaryKey.Fingerprint, fp) {
+			return errFingerprintMismatch
+		}
 	}
 
 	// Obtain digest from plaintext.
 	d, err := newLegacyDigest(ht, b)
 	if err != nil {
-		return e, err
+		return err
 	}
 
 	// Get reader covering all non-signature objects.
@@ -259,156 +211,93 @@ func (v *legacyGroupVerifier) verifySignature(sig sif.Descriptor, kr openpgp.Key
 
 	// Verify integrity of objects.
 	if ok, err := d.matches(r); err != nil {
-		return e, err
-	} else if !ok {
-		return e, &ObjectIntegrityError{}
-	}
-
-	return e, nil
-}
-
-// verifyWithKeyRing performs verification of the objects specified by v using keyring kr.
-//
-// If no signatures are found for the object group specified by v, a SignatureNotFoundError is
-// returned. If an invalid signature is encountered, a SignatureNotValidError is returned.
-//
-// If verification of the data object group fails, a ObjectIntegrityError is returned.
-func (v *legacyGroupVerifier) verifyWithKeyRing(kr openpgp.KeyRing) error {
-	// Obtain all signatures related to object.
-	sigs, err := getGroupSignatures(v.f, v.groupID, true)
-	if err != nil {
 		return err
+	} else if !ok {
+		return &ObjectIntegrityError{}
 	}
 
-	for _, sig := range sigs {
-		e, err := v.verifySignature(sig, kr)
-
-		// Call verify callback, if applicable.
-		if v.cb != nil {
-			r := VerifyResult{sig: sig, e: e, err: err}
-			if err == nil {
-				r.verified = v.ods
-			}
-			if ignoreError := v.cb(r); ignoreError {
-				err = nil
-			}
-		}
-
-		if err != nil {
-			return err
-		}
-	}
-
+	vr.verified = v.ods
 	return nil
 }
 
 type legacyObjectVerifier struct {
 	f  *sif.FileImage // SIF image to verify.
-	cb VerifyCallback // Verification callback.
 	od sif.Descriptor // Object descriptor.
 }
 
 // newLegacyObjectVerifier constructs a new legacy object verifier.
-func newLegacyObjectVerifier(f *sif.FileImage, cb VerifyCallback, id uint32) (*legacyObjectVerifier, error) {
-	od, err := f.GetDescriptor(sif.WithID(id))
-	if err != nil {
-		return nil, err
-	}
-	return &legacyObjectVerifier{f: f, cb: cb, od: od}, nil
+func newLegacyObjectVerifier(f *sif.FileImage, od sif.Descriptor) *legacyObjectVerifier {
+	return &legacyObjectVerifier{f: f, od: od}
 }
 
-// fingerprints returns a sorted list of unique fingerprints of entities that have signed the
-// objects specified by v.
-func (v *legacyObjectVerifier) fingerprints() ([][]byte, error) {
-	sigs, err := getObjectSignatures(v.f, v.od.ID())
-	if errors.Is(err, &SignatureNotFoundError{}) {
-		return nil, nil
-	} else if err != nil {
-		return nil, err
-	}
-	return getFingerprints(sigs)
+// signatures returns descriptors in f that contain signature objects linked to the objects
+// specified by v. If no such signatures are found, a SignatureNotFoundError is returned.
+func (v *legacyObjectVerifier) signatures() ([]sif.Descriptor, error) {
+	return getObjectSignatures(v.f, v.od.ID())
 }
 
-// verifySignature verifies the objects specified by v against signature sig using keyring kr.
+// verifySignature performs cryptographic validation of the digital signature contained in sig
+// using decoder de, populating vr as appropriate.
 //
 // If an invalid signature is encountered, a SignatureNotValidError is returned.
 //
 // If verification of a data object fails, a ObjectIntegrityError is returned.
-func (v *legacyObjectVerifier) verifySignature(sig sif.Descriptor, kr openpgp.KeyRing) (*openpgp.Entity, error) {
-	b, err := sig.GetData()
+func (v *legacyObjectVerifier) verifySignature(sig sif.Descriptor, de decoder, vr *VerifyResult) error {
+	// Verify signature and decode message.
+	b, err := de.verifyMessage(sig.GetReader(), crypto.SHA256, vr)
 	if err != nil {
-		return nil, err
+		return &SignatureNotValidError{ID: sig.ID(), Err: err}
 	}
 
-	// Verify signature and decode plaintext.
-	e, b, _, err := verifyAndDecode(b, kr)
+	ht, fp, err := sig.SignatureMetadata()
 	if err != nil {
-		return e, &SignatureNotValidError{ID: sig.ID(), Err: err}
+		return err
 	}
 
 	// Ensure signing entity matches fingerprint in descriptor.
-	ht, fp, err := sig.SignatureMetadata()
-	if err != nil {
-		return e, err
-	}
-	if !bytes.Equal(e.PrimaryKey.Fingerprint, fp) {
-		return e, errFingerprintMismatch
+	if e := vr.e; e != nil {
+		if !bytes.Equal(e.PrimaryKey.Fingerprint, fp) {
+			return errFingerprintMismatch
+		}
 	}
 
 	// Obtain digest from plaintext.
 	d, err := newLegacyDigest(ht, b)
 	if err != nil {
-		return e, err
+		return err
 	}
 
 	// Verify object integrity.
 	if ok, err := d.matches(v.od.GetReader()); err != nil {
-		return e, err
-	} else if !ok {
-		return e, &ObjectIntegrityError{ID: v.od.ID()}
-	}
-
-	return e, nil
-}
-
-// verifyWithKeyRing performs verification of the objects specified by v using keyring kr.
-//
-// If no signatures are found for the object specified by v, a SignatureNotFoundError is returned.
-// If an invalid signature is encountered, a SignatureNotValidError is returned.
-//
-// If verification of the data object fails, a ObjectIntegrityError is returned.
-func (v *legacyObjectVerifier) verifyWithKeyRing(kr openpgp.KeyRing) error {
-	// Obtain all signatures related to object.
-	sigs, err := getObjectSignatures(v.f, v.od.ID())
-	if err != nil {
 		return err
+	} else if !ok {
+		return &ObjectIntegrityError{ID: v.od.ID()}
 	}
 
-	for _, sig := range sigs {
-		e, err := v.verifySignature(sig, kr)
-
-		// Call verify callback, if applicable.
-		if v.cb != nil {
-			r := VerifyResult{sig: sig, e: e, err: err}
-			if err == nil {
-				r.verified = []sif.Descriptor{v.od}
-			}
-			if ignoreError := v.cb(r); ignoreError {
-				err = nil
-			}
-		}
-
-		if err != nil {
-			return err
-		}
-	}
-
+	vr.verified = []sif.Descriptor{v.od}
 	return nil
 }
 
+type decoder interface {
+	// verifyMessage reads a message from r, verifies its signature, and returns the message
+	// contents.
+	verifyMessage(r io.Reader, h crypto.Hash, vr *VerifyResult) ([]byte, error)
+}
+
 type verifyTask interface {
-	fingerprints() ([][]byte, error)
-	verifyWithKeyRing(kr openpgp.KeyRing) error
+	// signatures returns descriptors that contain signature objects linked to the task. If no such
+	// signatures are found, a SignatureNotFoundError is returned.
+	signatures() ([]sif.Descriptor, error)
+
+	// verifySignature performs cryptographic validation of the digital signature contained in sig
+	// using decoder de, populating vr as appropriate.
+	//
+	// If an invalid signature is encountered, a SignatureNotValidError is returned.
+	//
+	// If verification of the SIF global header fails, ErrHeaderIntegrity is returned. If
+	// verification of a data object descriptor fails, a DescriptorIntegrityError is returned. If
+	// verification of a data object fails, a ObjectIntegrityError is returned.
+	verifySignature(sig sif.Descriptor, de decoder, vr *VerifyResult) error
 }
 
 type verifyOpts struct {
@@ -493,11 +382,11 @@ func OptVerifyCallback(cb VerifyCallback) VerifierOpt {
 }
 
 // getTasks returns verification tasks corresponding to groupIDs and objectIDs.
-func getTasks(f *sif.FileImage, cb VerifyCallback, groupIDs, objectIDs []uint32) ([]verifyTask, error) {
+func getTasks(f *sif.FileImage, groupIDs, objectIDs []uint32) ([]verifyTask, error) {
 	t := make([]verifyTask, 0, len(groupIDs)+len(objectIDs))
 
 	for _, groupID := range groupIDs {
-		v, err := newGroupVerifier(f, cb, groupID)
+		v, err := newGroupVerifier(f, groupID)
 		if err != nil {
 			return nil, err
 		}
@@ -510,7 +399,7 @@ func getTasks(f *sif.FileImage, cb VerifyCallback, groupIDs, objectIDs []uint32)
 			return nil, err
 		}
 
-		v, err := newGroupVerifier(f, cb, od.GroupID(), od)
+		v, err := newGroupVerifier(f, od.GroupID(), od)
 		if err != nil {
 			return nil, err
 		}
@@ -521,11 +410,11 @@ func getTasks(f *sif.FileImage, cb VerifyCallback, groupIDs, objectIDs []uint32)
 }
 
 // getLegacyTasks returns legacy verification tasks corresponding to groupIDs and objectIDs.
-func getLegacyTasks(f *sif.FileImage, cb VerifyCallback, groupIDs, objectIDs []uint32) ([]verifyTask, error) {
+func getLegacyTasks(f *sif.FileImage, groupIDs, objectIDs []uint32) ([]verifyTask, error) {
 	t := make([]verifyTask, 0, len(groupIDs)+len(objectIDs))
 
 	for _, groupID := range groupIDs {
-		v, err := newLegacyGroupVerifier(f, cb, groupID)
+		v, err := newLegacyGroupVerifier(f, groupID)
 		if err != nil {
 			return nil, err
 		}
@@ -533,11 +422,12 @@ func getLegacyTasks(f *sif.FileImage, cb VerifyCallback, groupIDs, objectIDs []u
 	}
 
 	for _, id := range objectIDs {
-		v, err := newLegacyObjectVerifier(f, cb, id)
+		od, err := f.GetDescriptor(sif.WithID(id))
 		if err != nil {
 			return nil, err
 		}
-		t = append(t, v)
+
+		t = append(t, newLegacyObjectVerifier(f, od))
 	}
 
 	return t, nil
@@ -546,8 +436,9 @@ func getLegacyTasks(f *sif.FileImage, cb VerifyCallback, groupIDs, objectIDs []u
 // Verifier describes a SIF image verifier.
 type Verifier struct {
 	f     *sif.FileImage
-	kr    openpgp.KeyRing
 	tasks []verifyTask
+	kr    openpgp.KeyRing
+	cb    VerifyCallback
 }
 
 // NewVerifier returns a Verifier to examine and/or verify digital signatures(s) in f according to
@@ -598,15 +489,16 @@ func NewVerifier(f *sif.FileImage, opts ...VerifierOpt) (*Verifier, error) {
 	if vo.isLegacy {
 		getTasksFunc = getLegacyTasks
 	}
-	t, err := getTasksFunc(f, vo.cb, vo.groups, vo.objects)
+	t, err := getTasksFunc(f, vo.groups, vo.objects)
 	if err != nil {
 		return nil, fmt.Errorf("integrity: %w", err)
 	}
 
 	v := Verifier{
 		f:     f,
-		kr:    vo.kr,
 		tasks: t,
+		kr:    vo.kr,
+		cb:    vo.cb,
 	}
 	return &v, nil
 }
@@ -619,7 +511,12 @@ func (v *Verifier) fingerprints(any bool) ([][]byte, error) {
 
 	// Build up a map containing fingerprints, and the number of tasks they are participating in.
 	for _, t := range v.tasks {
-		fps, err := t.fingerprints()
+		sigs, err := t.signatures()
+		if err != nil && !errors.Is(err, &SignatureNotFoundError{}) {
+			return nil, err
+		}
+
+		fps, err := getFingerprints(sigs)
 		if err != nil {
 			return nil, err
 		}
@@ -688,7 +585,12 @@ func (v *Verifier) AllSignedBy() ([][]byte, error) {
 // DescriptorIntegrityError is returned. If verification of a data object fails, an error wrapping
 // a ObjectIntegrityError is returned.
 func (v *Verifier) Verify() error {
-	if v.kr == nil {
+	// Get message decoder.
+	var de decoder
+	switch {
+	case v.kr != nil:
+		de = newClearsignDecoder(v.kr)
+	default:
 		return fmt.Errorf("integrity: %w", ErrNoKeyMaterial)
 	}
 
@@ -703,10 +605,32 @@ func (v *Verifier) Verify() error {
 		}
 	}
 
+	// Verify signature(s) associated with each task.
 	for _, t := range v.tasks {
-		if err := t.verifyWithKeyRing(v.kr); err != nil {
+		sigs, err := t.signatures()
+		if err != nil {
 			return fmt.Errorf("integrity: %w", err)
 		}
+
+		for _, sig := range sigs {
+			vr := VerifyResult{sig: sig}
+
+			// Verify signature.
+			err := t.verifySignature(sig, de, &vr)
+
+			// Call verify callback, if applicable.
+			if v.cb != nil {
+				vr.err = err
+				if ignoreError := v.cb(vr); ignoreError {
+					err = nil
+				}
+			}
+
+			if err != nil {
+				return fmt.Errorf("integrity: %w", err)
+			}
+		}
 	}
+
 	return nil
 }

--- a/pkg/integrity/verify_test.go
+++ b/pkg/integrity/verify_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -6,10 +6,12 @@
 package integrity
 
 import (
+	"crypto"
 	"errors"
 	"io"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
@@ -17,29 +19,33 @@ import (
 	"github.com/sylabs/sif/v2/pkg/sif"
 )
 
-func TestGroupVerifier_fingerprints(t *testing.T) {
+func TestGroupVerifier_signatures(t *testing.T) {
 	oneGroupImage := loadContainer(t, filepath.Join(corpus, "one-group.sif"))
 	oneGroupSignedImage := loadContainer(t, filepath.Join(corpus, "one-group-signed.sif"))
 
-	e := getTestEntity(t)
+	sigs, err := oneGroupSignedImage.GetDescriptors(sif.WithDataType(sif.DataSignature))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	tests := []struct {
-		name    string
-		f       *sif.FileImage
-		groupID uint32
-		wantFPs [][]byte
-		wantErr error
+		name     string
+		f        *sif.FileImage
+		groupID  uint32
+		wantSigs []sif.Descriptor
+		wantErr  error
 	}{
 		{
 			name:    "Unsigned",
 			f:       oneGroupImage,
 			groupID: 1,
+			wantErr: &SignatureNotFoundError{},
 		},
 		{
-			name:    "Signed",
-			f:       oneGroupSignedImage,
-			groupID: 1,
-			wantFPs: [][]byte{e.PrimaryKey.Fingerprint},
+			name:     "Signed",
+			f:        oneGroupSignedImage,
+			groupID:  1,
+			wantSigs: sigs,
 		},
 	}
 
@@ -51,114 +57,88 @@ func TestGroupVerifier_fingerprints(t *testing.T) {
 				groupID: tt.groupID,
 			}
 
-			got, err := v.fingerprints()
+			sigs, err := v.signatures()
 
-			if !errors.Is(err, tt.wantErr) {
-				t.Errorf("got error %v, want %v", err, tt.wantErr)
+			if got, want := err, tt.wantErr; !errors.Is(got, want) {
+				t.Fatalf("got error %v, want %v", got, want)
 			}
 
-			if !reflect.DeepEqual(got, tt.wantFPs) {
-				t.Errorf("got fingerprints %v, want %v", got, tt.wantFPs)
+			if got, want := sigs, tt.wantSigs; !reflect.DeepEqual(got, want) {
+				t.Errorf("got signatures %v, want %v", got, want)
 			}
 		})
 	}
 }
 
-func TestGroupVerifier_verifyWithKeyRing(t *testing.T) {
-	oneGroupImage := loadContainer(t, filepath.Join(corpus, "one-group.sif"))
+func TestGroupVerifier_verify(t *testing.T) {
 	oneGroupSignedImage := loadContainer(t, filepath.Join(corpus, "one-group-signed.sif"))
 
+	sig, err := oneGroupSignedImage.GetDescriptor(sif.WithDataType(sif.DataSignature))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	verified, err := oneGroupSignedImage.GetDescriptors(sif.WithGroupID(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	e := getTestEntity(t)
-	kr := openpgp.EntityList{e}
 
 	tests := []struct {
-		name            string
-		f               *sif.FileImage
-		testCallback    bool
-		ignoreError     bool
-		groupID         uint32
-		objectIDs       []uint32
-		subsetOK        bool
-		kr              openpgp.KeyRing
-		wantCBSignature uint32
-		wantCBVerified  []uint32
-		wantCBEntity    *openpgp.Entity
-		wantCBErr       error
-		wantErr         error
+		name         string
+		f            *sif.FileImage
+		groupID      uint32
+		objectIDs    []uint32
+		subsetOK     bool
+		sig          sif.Descriptor
+		de           decoder
+		wantErr      error
+		wantVerified []sif.Descriptor
+		wantEntity   *openpgp.Entity
 	}{
 		{
-			name:      "SignatureNotFound",
-			f:         oneGroupImage,
-			groupID:   1,
-			objectIDs: []uint32{1, 2},
-			kr:        kr,
-			wantErr:   &SignatureNotFoundError{},
-		},
-		{
-			name:      "SignedObjectNotFound",
-			f:         oneGroupSignedImage,
-			groupID:   1,
-			objectIDs: []uint32{1},
-			kr:        kr,
-			wantErr:   errSignedObjectNotFound,
+			name:       "SignedObjectNotFound",
+			f:          oneGroupSignedImage,
+			groupID:    1,
+			objectIDs:  []uint32{1},
+			sig:        sig,
+			de:         newClearsignDecoder(openpgp.EntityList{e}),
+			wantErr:    errSignedObjectNotFound,
+			wantEntity: e,
 		},
 		{
 			name:      "UnknownIssuer",
 			f:         oneGroupSignedImage,
 			groupID:   1,
 			objectIDs: []uint32{1, 2},
-			kr:        openpgp.EntityList{},
-			wantErr:   &SignatureNotValidError{ID: 3, Err: pgperrors.ErrUnknownIssuer},
+			sig:       sig,
+			de:        newClearsignDecoder(openpgp.EntityList{}),
+			wantErr: &SignatureNotValidError{
+				ID:  3,
+				Err: pgperrors.ErrUnknownIssuer,
+			},
 		},
 		{
-			name:            "IgnoreError",
-			f:               oneGroupSignedImage,
-			testCallback:    true,
-			ignoreError:     true,
-			groupID:         1,
-			objectIDs:       []uint32{1, 2},
-			kr:              openpgp.EntityList{},
-			wantCBSignature: 3,
-			wantCBErr:       &SignatureNotValidError{ID: 3, Err: pgperrors.ErrUnknownIssuer},
-			wantErr:         nil,
+			name:         "OneGroupSigned",
+			f:            oneGroupSignedImage,
+			groupID:      1,
+			objectIDs:    []uint32{1, 2},
+			sig:          sig,
+			de:           newClearsignDecoder(openpgp.EntityList{e}),
+			wantVerified: verified,
+			wantEntity:   e,
 		},
 		{
-			name:      "OneGroupSigned",
-			f:         oneGroupSignedImage,
-			groupID:   1,
-			objectIDs: []uint32{1, 2},
-			kr:        kr,
-		},
-		{
-			name:            "OneGroupSignedWithCallback",
-			f:               oneGroupSignedImage,
-			testCallback:    true,
-			groupID:         1,
-			objectIDs:       []uint32{1, 2},
-			kr:              kr,
-			wantCBSignature: 3,
-			wantCBVerified:  []uint32{1, 2},
-			wantCBEntity:    e,
-		},
-		{
-			name:      "OneGroupSignedSubset",
-			f:         oneGroupSignedImage,
-			groupID:   1,
-			objectIDs: []uint32{1},
-			subsetOK:  true,
-			kr:        kr,
-		},
-		{
-			name:            "OneGroupSignedSubsetWithCallback",
-			f:               oneGroupSignedImage,
-			testCallback:    true,
-			groupID:         1,
-			objectIDs:       []uint32{1},
-			subsetOK:        true,
-			kr:              kr,
-			wantCBSignature: 3,
-			wantCBVerified:  []uint32{1},
-			wantCBEntity:    e,
+			name:         "OneGroupSignedSubset",
+			f:            oneGroupSignedImage,
+			groupID:      1,
+			objectIDs:    []uint32{1},
+			subsetOK:     true,
+			sig:          sig,
+			de:           newClearsignDecoder(openpgp.EntityList{e}),
+			wantVerified: verified[:1],
+			wantEntity:   e,
 		},
 	}
 
@@ -174,75 +154,58 @@ func TestGroupVerifier_verifyWithKeyRing(t *testing.T) {
 				ods[i] = od
 			}
 
-			// Test callback functionality, if requested.
-			var cb VerifyCallback
-
-			//nolint:dupl
-			if tt.testCallback {
-				cb = func(r VerifyResult) bool {
-					if got, want := r.Signature().ID(), tt.wantCBSignature; got != want {
-						t.Errorf("got signature %v, want %v", got, want)
-					}
-
-					if got, want := len(r.Verified()), len(tt.wantCBVerified); got != want {
-						t.Fatalf("got %v verified objects, want %v", got, want)
-					}
-					for i, od := range r.Verified() {
-						if got, want := od.ID(), tt.wantCBVerified[i]; got != want {
-							t.Errorf("got verified ID %v, want %v", got, want)
-						}
-					}
-
-					if got, want := r.Entity(), tt.wantCBEntity; got != want {
-						t.Errorf("got entity %v, want %v", got, want)
-					}
-
-					if got, want := r.Error(), tt.wantCBErr; !errors.Is(got, want) {
-						t.Errorf("got error %v, want %v", got, want)
-					}
-
-					return tt.ignoreError
-				}
-			}
-
 			v := &groupVerifier{
 				f:        tt.f,
-				cb:       cb,
 				groupID:  tt.groupID,
 				ods:      ods,
 				subsetOK: tt.subsetOK,
 			}
 
-			if got, want := v.verifyWithKeyRing(tt.kr), tt.wantErr; !errors.Is(got, want) {
+			var vr VerifyResult
+			err := v.verifySignature(tt.sig, tt.de, &vr)
+
+			if got, want := err, tt.wantErr; !errors.Is(got, want) {
 				t.Errorf("got error %v, want %v", got, want)
+			}
+
+			if got, want := vr.Verified(), tt.wantVerified; !reflect.DeepEqual(got, want) {
+				t.Errorf("got verified %v, want %v", got, want)
+			}
+
+			if got, want := vr.Entity(), tt.wantEntity; !reflect.DeepEqual(got, want) {
+				t.Errorf("got entity %v, want %v", got, want)
 			}
 		})
 	}
 }
 
-func TestLegacyGroupVerifier_fingerprints(t *testing.T) {
+func TestLegacyGroupVerifier_signatures(t *testing.T) {
 	oneGroupImage := loadContainer(t, filepath.Join(corpus, "one-group.sif"))
-	oneGroupImageSigned := loadContainer(t, filepath.Join(corpus, "one-group-signed-legacy-group.sif"))
+	oneGroupSignedImage := loadContainer(t, filepath.Join(corpus, "one-group-signed-legacy-group.sif"))
 
-	e := getTestEntity(t)
+	sigs, err := oneGroupSignedImage.GetDescriptors(sif.WithDataType(sif.DataSignature))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	tests := []struct {
-		name    string
-		f       *sif.FileImage
-		id      uint32
-		wantFPs [][]byte
-		wantErr error
+		name     string
+		f        *sif.FileImage
+		id       uint32
+		wantSigs []sif.Descriptor
+		wantErr  error
 	}{
 		{
-			name: "Unsigned",
-			f:    oneGroupImage,
-			id:   1,
+			name:    "Unsigned",
+			f:       oneGroupImage,
+			id:      1,
+			wantErr: &SignatureNotFoundError{},
 		},
 		{
-			name:    "Signed",
-			f:       oneGroupImageSigned,
-			id:      1,
-			wantFPs: [][]byte{e.PrimaryKey.Fingerprint},
+			name:     "Signed",
+			f:        oneGroupSignedImage,
+			id:       1,
+			wantSigs: sigs,
 		},
 	}
 
@@ -254,132 +217,69 @@ func TestLegacyGroupVerifier_fingerprints(t *testing.T) {
 				groupID: 1,
 			}
 
-			got, err := v.fingerprints()
+			sigs, err := v.signatures()
 
-			if !errors.Is(err, tt.wantErr) {
-				t.Errorf("got error %v, want %v", err, tt.wantErr)
+			if got, want := err, tt.wantErr; !errors.Is(got, want) {
+				t.Fatalf("got error %v, want %v", got, want)
 			}
 
-			if !reflect.DeepEqual(got, tt.wantFPs) {
-				t.Errorf("got fingerprints %v, want %v", got, tt.wantFPs)
+			if got, want := sigs, tt.wantSigs; !reflect.DeepEqual(got, want) {
+				t.Errorf("got signatures %v, want %v", got, want)
 			}
 		})
 	}
 }
 
-func TestLegacyGroupVerifier_verifyWithKeyRing(t *testing.T) {
-	oneGroupImage := loadContainer(t, filepath.Join(corpus, "one-group.sif"))
+func TestLegacyGroupVerifier_verify(t *testing.T) {
 	oneGroupSignedImage := loadContainer(t, filepath.Join(corpus, "one-group-signed-legacy-group.sif"))
 
+	sig, err := oneGroupSignedImage.GetDescriptor(sif.WithDataType(sif.DataSignature))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	verified, err := oneGroupSignedImage.GetDescriptors(sif.WithGroupID(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	e := getTestEntity(t)
-	kr := openpgp.EntityList{e}
 
 	tests := []struct {
-		name            string
-		f               *sif.FileImage
-		testCallback    bool
-		ignoreError     bool
-		groupID         uint32
-		kr              openpgp.KeyRing
-		wantCBSignature uint32
-		wantCBVerified  []uint32
-		wantCBEntity    *openpgp.Entity
-		wantCBErr       error
-		wantErr         error
+		name         string
+		f            *sif.FileImage
+		groupID      uint32
+		sig          sif.Descriptor
+		de           decoder
+		wantErr      error
+		wantVerified []sif.Descriptor
+		wantEntity   *openpgp.Entity
 	}{
-		{
-			name:    "SignatureNotFound",
-			f:       oneGroupImage,
-			groupID: 1,
-			kr:      kr,
-			wantErr: &SignatureNotFoundError{},
-		},
 		{
 			name:    "UnknownIssuer",
 			f:       oneGroupSignedImage,
 			groupID: 1,
-			kr:      openpgp.EntityList{},
-			wantErr: pgperrors.ErrUnknownIssuer,
+			sig:     sig,
+			de:      newClearsignDecoder(openpgp.EntityList{}),
+			wantErr: &SignatureNotValidError{
+				ID:  3,
+				Err: pgperrors.ErrUnknownIssuer,
+			},
 		},
 		{
-			name:            "IgnoreError",
-			f:               oneGroupSignedImage,
-			testCallback:    true,
-			ignoreError:     true,
-			groupID:         1,
-			kr:              openpgp.EntityList{},
-			wantCBSignature: 3,
-			wantCBErr:       pgperrors.ErrUnknownIssuer,
-			wantErr:         nil,
-		},
-		{
-			name:    "OneGroupSigned",
-			f:       oneGroupSignedImage,
-			groupID: 1,
-			kr:      kr,
-		},
-		{
-			name:            "OneGroupSignedWithCallback",
-			f:               oneGroupSignedImage,
-			testCallback:    true,
-			groupID:         1,
-			kr:              kr,
-			wantCBSignature: 3,
-			wantCBVerified:  []uint32{1, 2},
-			wantCBEntity:    e,
-		},
-		{
-			name:    "OneGroupSignedSubset",
-			f:       oneGroupSignedImage,
-			groupID: 1,
-			kr:      kr,
-		},
-		{
-			name:            "OneGroupSignedSubsetWithCallback",
-			f:               oneGroupSignedImage,
-			testCallback:    true,
-			groupID:         1,
-			kr:              kr,
-			wantCBSignature: 3,
-			wantCBVerified:  []uint32{1, 2},
-			wantCBEntity:    e,
+			name:         "OneGroupSigned",
+			f:            oneGroupSignedImage,
+			groupID:      1,
+			sig:          sig,
+			de:           newClearsignDecoder(openpgp.EntityList{e}),
+			wantVerified: verified,
+			wantEntity:   e,
 		},
 	}
 
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			// Test callback functionality, if requested.
-			var cb VerifyCallback
-
-			//nolint:dupl
-			if tt.testCallback {
-				cb = func(r VerifyResult) bool {
-					if got, want := r.Signature().ID(), tt.wantCBSignature; got != want {
-						t.Errorf("got signature %v, want %v", got, want)
-					}
-
-					if got, want := len(r.Verified()), len(tt.wantCBVerified); got != want {
-						t.Fatalf("got %v verified objects, want %v", got, want)
-					}
-					for i, od := range r.Verified() {
-						if got, want := od.ID(), tt.wantCBVerified[i]; got != want {
-							t.Errorf("got verified ID %v, want %v", got, want)
-						}
-					}
-
-					if got, want := r.Entity(), tt.wantCBEntity; got != want {
-						t.Errorf("got entity %v, want %v", got, want)
-					}
-
-					if got, want := r.Error(), tt.wantCBErr; !errors.Is(got, want) {
-						t.Errorf("got error %v, want %v", got, want)
-					}
-
-					return tt.ignoreError
-				}
-			}
-
 			ods, err := getGroupObjects(tt.f, tt.groupID)
 			if err != nil {
 				t.Fatal(err)
@@ -387,183 +287,64 @@ func TestLegacyGroupVerifier_verifyWithKeyRing(t *testing.T) {
 
 			v := &legacyGroupVerifier{
 				f:       tt.f,
-				cb:      cb,
 				groupID: tt.groupID,
 				ods:     ods,
 			}
 
-			if got, want := v.verifyWithKeyRing(tt.kr), tt.wantErr; !errors.Is(got, want) {
+			var vr VerifyResult
+			err = v.verifySignature(tt.sig, tt.de, &vr)
+
+			if got, want := err, tt.wantErr; !errors.Is(got, want) {
 				t.Errorf("got error %v, want %v", got, want)
 			}
-		})
-	}
-}
 
-func TestLegacyObjectVerifier_fingerprints(t *testing.T) {
-	oneGroupImage := loadContainer(t, filepath.Join(corpus, "one-group.sif"))
-	oneGroupImageSigned := loadContainer(t, filepath.Join(corpus, "one-group-signed-legacy-all.sif"))
-
-	e := getTestEntity(t)
-
-	tests := []struct {
-		name    string
-		f       *sif.FileImage
-		id      uint32
-		wantFPs [][]byte
-		wantErr error
-	}{
-		{
-			name: "Unsigned",
-			f:    oneGroupImage,
-			id:   1,
-		},
-		{
-			name:    "Signed",
-			f:       oneGroupImageSigned,
-			id:      1,
-			wantFPs: [][]byte{e.PrimaryKey.Fingerprint},
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			od, err := tt.f.GetDescriptor(sif.WithID(tt.id))
-			if err != nil {
-				t.Fatal(err)
+			if got, want := vr.Verified(), tt.wantVerified; !reflect.DeepEqual(got, want) {
+				t.Errorf("got verified %v, want %v", got, want)
 			}
 
-			v := &legacyObjectVerifier{
-				f:  tt.f,
-				od: od,
-			}
-
-			got, err := v.fingerprints()
-
-			if !errors.Is(err, tt.wantErr) {
-				t.Errorf("got error %v, want %v", err, tt.wantErr)
-			}
-
-			if !reflect.DeepEqual(got, tt.wantFPs) {
-				t.Errorf("got fingerprints %v, want %v", got, tt.wantFPs)
+			if got, want := vr.Entity(), tt.wantEntity; !reflect.DeepEqual(got, want) {
+				t.Errorf("got entity %v, want %v", got, want)
 			}
 		})
 	}
 }
 
-func TestLegacyObjectVerifier_verifyWithKeyRing(t *testing.T) {
+func TestLegacyObjectVerifier_signatures(t *testing.T) {
 	oneGroupImage := loadContainer(t, filepath.Join(corpus, "one-group.sif"))
 	oneGroupSignedImage := loadContainer(t, filepath.Join(corpus, "one-group-signed-legacy-all.sif"))
 
-	e := getTestEntity(t)
-	kr := openpgp.EntityList{e}
+	sigs, err := oneGroupSignedImage.GetDescriptors(
+		sif.WithDataType(sif.DataSignature),
+		sif.WithLinkedID(1),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	tests := []struct {
-		name            string
-		f               *sif.FileImage
-		testCallback    bool
-		ignoreError     bool
-		id              uint32
-		kr              openpgp.KeyRing
-		wantCBSignature uint32
-		wantCBVerified  []uint32
-		wantCBEntity    *openpgp.Entity
-		wantCBErr       error
-		wantErr         error
+		name     string
+		f        *sif.FileImage
+		id       uint32
+		wantSigs []sif.Descriptor
+		wantErr  error
 	}{
 		{
-			name:    "SignatureNotFound",
+			name:    "Unsigned",
 			f:       oneGroupImage,
 			id:      1,
-			kr:      kr,
 			wantErr: &SignatureNotFoundError{},
 		},
 		{
-			name:    "UnknownIssuer",
-			f:       oneGroupSignedImage,
-			id:      1,
-			kr:      openpgp.EntityList{},
-			wantErr: pgperrors.ErrUnknownIssuer,
-		},
-		{
-			name:            "IgnoreError",
-			f:               oneGroupSignedImage,
-			testCallback:    true,
-			ignoreError:     true,
-			id:              1,
-			kr:              openpgp.EntityList{},
-			wantCBSignature: 3,
-			wantCBErr:       pgperrors.ErrUnknownIssuer,
-			wantErr:         nil,
-		},
-		{
-			name: "OneGroupSigned",
-			f:    oneGroupSignedImage,
-			id:   1,
-			kr:   kr,
-		},
-		{
-			name:            "OneGroupSignedWithCallback",
-			f:               oneGroupSignedImage,
-			testCallback:    true,
-			id:              1,
-			kr:              kr,
-			wantCBSignature: 3,
-			wantCBVerified:  []uint32{1},
-			wantCBEntity:    e,
-		},
-		{
-			name: "OneGroupSignedSubset",
-			f:    oneGroupSignedImage,
-			id:   1,
-			kr:   kr,
-		},
-		{
-			name:            "OneGroupSignedSubsetWithCallback",
-			f:               oneGroupSignedImage,
-			testCallback:    true,
-			id:              1,
-			kr:              kr,
-			wantCBSignature: 3,
-			wantCBVerified:  []uint32{1},
-			wantCBEntity:    e,
+			name:     "Signed",
+			f:        oneGroupSignedImage,
+			id:       1,
+			wantSigs: sigs,
 		},
 	}
 
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			// Test callback functionality, if requested.
-			var cb VerifyCallback
-
-			//nolint:dupl
-			if tt.testCallback {
-				cb = func(r VerifyResult) bool {
-					if got, want := r.Signature().ID(), tt.wantCBSignature; got != want {
-						t.Errorf("got signature %v, want %v", got, want)
-					}
-
-					if got, want := len(r.Verified()), len(tt.wantCBVerified); got != want {
-						t.Fatalf("got %v verified objects, want %v", got, want)
-					}
-					for i, od := range r.Verified() {
-						if got, want := od.ID(), tt.wantCBVerified[i]; got != want {
-							t.Errorf("got verified ID %v, want %v", got, want)
-						}
-					}
-
-					if got, want := r.Entity(), tt.wantCBEntity; got != want {
-						t.Errorf("got entity %v, want %v", got, want)
-					}
-
-					if got, want := r.Error(), tt.wantCBErr; !errors.Is(got, want) {
-						t.Errorf("got error %v, want %v", got, want)
-					}
-
-					return tt.ignoreError
-				}
-			}
-
 			od, err := tt.f.GetDescriptor(sif.WithID(tt.id))
 			if err != nil {
 				t.Fatal(err)
@@ -571,12 +352,98 @@ func TestLegacyObjectVerifier_verifyWithKeyRing(t *testing.T) {
 
 			v := &legacyObjectVerifier{
 				f:  tt.f,
-				cb: cb,
 				od: od,
 			}
 
-			if got, want := v.verifyWithKeyRing(tt.kr), tt.wantErr; !errors.Is(got, want) {
+			sigs, err := v.signatures()
+
+			if got, want := err, tt.wantErr; !errors.Is(got, want) {
+				t.Fatalf("got error %v, want %v", got, want)
+			}
+
+			if got, want := sigs, tt.wantSigs; !reflect.DeepEqual(got, want) {
+				t.Errorf("got signatures %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestLegacyObjectVerifier_verify(t *testing.T) {
+	oneGroupSignedImage := loadContainer(t, filepath.Join(corpus, "one-group-signed-legacy-all.sif"))
+
+	sig, err := oneGroupSignedImage.GetDescriptor(
+		sif.WithDataType(sif.DataSignature),
+		sif.WithLinkedID(1),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	verified, err := oneGroupSignedImage.GetDescriptors(sif.WithID(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := getTestEntity(t)
+
+	tests := []struct {
+		name         string
+		f            *sif.FileImage
+		id           uint32
+		sig          sif.Descriptor
+		de           decoder
+		wantErr      error
+		wantVerified []sif.Descriptor
+		wantEntity   *openpgp.Entity
+	}{
+		{
+			name: "UnknownIssuer",
+			f:    oneGroupSignedImage,
+			id:   1,
+			sig:  sig,
+			de:   newClearsignDecoder(openpgp.EntityList{}),
+			wantErr: &SignatureNotValidError{
+				ID:  3,
+				Err: pgperrors.ErrUnknownIssuer,
+			},
+		},
+		{
+			name:         "OneGroupSigned",
+			f:            oneGroupSignedImage,
+			id:           1,
+			sig:          sig,
+			de:           newClearsignDecoder(openpgp.EntityList{e}),
+			wantVerified: verified,
+			wantEntity:   e,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			od, err := tt.f.GetDescriptor(sif.WithID(tt.id))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			v := &legacyObjectVerifier{
+				f:  tt.f,
+				od: od,
+			}
+
+			var vr VerifyResult
+			err = v.verifySignature(tt.sig, tt.de, &vr)
+
+			if got, want := err, tt.wantErr; !errors.Is(got, want) {
 				t.Errorf("got error %v, want %v", got, want)
+			}
+
+			if got, want := vr.Verified(), tt.wantVerified; !reflect.DeepEqual(got, want) {
+				t.Errorf("got verified %v, want %v", got, want)
+			}
+
+			if got, want := vr.Entity(), tt.wantEntity; !reflect.DeepEqual(got, want) {
+				t.Errorf("got entity %v, want %v", got, want)
 			}
 		})
 	}
@@ -811,16 +678,68 @@ func TestNewVerifier(t *testing.T) {
 }
 
 type mockVerifier struct {
-	fps [][]byte
-	err error
+	sigs    []sif.Descriptor
+	sigsErr error
+
+	verified  []sif.Descriptor
+	e         *openpgp.Entity
+	verifyErr error
 }
 
-func (v mockVerifier) fingerprints() ([][]byte, error) {
-	return v.fps, v.err
+func (v mockVerifier) signatures() ([]sif.Descriptor, error) {
+	return v.sigs, v.sigsErr
 }
 
-func (v mockVerifier) verifyWithKeyRing(kr openpgp.KeyRing) error {
-	return v.err
+func (v mockVerifier) verifySignature(sig sif.Descriptor, de decoder, vr *VerifyResult) error {
+	vr.verified = v.verified
+	vr.e = v.e
+	return v.verifyErr
+}
+
+// getSignedDummy generates a dummy SIF container that contains a data object and one dummy
+// signature per fingerprint.
+func getSignedDummy(t *testing.T, fps ...[]byte) *sif.FileImage {
+	t.Helper()
+
+	di, err := sif.NewDescriptorInput(sif.DataGeneric, strings.NewReader("data"),
+		sif.OptGroupID(1),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dis := []sif.DescriptorInput{di}
+
+	for _, fp := range fps {
+		di, err := sif.NewDescriptorInput(sif.DataSignature, strings.NewReader("sig"),
+			sif.OptSignatureMetadata(crypto.SHA256, fp),
+			sif.OptNoGroup(),
+			sif.OptLinkedGroupID(1),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		dis = append(dis, di)
+	}
+
+	var buf sif.Buffer
+
+	fi, err := sif.CreateContainer(&buf,
+		sif.OptCreateDeterministic(),
+		sif.OptCreateWithDescriptors(dis...),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		if err := fi.UnloadContainer(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	return fi
 }
 
 func TestVerifier_AnySignedBy(t *testing.T) {
@@ -834,6 +753,13 @@ func TestVerifier_AnySignedBy(t *testing.T) {
 		0x09, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00,
 	}
 
+	fi := getSignedDummy(t, fp1, fp2)
+
+	sigs, err := fi.GetDescriptors(sif.WithDataType(sif.DataSignature))
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	tests := []struct {
 		name             string
 		tasks            []verifyTask
@@ -843,48 +769,48 @@ func TestVerifier_AnySignedBy(t *testing.T) {
 		{
 			name: "OneTaskEOF",
 			tasks: []verifyTask{
-				mockVerifier{err: io.EOF},
+				mockVerifier{sigsErr: io.EOF},
 			},
 			wantErr: io.EOF,
 		},
 		{
 			name: "TwoTasksEOF",
 			tasks: []verifyTask{
-				mockVerifier{fps: [][]byte{fp1}},
-				mockVerifier{err: io.EOF},
+				mockVerifier{sigs: sigs[:1]},
+				mockVerifier{sigsErr: io.EOF},
 			},
 			wantErr: io.EOF,
 		},
 		{
 			name: "OneTaskOneFP",
 			tasks: []verifyTask{
-				mockVerifier{fps: [][]byte{fp1}},
+				mockVerifier{sigs: sigs[:1]},
 			},
 			wantFingerprints: [][]byte{fp1},
 		},
 		{
 			name: "TwoTasksSameFP",
 			tasks: []verifyTask{
-				mockVerifier{fps: [][]byte{fp1}},
-				mockVerifier{fps: [][]byte{fp1}},
+				mockVerifier{sigs: sigs[:1]},
+				mockVerifier{sigs: sigs[:1]},
 			},
 			wantFingerprints: [][]byte{fp1},
 		},
 		{
 			name: "TwoTasksTwoFP",
 			tasks: []verifyTask{
-				mockVerifier{fps: [][]byte{fp1}},
-				mockVerifier{fps: [][]byte{fp2}},
+				mockVerifier{sigs: sigs[:1]},
+				mockVerifier{sigs: sigs[1:]},
 			},
 			wantFingerprints: [][]byte{fp1, fp2},
 		},
 		{
 			name: "KitchenSink",
 			tasks: []verifyTask{
-				mockVerifier{fps: [][]byte{}},
-				mockVerifier{fps: [][]byte{fp1}},
-				mockVerifier{fps: [][]byte{fp2}},
-				mockVerifier{fps: [][]byte{fp1, fp2}},
+				mockVerifier{},
+				mockVerifier{sigs: sigs[:1]},
+				mockVerifier{sigs: sigs[1:]},
+				mockVerifier{sigs: sigs},
 			},
 			wantFingerprints: [][]byte{fp1, fp2},
 		},
@@ -919,6 +845,13 @@ func TestVerifier_AllSignedBy(t *testing.T) {
 		0x09, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00,
 	}
 
+	fi := getSignedDummy(t, fp1, fp2)
+
+	sigs, err := fi.GetDescriptors(sif.WithDataType(sif.DataSignature))
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	tests := []struct {
 		name             string
 		tasks            []verifyTask
@@ -928,53 +861,53 @@ func TestVerifier_AllSignedBy(t *testing.T) {
 		{
 			name: "OneTaskEOF",
 			tasks: []verifyTask{
-				mockVerifier{err: io.EOF},
+				mockVerifier{sigsErr: io.EOF},
 			},
 			wantErr: io.EOF,
 		},
 		{
 			name: "TwoTasksEOF",
 			tasks: []verifyTask{
-				mockVerifier{fps: [][]byte{fp1}},
-				mockVerifier{err: io.EOF},
+				mockVerifier{sigs: sigs[:1]},
+				mockVerifier{sigsErr: io.EOF},
 			},
 			wantErr: io.EOF,
 		},
 		{
 			name: "OneTaskNoFP",
 			tasks: []verifyTask{
-				mockVerifier{fps: [][]byte{}},
+				mockVerifier{},
 			},
 		},
 		{
 			name: "OneTaskOneFP",
 			tasks: []verifyTask{
-				mockVerifier{fps: [][]byte{fp1}},
+				mockVerifier{sigs: sigs[:1]},
 			},
 			wantFingerprints: [][]byte{fp1},
 		},
 		{
 			name: "TwoTasksSameFP",
 			tasks: []verifyTask{
-				mockVerifier{fps: [][]byte{fp1}},
-				mockVerifier{fps: [][]byte{fp1}},
+				mockVerifier{sigs: sigs[:1]},
+				mockVerifier{sigs: sigs[:1]},
 			},
 			wantFingerprints: [][]byte{fp1},
 		},
 		{
 			name: "TwoTasksTwoFP",
 			tasks: []verifyTask{
-				mockVerifier{fps: [][]byte{fp1}},
-				mockVerifier{fps: [][]byte{fp2}},
+				mockVerifier{sigs: sigs[:1]},
+				mockVerifier{sigs: sigs[1:]},
 			},
 		},
 		{
 			name: "KitchenSink",
 			tasks: []verifyTask{
-				mockVerifier{fps: [][]byte{}},
-				mockVerifier{fps: [][]byte{fp1}},
-				mockVerifier{fps: [][]byte{fp2}},
-				mockVerifier{fps: [][]byte{fp1, fp2}},
+				mockVerifier{},
+				mockVerifier{sigs: sigs[:1]},
+				mockVerifier{sigs: sigs[1:]},
+				mockVerifier{sigs: sigs},
 			},
 		},
 	}
@@ -998,35 +931,109 @@ func TestVerifier_AllSignedBy(t *testing.T) {
 }
 
 func TestVerifier_Verify(t *testing.T) {
+	oneGroupImage := loadContainer(t, filepath.Join(corpus, "one-group.sif"))
 	oneGroupSignedImage := loadContainer(t, filepath.Join(corpus, "one-group-signed.sif"))
 
-	kr := openpgp.EntityList{getTestEntity(t)}
+	verified, err := oneGroupSignedImage.GetDescriptors(sif.WithGroupID(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sig, err := oneGroupSignedImage.GetDescriptor(sif.WithDataType(sif.DataSignature))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := getTestEntity(t)
+
+	kr := openpgp.EntityList{e}
 
 	tests := []struct {
-		name    string
-		f       *sif.FileImage
-		kr      openpgp.KeyRing
-		tasks   []verifyTask
-		wantErr error
+		name            string
+		f               *sif.FileImage
+		tasks           []verifyTask
+		kr              openpgp.KeyRing
+		testCallback    bool
+		ignoreError     bool
+		wantCBSignature sif.Descriptor
+		wantCBVerified  []sif.Descriptor
+		wantCBEntity    *openpgp.Entity
+		wantCBErr       error
+		wantErr         error
 	}{
 		{
-			name:    "ErrNoKeyMaterial",
-			f:       oneGroupSignedImage,
-			tasks:   []verifyTask{mockVerifier{}},
+			name: "NoKeyMaterial",
+			f:    oneGroupSignedImage,
+			tasks: []verifyTask{
+				mockVerifier{},
+			},
 			wantErr: ErrNoKeyMaterial,
 		},
 		{
-			name:    "EOF",
-			f:       oneGroupSignedImage,
+			name: "SignatureNotFound",
+			f:    oneGroupImage,
+			tasks: []verifyTask{
+				mockVerifier{
+					sigsErr: &SignatureNotFoundError{ID: 1, IsGroup: true},
+				},
+			},
 			kr:      kr,
-			tasks:   []verifyTask{mockVerifier{err: io.EOF}},
-			wantErr: io.EOF,
+			wantErr: &SignatureNotFoundError{},
 		},
 		{
-			name:  "OK",
-			f:     oneGroupSignedImage,
-			kr:    kr,
-			tasks: []verifyTask{mockVerifier{}},
+			name: "UnknownIssuer",
+			f:    oneGroupSignedImage,
+			tasks: []verifyTask{
+				mockVerifier{
+					sigs:      []sif.Descriptor{sig},
+					verifyErr: &SignatureNotValidError{ID: 3, Err: pgperrors.ErrUnknownIssuer},
+				},
+			},
+			kr:      kr,
+			wantErr: &SignatureNotValidError{},
+		},
+		{
+			name: "UnknownIssuerIgnoreError",
+			f:    oneGroupSignedImage,
+			tasks: []verifyTask{
+				mockVerifier{
+					sigs:      []sif.Descriptor{sig},
+					verifyErr: &SignatureNotValidError{ID: 3, Err: pgperrors.ErrUnknownIssuer},
+				},
+			},
+			testCallback:    true,
+			ignoreError:     true,
+			kr:              openpgp.EntityList{},
+			wantCBSignature: sig,
+			wantCBErr:       &SignatureNotValidError{ID: 3, Err: pgperrors.ErrUnknownIssuer},
+			wantErr:         nil,
+		},
+		{
+			name: "OneGroupSigned",
+			f:    oneGroupSignedImage,
+			tasks: []verifyTask{
+				mockVerifier{
+					sigs:     []sif.Descriptor{sig},
+					verified: verified,
+				},
+			},
+			kr: kr,
+		},
+		{
+			name:         "OneGroupSignedWithCallback",
+			f:            oneGroupSignedImage,
+			testCallback: true,
+			tasks: []verifyTask{
+				mockVerifier{
+					sigs:     []sif.Descriptor{sig},
+					verified: verified,
+					e:        e,
+				},
+			},
+			kr:              kr,
+			wantCBSignature: sig,
+			wantCBVerified:  verified,
+			wantCBEntity:    e,
 		},
 	}
 
@@ -1035,8 +1042,31 @@ func TestVerifier_Verify(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			v := Verifier{
 				f:     tt.f,
-				kr:    tt.kr,
 				tasks: tt.tasks,
+				kr:    tt.kr,
+			}
+
+			// Test callback functionality, if requested.
+			if tt.testCallback {
+				v.cb = func(r VerifyResult) bool {
+					if got, want := r.Signature(), tt.wantCBSignature; got != want {
+						t.Errorf("got signature %v, want %v", got, want)
+					}
+
+					if got, want := r.Verified(), tt.wantCBVerified; !reflect.DeepEqual(got, want) {
+						t.Errorf("got verified %v, want %v", got, want)
+					}
+
+					if got, want := r.Entity(), tt.wantCBEntity; got != want {
+						t.Errorf("got entity %v, want %v", got, want)
+					}
+
+					if got, want := r.Error(), tt.wantCBErr; !errors.Is(got, want) {
+						t.Errorf("got error %v, want %v", got, want)
+					}
+
+					return tt.ignoreError
+				}
 			}
 
 			if got, want := v.Verify(), tt.wantErr; !errors.Is(got, want) {


### PR DESCRIPTION
De-couple digital signature decoding and verification from higher level verifier logic. Centralize fingerprint and vericiation callback logic. Re-factor `type encoder interface` to make fingerprint optional via `optSignGroupFingerprint`.