### PR TITLE
chore: bump golangci-lint to v1.57

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:20-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.56
+      - image: golangci/golangci-lint:v1.57
   golang-previous:
     docker:
       - image: golang:1.21

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
+    - copyloopvar
     - decorder
     - dogsled
     - dupl
@@ -31,6 +32,7 @@ linters:
     - grouper
     - ineffassign
     - interfacebloat
+    - intrange
     - ireturn
     - lll
     - maintidx

--- a/internal/app/siftool/info_test.go
+++ b/internal/app/siftool/info_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2024, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -66,8 +66,6 @@ func Test_readableSize(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			if got, want := readableSize(tt.size), tt.want; got != want {
 				t.Errorf("got %v, want %v", got, want)

--- a/pkg/integrity/clearsign_test.go
+++ b/pkg/integrity/clearsign_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2024, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -51,7 +51,6 @@ func Test_clearsignEncoder_signMessage(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			b := bytes.Buffer{}
 
@@ -170,7 +169,6 @@ func Test_clearsignDecoder_verifyMessage(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			b := bytes.Buffer{}
 

--- a/pkg/integrity/digest_test.go
+++ b/pkg/integrity/digest_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2024, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -90,7 +90,6 @@ func TestNewLegacyDigest(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			d, err := newLegacyDigest(tt.ht, []byte(tt.text))
 			if got, want := err, tt.wantError; !errors.Is(got, want) {
@@ -156,7 +155,6 @@ func TestDigest_MarshalJSON(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			value, err := hex.DecodeString(tt.value)
 			if err != nil {
@@ -261,7 +259,6 @@ func TestDigest_UnmarshalJSON(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			var d digest
 

--- a/pkg/integrity/dsse_test.go
+++ b/pkg/integrity/dsse_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2024, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -78,7 +78,6 @@ func Test_dsseEncoder_signMessage(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			b := bytes.Buffer{}
 
@@ -319,7 +318,6 @@ func Test_dsseDecoder_verifyMessage(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			b := bytes.Buffer{}
 

--- a/pkg/integrity/metadata_test.go
+++ b/pkg/integrity/metadata_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2024, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -46,7 +46,6 @@ func TestGetHeaderMetadata(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			md, err := getHeaderMetadata(tt.header, tt.hash)
 			if got, want := err, tt.wantErr; !errors.Is(got, want) {
@@ -102,7 +101,6 @@ func TestGetObjectMetadata(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			md, err := getObjectMetadata(tt.relativeID, tt.descr, tt.data, tt.hash)
 			if got, want := err, tt.wantErr; !errors.Is(got, want) {
@@ -155,7 +153,6 @@ func TestGetImageMetadata(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			md, err := getImageMetadata(f, tt.minID, tt.ods, tt.hash)
 			if got, want := err, tt.wantErr; !errors.Is(got, want) {

--- a/pkg/integrity/sign_test.go
+++ b/pkg/integrity/sign_test.go
@@ -68,7 +68,6 @@ func TestOptSignGroupObjects(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			gs := groupSigner{f: twoGroupImage, id: tt.groupID}
 
@@ -195,7 +194,6 @@ func TestNewGroupSigner(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			en := newClearsignEncoder(getTestEntity(t), fixedTime)
 
@@ -339,7 +337,6 @@ func TestGroupSigner_Sign(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			di, err := tt.gs.sign(context.Background())
 			if (err != nil) != tt.wantErr {
@@ -534,7 +531,6 @@ func TestNewSigner(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			s, err := NewSigner(tt.fi, tt.opts...)
 			if got, want := err, tt.wantErr; !errors.Is(got, want) {
@@ -827,8 +823,6 @@ func TestSigner_Sign(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			b, err := os.ReadFile(filepath.Join(corpus, tt.inputFile))
 			if err != nil {

--- a/pkg/integrity/verify_test.go
+++ b/pkg/integrity/verify_test.go
@@ -51,7 +51,6 @@ func TestGroupVerifier_signatures(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			v := &groupVerifier{
 				f:       tt.f,
@@ -144,7 +143,6 @@ func TestGroupVerifier_verify(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ods := make([]sif.Descriptor, len(tt.objectIDs))
 			for i, id := range tt.objectIDs {
@@ -211,7 +209,6 @@ func TestLegacyGroupVerifier_signatures(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			v := &legacyGroupVerifier{
 				f:       tt.f,
@@ -279,7 +276,6 @@ func TestLegacyGroupVerifier_verify(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ods, err := getGroupObjects(tt.f, tt.groupID)
 			if err != nil {
@@ -344,7 +340,6 @@ func TestLegacyObjectVerifier_signatures(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			od, err := tt.f.GetDescriptor(sif.WithID(tt.id))
 			if err != nil {
@@ -420,7 +415,6 @@ func TestLegacyObjectVerifier_verify(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			od, err := tt.f.GetDescriptor(sif.WithID(tt.id))
 			if err != nil {
@@ -677,7 +671,6 @@ func TestNewVerifier(t *testing.T) { //nolint:maintidx
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			v, err := NewVerifier(tt.fi, tt.opts...)
 			if got, want := err, tt.wantErr; !errors.Is(got, want) {
@@ -845,7 +838,6 @@ func TestVerifier_AnySignedBy(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			v := Verifier{tasks: tt.tasks}
 
@@ -941,7 +933,6 @@ func TestVerifier_AllSignedBy(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			v := Verifier{tasks: tt.tasks}
 
@@ -1097,7 +1088,6 @@ func TestVerifier_Verify(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			var vr VerifyResult
 

--- a/pkg/sif/descriptor_test.go
+++ b/pkg/sif/descriptor_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -521,7 +521,6 @@ func TestDescriptor_GetIntegrityReader(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			d := Descriptor{
 				raw:        rd,

--- a/pkg/sif/load_test.go
+++ b/pkg/sif/load_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -33,8 +33,6 @@ func TestLoadContainerFromPath(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			f, err := LoadContainerFromPath(tt.path, tt.opts...)
 			if err != nil {
@@ -66,8 +64,6 @@ func TestLoadContainer(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			rw, err := os.Open(filepath.Join(corpus, "one-group.sif"))
 			if err != nil {

--- a/pkg/sif/sif_test.go
+++ b/pkg/sif/sif_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2024, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -86,7 +86,6 @@ func TestHeader_GetIntegrityReader(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			b := bytes.Buffer{}
 


### PR DESCRIPTION
Bump `golangci-lint` to v1.57. Add `copyloopvar` and `intrange`, which won't come into play until this module adopts Go 1.22 but play nicely with Go 1.21. Drop loop variable usage in (non-parallel) tests, which is safe for Go 1.21 and will lessen the number of changes required for a clean `copyloopvar` run when Go 1.22 is adopted.

Add patch version to `go` directive in `go.mod` (see https://github.com/golang/go/issues/62278).