### PR TITLE
chore: bump module Go version to 1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,10 @@ executors:
       - image: golangci/golangci-lint:v1.53
   golang-previous:
     docker:
-      - image: golang:1.19
+      - image: golang:1.20
   golang-latest:
     docker:
-      - image: golang:1.20
-  golang-rc:
-    docker:
-      - image: golang:1.21-rc
+      - image: golang:1.21
 
 jobs:
   lint-markdown:
@@ -135,11 +132,11 @@ workflows:
       - build-source:
           matrix:
             parameters:
-              e: ["golang-previous", "golang-latest","golang-rc"]
+              e: ["golang-previous", "golang-latest"]
       - unit-test:
           matrix:
             parameters:
-              e: ["golang-previous", "golang-latest","golang-rc"]
+              e: ["golang-previous", "golang-latest"]
       - release-test
 
   tagged-release:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,9 +52,5 @@ linters:
     - whitespace
 
 linters-settings:
-  errorlint:
-    # Go 1.19 compatibility (https://github.com/sylabs/sif/issues/265).
-    errorf-multi: false
-
   misspell:
     locale: US

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sylabs/sif/v2
 
-go 1.19
+go 1.20
 
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20230710112148-e01326fd72eb

--- a/pkg/integrity/digest.go
+++ b/pkg/integrity/digest.go
@@ -117,7 +117,7 @@ func (d digest) MarshalJSON() ([]byte, error) {
 func (d *digest) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
-		return fmt.Errorf("%w: %v", errDigestMalformed, err)
+		return fmt.Errorf("%w: %w", errDigestMalformed, err)
 	}
 
 	parts := strings.Split(s, ":")
@@ -129,7 +129,7 @@ func (d *digest) UnmarshalJSON(data []byte) error {
 
 	v, err := hex.DecodeString(value)
 	if err != nil {
-		return fmt.Errorf("%w: %v", errDigestMalformed, err)
+		return fmt.Errorf("%w: %w", errDigestMalformed, err)
 	}
 
 	for h, n := range supportedDigestAlgorithms {

--- a/pkg/integrity/dsse.go
+++ b/pkg/integrity/dsse.go
@@ -125,7 +125,7 @@ func (de *dsseDecoder) verifyMessage(ctx context.Context, r io.Reader, h crypto.
 
 	vr.aks, err = v.Verify(ctx, &e)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", errDSSEVerifyEnvelopeFailed, err)
+		return nil, fmt.Errorf("%w: %w", errDSSEVerifyEnvelopeFailed, err)
 	}
 
 	if e.PayloadType != de.payloadType {


### PR DESCRIPTION
Bump module Go version to 1.20. Advance Go range tested in CI to 1.20-1.21.

Closes #265 