### PR TITLE
ci: bump golangci-lint to v1.61

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:22-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.60
+      - image: golangci/golangci-lint:v1.61
   golang-previous:
     docker:
       - image: golang:1.22

--- a/pkg/sif/create.go
+++ b/pkg/sif/create.go
@@ -23,21 +23,19 @@ var errAlignmentOverflow = errors.New("integer overflow when calculating alignme
 
 // nextAligned finds the next offset that satisfies alignment.
 func nextAligned(offset int64, alignment int) (int64, error) {
-	align64 := uint64(alignment)
-	offset64 := uint64(offset)
+	align64 := int64(alignment)
 
-	if align64 <= 0 || offset64%align64 == 0 {
+	if align64 <= 0 || offset%align64 == 0 {
 		return offset, nil
 	}
 
-	offset64 += (align64 - offset64%align64)
+	align64 -= offset % align64
 
-	if offset64 > math.MaxInt64 {
+	if (math.MaxInt64 - offset) < align64 {
 		return 0, errAlignmentOverflow
 	}
 
-	//nolint:gosec // Overflow handled above.
-	return int64(offset64), nil
+	return offset + align64, nil
 }
 
 // writeDataObjectAt writes the data object described by di to ws, using time t, recording details

--- a/pkg/siftool/del.go
+++ b/pkg/siftool/del.go
@@ -29,7 +29,6 @@ func (c *command) getDel() *cobra.Command {
 				return fmt.Errorf("while converting id: %w", err)
 			}
 
-			//nolint:gosec // ParseUint above ensures id is safe to cast to uint32.
 			return c.app.Del(args[1], uint32(id))
 		},
 		DisableFlagsInUseLine: true,

--- a/pkg/siftool/dump.go
+++ b/pkg/siftool/dump.go
@@ -30,7 +30,6 @@ func (c *command) getDump() *cobra.Command {
 				return fmt.Errorf("while converting id: %w", err)
 			}
 
-			//nolint:gosec // ParseUint above ensures id is safe to cast to uint32.
 			return c.app.Dump(args[1], uint32(id))
 		},
 		DisableFlagsInUseLine: true,

--- a/pkg/siftool/info.go
+++ b/pkg/siftool/info.go
@@ -31,7 +31,6 @@ func (c *command) getInfo() *cobra.Command {
 				return fmt.Errorf("while converting id: %w", err)
 			}
 
-			//nolint:gosec // ParseUint above ensures id is safe to cast to uint32.
 			return c.app.Info(args[1], uint32(id))
 		},
 		DisableFlagsInUseLine: true,

--- a/pkg/siftool/setprim.go
+++ b/pkg/siftool/setprim.go
@@ -29,7 +29,6 @@ func (c *command) getSetPrim() *cobra.Command {
 				return fmt.Errorf("while converting id: %w", err)
 			}
 
-			//nolint:gosec // ParseUint above ensures id is safe to cast to uint32.
 			return c.app.Setprim(args[1], uint32(id))
 		},
 		DisableFlagsInUseLine: true,


### PR DESCRIPTION
Remove some `nolint` comments that are no longer necessary due to improvements in the `gosec` linter. Improve alignment overflow check logic.