### PR TITLE
fix: add nolint to silence go-errorlint

### DIFF
--- a/pkg/integrity/digest.go
+++ b/pkg/integrity/digest.go
@@ -117,6 +117,7 @@ func (d digest) MarshalJSON() ([]byte, error) {
 func (d *digest) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
+		//nolint:errorlint // Go 1.19 compatibility
 		return fmt.Errorf("%w: %v", errDigestMalformed, err)
 	}
 
@@ -129,6 +130,7 @@ func (d *digest) UnmarshalJSON(data []byte) error {
 
 	v, err := hex.DecodeString(value)
 	if err != nil {
+		//nolint:errorlint // Go 1.19 compatibility
 		return fmt.Errorf("%w: %v", errDigestMalformed, err)
 	}
 

--- a/pkg/integrity/dsse.go
+++ b/pkg/integrity/dsse.go
@@ -125,6 +125,7 @@ func (de *dsseDecoder) verifyMessage(r io.Reader, h crypto.Hash, vr *VerifyResul
 
 	vr.aks, err = v.Verify(context.TODO(), &e)
 	if err != nil {
+		//nolint:errorlint // Go 1.19 compatibility
 		return nil, fmt.Errorf("%w: %v", errDSSEVerifyEnvelopeFailed, err)
 	}
 


### PR DESCRIPTION
Temporarily disable `go-errorlint` where suggestions would break Go 1.19 compatibility (https://github.com/polyfloyd/go-errorlint/issues/37).