### PR TITLE
ci: disable codecov status

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,6 @@
+coverage:
+  status:
+    patch: off
+    project: off
+
 github_checks: false


### PR DESCRIPTION
Building on #296, disable Github status updates for now.