### PR TITLE
chore: remove unnecessary nolint:errorlint lines

### DIFF
--- a/pkg/integrity/metadata.go
+++ b/pkg/integrity/metadata.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -40,7 +40,6 @@ func (e *DescriptorIntegrityError) Error() string {
 // Is compares e against target. If target is a DescriptorIntegrityError and matches e or target
 // has a zero value ID, true is returned.
 func (e *DescriptorIntegrityError) Is(target error) bool {
-	//nolint:errorlint // don't compare wrapped errors in Is()
 	t, ok := target.(*DescriptorIntegrityError)
 	if !ok {
 		return false
@@ -63,7 +62,6 @@ func (e *ObjectIntegrityError) Error() string {
 // Is compares e against target. If target is a ObjectIntegrityError and matches e or target has a
 // zero value ID, true is returned.
 func (e *ObjectIntegrityError) Is(target error) bool {
-	//nolint:errorlint // don't compare wrapped errors in Is()
 	t, ok := target.(*ObjectIntegrityError)
 	if !ok {
 		return false

--- a/pkg/integrity/select.go
+++ b/pkg/integrity/select.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -68,7 +68,6 @@ func (e *SignatureNotFoundError) Error() string {
 // Is compares e against target. If target is a SignatureNotFoundError and matches e or target has
 // a zero value ID, true is returned.
 func (e *SignatureNotFoundError) Is(target error) bool {
-	//nolint:errorlint // don't compare wrapped errors in Is()
 	t, ok := target.(*SignatureNotFoundError)
 	if !ok {
 		return false

--- a/pkg/integrity/verify.go
+++ b/pkg/integrity/verify.go
@@ -59,7 +59,6 @@ func (e *SignatureNotValidError) Unwrap() error {
 // Is compares e against target. If target is a SignatureNotValidError and matches e or target has
 // a zero value ID, true is returned.
 func (e *SignatureNotValidError) Is(target error) bool {
-	//nolint:errorlint // don't compare wrapped errors in Is()
 	t, ok := target.(*SignatureNotValidError)
 	if !ok {
 		return false

--- a/pkg/sif/descriptor_input.go
+++ b/pkg/sif/descriptor_input.go
@@ -111,7 +111,6 @@ func (e *unexpectedDataTypeError) Error() string {
 }
 
 func (e *unexpectedDataTypeError) Is(target error) bool {
-	//nolint:errorlint // don't compare wrapped errors in Is()
 	t, ok := target.(*unexpectedDataTypeError)
 	if !ok {
 		return false


### PR DESCRIPTION
As of v1.4.4, go-errorlint exempts `Is` methods from type assertions (see https://github.com/polyfloyd/go-errorlint/issues/50).