### PR TITLE
ci: test against Go 1.22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,10 @@ executors:
       - image: golangci/golangci-lint:v1.56
   golang-previous:
     docker:
-      - image: golang:1.20
+      - image: golang:1.21
   golang-latest:
     docker:
-      - image: golang:1.21
-  golang-rc:
-    docker:
-      - image: golang:1.22-rc
+      - image: golang:1.22
 
 jobs:
   lint-markdown:
@@ -135,11 +132,11 @@ workflows:
       - build-source:
           matrix:
             parameters:
-              e: ["golang-previous", "golang-latest", "golang-rc"]
+              e: ["golang-previous", "golang-latest"]
       - unit-test:
           matrix:
             parameters:
-              e: ["golang-previous", "golang-latest", "golang-rc"]
+              e: ["golang-previous", "golang-latest"]
       - release-test
 
   tagged-release:


### PR DESCRIPTION
In advance of #351, start testing against Go 1.22 release.