### PR TITLE
ci: bump golangci-lint to v1.53

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:19-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.52-alpine
+      - image: golangci/golangci-lint:v1.53
   golang-previous:
     docker:
       - image: golang:1.19

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,6 @@ linters:
     - containedctx
     - contextcheck
     - decorder
-    - depguard
     - dogsled
     - dupl
     - dupword
@@ -16,6 +15,7 @@ linters:
     - errname
     - errorlint
     - exportloopref
+    - forcetypeassert
     - gochecknoinits
     - gocritic
     - godot
@@ -34,6 +34,7 @@ linters:
     - ireturn
     - lll
     - maintidx
+    - mirror
     - misspell
     - nilnil
     - nolintlint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,6 +44,7 @@ linters:
     - revive
     - staticcheck
     - tenv
+    - thelper
     - typecheck
     - unconvert
     - unparam

--- a/pkg/integrity/dsse_test.go
+++ b/pkg/integrity/dsse_test.go
@@ -107,6 +107,8 @@ func Test_dsseEncoder_signMessage(t *testing.T) {
 // corruptPayloadType corrupts the payload type of e and re-signs the envelope. The result is a
 // cryptographically valid envelope with an unexpected payload types.
 func corruptPayloadType(t *testing.T, en *dsseEncoder, e *dsse.Envelope) {
+	t.Helper()
+
 	body, err := e.DecodeB64Payload()
 	if err != nil {
 		t.Fatal(err)
@@ -123,6 +125,8 @@ func corruptPayloadType(t *testing.T, en *dsseEncoder, e *dsse.Envelope) {
 // corruptPayload corrupts the payload in e. The result is that the signature(s) in e do not match
 // the payload.
 func corruptPayload(t *testing.T, _ *dsseEncoder, e *dsse.Envelope) {
+	t.Helper()
+
 	body, err := e.DecodeB64Payload()
 	if err != nil {
 		t.Fatal(err)
@@ -134,6 +138,8 @@ func corruptPayload(t *testing.T, _ *dsseEncoder, e *dsse.Envelope) {
 // corruptSignatures corrupts the signature(s) in e. The result is that the signature(s) in e do
 // not match the payload.
 func corruptSignatures(t *testing.T, _ *dsseEncoder, e *dsse.Envelope) {
+	t.Helper()
+
 	for i, sig := range e.Signatures {
 		b, err := base64.StdEncoding.DecodeString(sig.Sig)
 		if err != nil {

--- a/pkg/sif/select_test.go
+++ b/pkg/sif/select_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -271,6 +271,7 @@ func TestFileImage_WithDescriptors(t *testing.T) {
 		{
 			name: "ReturnTrue",
 			fn: func(t *testing.T) func(d Descriptor) bool {
+				t.Helper()
 				return func(d Descriptor) bool {
 					if id := d.ID(); id > 1 {
 						t.Errorf("unexpected ID: %v", id)
@@ -282,6 +283,7 @@ func TestFileImage_WithDescriptors(t *testing.T) {
 		{
 			name: "ReturnFalse",
 			fn: func(t *testing.T) func(d Descriptor) bool {
+				t.Helper()
 				return func(d Descriptor) bool {
 					if id := d.ID(); id > 2 {
 						t.Errorf("unexpected ID: %v", id)

--- a/pkg/siftool/siftool_test.go
+++ b/pkg/siftool/siftool_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -20,6 +20,8 @@ import (
 var corpus = filepath.Join("..", "..", "test", "images")
 
 func makeTestSIF(t *testing.T, withDataObject bool) string {
+	t.Helper()
+
 	tf, err := os.CreateTemp("", "sif-test-*")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Disable `depguard`, enable `forcetypeassert`, `thelper` and new `mirror` linter.