### PR TITLE
Bump Go Version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,10 @@ executors:
       - image: golangci/golangci-lint:v1.50-alpine
   golang-previous:
     docker:
-      - image: golang:1.18
+      - image: golang:1.19
   golang-latest:
     docker:
-      - image: golang:1.19
-  golang-rc:
-    docker:
-      - image: golang:1.20-rc
+      - image: golang:1.20
 
 jobs:
   lint-markdown:
@@ -132,11 +129,11 @@ workflows:
       - build-source:
           matrix:
             parameters:
-              e: ["golang-previous", "golang-latest", "golang-rc"]
+              e: ["golang-previous", "golang-latest"]
       - unit-test:
           matrix:
             parameters:
-              e: ["golang-previous", "golang-latest", "golang-rc"]
+              e: ["golang-previous", "golang-latest"]
       - release-test
 
   tagged-release:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/sylabs/sif/v2
 go 1.19
 
 require (
-	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4
+	github.com/ProtonMail/go-crypto v0.0.0-20230201104953-d1d05f4e2bfb
 	github.com/google/uuid v1.3.0
 	github.com/sebdah/goldie/v2 v2.5.3
 	github.com/secure-systems-lab/go-securesystemslib v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sylabs/sif/v2
 
-go 1.18
+go 1.19
 
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 h1:ra2OtmuW0AE5csawV4YXMNGNQQXvLRps3z2Z59OPO+I=
-github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4/go.mod h1:UBYPn8k0D56RtnR8RFQMjmh4KrZzWJ5o7Z9SYjossQ8=
+github.com/ProtonMail/go-crypto v0.0.0-20230201104953-d1d05f4e2bfb h1:Vx1Bw/nGULx+FuY7Sw+8ZDpOx9XOdA+mOfo678SqkbU=
+github.com/ProtonMail/go-crypto v0.0.0-20230201104953-d1d05f4e2bfb/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=

--- a/pkg/integrity/clearsign_test.go
+++ b/pkg/integrity/clearsign_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -133,12 +133,6 @@ func Test_clearsignDecoder_verifyMessage(t *testing.T) {
 			name:       "DefaultHash",
 			de:         newClearsignDecoder(openpgp.EntityList{e}),
 			wantEntity: e,
-		},
-		{
-			name:    "SHA1",
-			hash:    crypto.SHA1,
-			de:      newClearsignDecoder(openpgp.EntityList{e}),
-			wantErr: pgperrors.StructuralError("hash algorithm mismatch with cleartext message headers"),
 		},
 		{
 			name:       "SHA224",

--- a/pkg/integrity/sign_test.go
+++ b/pkg/integrity/sign_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -171,9 +171,9 @@ func TestNewGroupSigner(t *testing.T) {
 			name:        "OptSignGroupMetadataHash",
 			fi:          twoGroupImage,
 			groupID:     1,
-			opts:        []groupSignerOpt{optSignGroupMetadataHash(crypto.SHA1)},
+			opts:        []groupSignerOpt{optSignGroupMetadataHash(crypto.SHA384)},
 			wantObjects: []uint32{1, 2},
-			wantMDHash:  crypto.SHA1,
+			wantMDHash:  crypto.SHA384,
 		},
 		{
 			name:    "OptSignGroupMetadataHash",
@@ -287,7 +287,7 @@ func TestGroupSigner_Sign(t *testing.T) {
 				f:      twoGroups,
 				id:     1,
 				ods:    []sif.Descriptor{d1},
-				mdHash: crypto.SHA1,
+				mdHash: crypto.SHA256,
 				fp:     encrypted.PrimaryKey.Fingerprint,
 			},
 			wantErr: true,


### PR DESCRIPTION
Bump module Go version to 1.19. Advance CI testing to Go 1.19-1.20. Bump `github.com/ProtonMail/go-crypto` to latest. Remove SHA1 test case, since signing with SHA1 is no longer supported by `go-crypto` (https://github.com/ProtonMail/go-crypto/pull/143).