### PR TITLE
ci: disable GitHub checks for CodeCov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+github_checks: false


### PR DESCRIPTION
These just started showing up, and are failing. Disabling for now.

![Screenshot 2023-05-12 at 3 17 32 PM](https://github.com/sylabs/sif/assets/9903835/b1748cc6-03f3-4d12-9388-56c6f04cc139)
