### PR TITLE
chore: bump golangci-lint to v1.60

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:22-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.59
+      - image: golangci/golangci-lint:v1.60
   golang-previous:
     docker:
       - image: golang:1.22

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,6 @@ linters:
     - errchkjson
     - errname
     - errorlint
-    - exportloopref
     - forcetypeassert
     - gochecknoinits
     - gocritic

--- a/pkg/sif/create.go
+++ b/pkg/sif/create.go
@@ -12,30 +12,44 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"time"
 
 	"github.com/google/uuid"
 )
 
+var errAlignmentOverflow = errors.New("integer overflow when calculating alignment")
+
 // nextAligned finds the next offset that satisfies alignment.
-func nextAligned(offset int64, alignment int) int64 {
+func nextAligned(offset int64, alignment int) (int64, error) {
 	align64 := uint64(alignment)
 	offset64 := uint64(offset)
 
-	if align64 != 0 && offset64%align64 != 0 {
-		offset64 = (offset64 & ^(align64 - 1)) + align64
+	if align64 <= 0 || offset64%align64 == 0 {
+		return offset, nil
 	}
 
-	return int64(offset64)
+	offset64 += (align64 - offset64%align64)
+
+	if offset64 > math.MaxInt64 {
+		return 0, errAlignmentOverflow
+	}
+
+	//nolint:gosec // Overflow handled above.
+	return int64(offset64), nil
 }
 
 // writeDataObjectAt writes the data object described by di to ws, using time t, recording details
 // in d. The object is written at the first position that satisfies the alignment requirements
 // described by di following offsetUnaligned.
 func writeDataObjectAt(ws io.WriteSeeker, offsetUnaligned int64, di DescriptorInput, t time.Time, d *rawDescriptor) error { //nolint:lll
-	offset, err := ws.Seek(nextAligned(offsetUnaligned, di.opts.alignment), io.SeekStart)
+	offset, err := nextAligned(offsetUnaligned, di.opts.alignment)
 	if err != nil {
+		return err
+	}
+
+	if _, err := ws.Seek(offset, io.SeekStart); err != nil {
 		return err
 	}
 
@@ -72,6 +86,7 @@ func (f *FileImage) calculatedDataSize() int64 {
 var (
 	errInsufficientCapacity = errors.New("insufficient descriptor capacity to add data object(s) to image")
 	errPrimaryPartition     = errors.New("image already contains a primary partition")
+	errObjectIDOverflow     = errors.New("object ID would overflow")
 )
 
 // writeDataObject writes the data object described by di to f, using time t, recording details in
@@ -79,6 +94,11 @@ var (
 func (f *FileImage) writeDataObject(i int, di DescriptorInput, t time.Time) error {
 	if i >= len(f.rds) {
 		return errInsufficientCapacity
+	}
+
+	// We derive the ID from i, so make sure the ID will not overflow.
+	if i >= math.MaxInt32 {
+		return errObjectIDOverflow
 	}
 
 	// If this is a primary partition, verify there isn't another primary partition, and update the
@@ -92,7 +112,7 @@ func (f *FileImage) writeDataObject(i int, di DescriptorInput, t time.Time) erro
 	}
 
 	d := &f.rds[i]
-	d.ID = uint32(i) + 1
+	d.ID = uint32(i) + 1 //nolint:gosec // Overflow handled above.
 
 	f.h.DataSize = f.calculatedDataSize()
 

--- a/pkg/siftool/del.go
+++ b/pkg/siftool/del.go
@@ -29,6 +29,7 @@ func (c *command) getDel() *cobra.Command {
 				return fmt.Errorf("while converting id: %w", err)
 			}
 
+			//nolint:gosec // ParseUint above ensures id is safe to cast to uint32.
 			return c.app.Del(args[1], uint32(id))
 		},
 		DisableFlagsInUseLine: true,

--- a/pkg/siftool/dump.go
+++ b/pkg/siftool/dump.go
@@ -30,6 +30,7 @@ func (c *command) getDump() *cobra.Command {
 				return fmt.Errorf("while converting id: %w", err)
 			}
 
+			//nolint:gosec // ParseUint above ensures id is safe to cast to uint32.
 			return c.app.Dump(args[1], uint32(id))
 		},
 		DisableFlagsInUseLine: true,

--- a/pkg/siftool/info.go
+++ b/pkg/siftool/info.go
@@ -31,6 +31,7 @@ func (c *command) getInfo() *cobra.Command {
 				return fmt.Errorf("while converting id: %w", err)
 			}
 
+			//nolint:gosec // ParseUint above ensures id is safe to cast to uint32.
 			return c.app.Info(args[1], uint32(id))
 		},
 		DisableFlagsInUseLine: true,

--- a/pkg/siftool/setprim.go
+++ b/pkg/siftool/setprim.go
@@ -29,6 +29,7 @@ func (c *command) getSetPrim() *cobra.Command {
 				return fmt.Errorf("while converting id: %w", err)
 			}
 
+			//nolint:gosec // ParseUint above ensures id is safe to cast to uint32.
 			return c.app.Setprim(args[1], uint32(id))
 		},
 		DisableFlagsInUseLine: true,


### PR DESCRIPTION
Bump `golangci-lint` to v1.60. Address lint, and remove deprecated linter.