### PR TITLE
test: move gen_sifs.go to images dir

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - checkout
       - run:
           name: Generate Test Corpus
-          command: pushd test/ && go run ./gen_sifs.go && popd
+          command: pushd test/images/ && go run ./gen_sifs.go && popd
       - run:
           name: Check Test Corpus Tidiness
           command: git diff --exit-code --

--- a/test/images/gen_sifs.go
+++ b/test/images/gen_sifs.go
@@ -23,14 +23,14 @@ import (
 
 // getSignerVerifier returns a SignerVerifier read from the PEM file at path.
 func getSignerVerifier(name string) (signature.SignerVerifier, error) { //nolint:ireturn
-	path := filepath.Join("keys", name)
+	path := filepath.Join("..", "keys", name)
 	return signature.LoadSignerVerifierFromPEMFile(path, crypto.SHA256, cryptoutils.SkipPassword)
 }
 
 var errUnexpectedNumEntities = errors.New("unexpected number of entities")
 
 func getEntity() (*openpgp.Entity, error) {
-	f, err := os.Open(filepath.Join("keys", "private.asc"))
+	f, err := os.Open(filepath.Join("..", "keys", "private.asc"))
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func generateImages() error {
 	}
 
 	objectSBOM := func() (sif.DescriptorInput, error) {
-		b, err := os.ReadFile(filepath.Join("input", "sbom.cdx.json"))
+		b, err := os.ReadFile(filepath.Join("..", "input", "sbom.cdx.json"))
 		if err != nil {
 			return sif.DescriptorInput{}, err
 		}
@@ -96,7 +96,7 @@ func generateImages() error {
 	}
 
 	partPrimSys := func() (sif.DescriptorInput, error) {
-		b, err := os.ReadFile(filepath.Join("input", "root.squashfs"))
+		b, err := os.ReadFile(filepath.Join("..", "input", "root.squashfs"))
 		if err != nil {
 			return sif.DescriptorInput{}, err
 		}
@@ -107,7 +107,7 @@ func generateImages() error {
 	}
 
 	partSystemGroup2 := func() (sif.DescriptorInput, error) {
-		b, err := os.ReadFile(filepath.Join("input", "root.ext3"))
+		b, err := os.ReadFile(filepath.Join("..", "input", "root.ext3"))
 		if err != nil {
 			return sif.DescriptorInput{}, err
 		}
@@ -248,7 +248,7 @@ func generateImages() error {
 		}
 		opts = append(opts, image.opts...)
 
-		f, err := sif.CreateContainerAtPath(filepath.Join("images", image.path), opts...)
+		f, err := sif.CreateContainerAtPath(image.path, opts...)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Move `test/gen_sifs.go` to `test/images/` directory for consistency (ex. `test/keys/gen_keys.go`).