### PR TITLE
ci: add testing against Go 1.23 RC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ executors:
   golang-latest:
     docker:
       - image: golang:1.22
+  golang-next:
+    docker:
+      - image: golang:1.23-rc
 
 jobs:
   lint-markdown:
@@ -132,11 +135,11 @@ workflows:
       - build-source:
           matrix:
             parameters:
-              e: ["golang-previous", "golang-latest"]
+              e: ["golang-previous", "golang-latest", "golang-next"]
       - unit-test:
           matrix:
             parameters:
-              e: ["golang-previous", "golang-latest"]
+              e: ["golang-previous", "golang-latest", "golang-next"]
       - release-test
 
   tagged-release:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sylabs/sif/v2
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/ProtonMail/go-crypto v1.0.0


### PR DESCRIPTION
Start building/testing against `go1.23-rc` in CI. Add patch version to `go` directive to address `Invalid Go toolchain version` warning in CodeQL.