### PR TITLE
Use hash algorithm from Signer

### DIFF
--- a/pkg/integrity/main_test.go
+++ b/pkg/integrity/main_test.go
@@ -56,6 +56,24 @@ func getTestSigner(t *testing.T, name string, h crypto.Hash) signature.Signer { 
 	return sv
 }
 
+type wrapSigner struct {
+	signature.Signer
+	h crypto.Hash
+}
+
+func (s *wrapSigner) HashFunc() crypto.Hash { return s.h }
+
+// getTestSignerWithOpts returns a Signer read from the PEM file at path, wrapped to implement the
+// crypto.SignerOpts interface.
+func getTestSignerWithOpts(t *testing.T, name string, h crypto.Hash) *wrapSigner {
+	t.Helper()
+
+	return &wrapSigner{
+		Signer: getTestSigner(t, name, h),
+		h:      h,
+	}
+}
+
 // getTestVerifier returns a Verifier read from the PEM file at path.
 func getTestVerifier(t *testing.T, name string, h crypto.Hash) signature.Verifier { //nolint:ireturn
 	t.Helper()

--- a/pkg/integrity/sign.go
+++ b/pkg/integrity/sign.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -330,7 +330,7 @@ func NewSigner(f *sif.FileImage, opts ...SignerOpt) (*Signer, error) {
 	switch {
 	case so.ss != nil:
 		var err error
-		en, err = newDSSEEncoder(so.ss)
+		en, err = newDSSEEncoder(so.ss...)
 		if err != nil {
 			return nil, fmt.Errorf("integrity: %w", err)
 		}


### PR DESCRIPTION
When `signature.Singer` implements `crypto.SignerOpts`, use the hash value specified by that. Otherwise, continue to use the default value of SHA-256.

Fixes #249 