### PR TITLE
test: add testing against Go 1.21 RC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ executors:
   golang-latest:
     docker:
       - image: golang:1.20
+  golang-rc:
+    docker:
+      - image: golang:1.21-rc
 
 jobs:
   lint-markdown:
@@ -132,11 +135,11 @@ workflows:
       - build-source:
           matrix:
             parameters:
-              e: ["golang-previous", "golang-latest"]
+              e: ["golang-previous", "golang-latest","golang-rc"]
       - unit-test:
           matrix:
             parameters:
-              e: ["golang-previous", "golang-latest"]
+              e: ["golang-previous", "golang-latest","golang-rc"]
       - release-test
 
   tagged-release:


### PR DESCRIPTION
Start verifying compatibility with upcoming Go 1.21 release (https://go.dev/blog/go1.21rc).