### PR TITLE
ci: use official Goreleaser bash script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
           command: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
       - run:
           name: Test Release
-          command: curl -sL https://git.io/goreleaser | bash -s -- --snapshot --skip-publish
+          command: curl -sSfL https://goreleaser.com/static/run | bash -s -- --snapshot --skip-publish
 
   publish-release:
     executor: golang-latest
@@ -114,7 +114,7 @@ jobs:
           command: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
       - run:
           name: Publish Release
-          command: curl -sL https://git.io/goreleaser | bash
+          command: curl -sSfL https://goreleaser.com/static/run | bash
 
 workflows:
   version: 2


### PR DESCRIPTION
Replace use of the `git.io` URL-shortener service, which occasionally returns a `500 Internal Server Error` ([example](https://app.circleci.com/pipelines/github/sylabs/sif/764/workflows/c4413a49-85b1-4b1b-8f18-8980e6755486/jobs/5305)). An [April 2022 GitHub blog post](https://github.blog/changelog/2022-04-25-git-io-deprecation/) indicates that the service is deprecated, although it also indicates the service should continue to work going forward.