### PR TITLE
refactor: simplify zero implementation

### DIFF
--- a/pkg/sif/create.go
+++ b/pkg/sif/create.go
@@ -322,32 +322,6 @@ func CreateContainerAtPath(path string, opts ...CreateOpt) (*FileImage, error) {
 	return f, nil
 }
 
-func zeroData(fimg *FileImage, descr *rawDescriptor) error {
-	// first, move to data object offset
-	if _, err := fimg.rw.Seek(descr.Offset, io.SeekStart); err != nil {
-		return err
-	}
-
-	var zero [4096]byte
-	n := descr.Size
-	upbound := int64(4096)
-	for {
-		if n < 4096 {
-			upbound = n
-		}
-
-		if _, err := fimg.rw.Write(zero[:upbound]); err != nil {
-			return err
-		}
-		n -= 4096
-		if n <= 0 {
-			break
-		}
-	}
-
-	return nil
-}
-
 // addOpts accumulates object add options.
 type addOpts struct {
 	t time.Time
@@ -427,6 +401,26 @@ func (f *FileImage) isLast(d *rawDescriptor) bool {
 	})
 
 	return isLast
+}
+
+// zeroReader is an io.Reader that returns a stream of zero-bytes.
+type zeroReader struct{}
+
+func (zeroReader) Read(b []byte) (int, error) {
+	for i := range b {
+		b[i] = 0
+	}
+	return len(b), nil
+}
+
+// zero overwrites the data object described by d with a stream of zero bytes.
+func (f *FileImage) zero(d *rawDescriptor) error {
+	if _, err := f.rw.Seek(d.Offset, io.SeekStart); err != nil {
+		return err
+	}
+
+	_, err := io.CopyN(f.rw, zeroReader{}, d.Size)
+	return err
 }
 
 // truncateAt truncates f at the start of the padded data object described by d.
@@ -512,7 +506,7 @@ func (f *FileImage) DeleteObject(id uint32, opts ...DeleteOpt) error {
 	}
 
 	if do.zero {
-		if err := zeroData(f, d); err != nil {
+		if err := f.zero(d); err != nil {
 			return fmt.Errorf("%w", err)
 		}
 	}


### PR DESCRIPTION
Replace `func zeroData` with a simpler implementation that uses an `io.Reader` that streams zero bytes.