### PR TITLE
ci: bump golangci-lint to v1.59

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   node:
     docker:
-      - image: node:20-slim
+      - image: node:22-slim
   golangci-lint:
     docker:
       - image: golangci/golangci-lint:v1.59

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:20-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.57
+      - image: golangci/golangci-lint:v1.59
   golang-previous:
     docker:
       - image: golang:1.21

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - dogsled
     - dupl
     - dupword
+    - err113
     - errcheck
     - errchkjson
     - errname
@@ -21,7 +22,6 @@ linters:
     - gocritic
     - godot
     - godox
-    - goerr113
     - gofumpt
     - goimports
     - gomodguard

--- a/pkg/sif/descriptor_input_test.go
+++ b/pkg/sif/descriptor_input_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2024, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -195,8 +195,6 @@ func TestNewDescriptorInput(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
Bump `golangci-lint` to v1.59. Update linter config to reflect name change of linter `goerr113` to `err113`.