### PR TITLE
test: report file/line info for makeTestSIF errors

### DIFF
--- a/pkg/siftool/siftool_test.go
+++ b/pkg/siftool/siftool_test.go
@@ -19,9 +19,8 @@ import (
 
 var corpus = filepath.Join("..", "..", "test", "images")
 
+//nolint:thelper // Complex enough to justify keeping file/line information on error.
 func makeTestSIF(t *testing.T, withDataObject bool) string {
-	t.Helper()
-
 	tf, err := os.CreateTemp("", "sif-test-*")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Restore previous behaviour for `makeTestSIF` on error.