### PR TITLE
chore: bump golangci-lint to v1.52

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:19-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.51-alpine
+      - image: golangci/golangci-lint:v1.52-alpine
   golang-previous:
     docker:
       - image: golang:1.19

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,5 +50,9 @@ linters:
     - whitespace
 
 linters-settings:
+  errorlint:
+    # Go 1.19 compatibility (https://github.com/sylabs/sif/issues/265).
+    errorf-multi: false
+
   misspell:
     locale: US

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,7 +46,7 @@ linters:
     - typecheck
     - unconvert
     - unparam
-    # - unused
+    - unused
     - whitespace
 
 linters-settings:

--- a/pkg/integrity/clearsign.go
+++ b/pkg/integrity/clearsign.go
@@ -38,7 +38,7 @@ func newClearsignEncoder(e *openpgp.Entity, timeFunc func() time.Time) *clearsig
 
 // signMessage signs the message from r in clear-sign format, and writes the result to w. On
 // success, the hash function is returned.
-func (en *clearsignEncoder) signMessage(ctx context.Context, w io.Writer, r io.Reader) (crypto.Hash, error) {
+func (en *clearsignEncoder) signMessage(_ context.Context, w io.Writer, r io.Reader) (crypto.Hash, error) {
 	plaintext, err := clearsign.Encode(w, en.e.PrivateKey, en.config)
 	if err != nil {
 		return 0, err
@@ -63,7 +63,7 @@ func newClearsignDecoder(kr openpgp.KeyRing) *clearsignDecoder {
 
 // verifyMessage reads a message from r, verifies its signature, and returns the message contents.
 // On success, the signing entity is set in vr.
-func (de *clearsignDecoder) verifyMessage(ctx context.Context, r io.Reader, h crypto.Hash, vr *VerifyResult) ([]byte, error) { //nolint:lll
+func (de *clearsignDecoder) verifyMessage(_ context.Context, r io.Reader, _ crypto.Hash, vr *VerifyResult) ([]byte, error) { //nolint:lll
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err

--- a/pkg/integrity/digest.go
+++ b/pkg/integrity/digest.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -117,7 +117,6 @@ func (d digest) MarshalJSON() ([]byte, error) {
 func (d *digest) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
-		//nolint:errorlint // Go 1.19 compatibility
 		return fmt.Errorf("%w: %v", errDigestMalformed, err)
 	}
 
@@ -130,7 +129,6 @@ func (d *digest) UnmarshalJSON(data []byte) error {
 
 	v, err := hex.DecodeString(value)
 	if err != nil {
-		//nolint:errorlint // Go 1.19 compatibility
 		return fmt.Errorf("%w: %v", errDigestMalformed, err)
 	}
 

--- a/pkg/integrity/dsse.go
+++ b/pkg/integrity/dsse.go
@@ -168,7 +168,7 @@ func (s *dsseSigner) Sign(ctx context.Context, data []byte) ([]byte, error) {
 var errSignNotImplemented = errors.New("sign not implemented")
 
 // Verify is not implemented, but required for the dsse.SignVerifier interface.
-func (s *dsseSigner) Verify(ctx context.Context, data, sig []byte) error {
+func (s *dsseSigner) Verify(_ context.Context, _, _ []byte) error {
 	return errSignNotImplemented
 }
 

--- a/pkg/integrity/dsse.go
+++ b/pkg/integrity/dsse.go
@@ -125,7 +125,6 @@ func (de *dsseDecoder) verifyMessage(ctx context.Context, r io.Reader, h crypto.
 
 	vr.aks, err = v.Verify(ctx, &e)
 	if err != nil {
-		//nolint:errorlint // Go 1.19 compatibility
 		return nil, fmt.Errorf("%w: %v", errDSSEVerifyEnvelopeFailed, err)
 	}
 

--- a/pkg/integrity/verify_test.go
+++ b/pkg/integrity/verify_test.go
@@ -718,7 +718,7 @@ func (v mockVerifier) signatures() ([]sif.Descriptor, error) {
 	return v.sigs, v.sigsErr
 }
 
-func (v mockVerifier) verifySignature(ctx context.Context, sig sif.Descriptor, de decoder, vr *VerifyResult) error {
+func (v mockVerifier) verifySignature(_ context.Context, _ sif.Descriptor, _ decoder, vr *VerifyResult) error {
 	vr.verified = v.verified
 	vr.e = v.e
 	return v.verifyErr

--- a/pkg/sif/create.go
+++ b/pkg/sif/create.go
@@ -451,11 +451,7 @@ func (f *FileImage) isLast(d *rawDescriptor) bool {
 func (f *FileImage) truncateAt(d *rawDescriptor) error {
 	start := d.Offset + d.Size - d.SizeWithPadding
 
-	if err := f.rw.Truncate(start); err != nil {
-		return err
-	}
-
-	return nil
+	return f.rw.Truncate(start)
 }
 
 // deleteOpts accumulates object deletion options.

--- a/pkg/siftool/siftool.go
+++ b/pkg/siftool/siftool.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 // Copyright (c) 2017, Yannick Cote <yhcote@gmail.com> All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
@@ -20,7 +20,7 @@ type command struct {
 }
 
 // initApp initializes the siftool app.
-func (c *command) initApp(cmd *cobra.Command, args []string) error {
+func (c *command) initApp(cmd *cobra.Command, _ []string) error {
 	app, err := siftool.New(
 		siftool.OptAppOutput(cmd.OutOrStdout()),
 		siftool.OptAppError(cmd.ErrOrStderr()),


### PR DESCRIPTION
Bump `golangci-lint` to v1.52. Replace individual `nolint` lines with `errorf-multi: false` in global CI config (#265). Re-enable `unused` linter (closes #269).