### PR TITLE
lint: bump `golangci-lint` to v1.63

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:22-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.62
+      - image: golangci/golangci-lint:v1.63
   golang-previous:
     docker:
       - image: golang:1.22

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
     - errchkjson
     - errname
     - errorlint
+    - exptostd
     - forcetypeassert
     - gochecknoinits
     - gocritic
@@ -38,6 +39,7 @@ linters:
     - maintidx
     - mirror
     - misspell
+    - nilnesserr
     - nilnil
     - nolintlint
     - nonamedreturns
@@ -51,6 +53,7 @@ linters:
     - unconvert
     - unparam
     - unused
+    - usetesting
     - whitespace
 
 linters-settings:

--- a/internal/app/siftool/modif_test.go
+++ b/internal/app/siftool/modif_test.go
@@ -21,11 +21,10 @@ func TestApp_New(t *testing.T) {
 		t.Fatalf("failed to create app: %v", err)
 	}
 
-	tf, err := os.CreateTemp("", "sif-test-*")
+	tf, err := os.CreateTemp(t.TempDir(), "sif-test-*")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(tf.Name())
 	tf.Close()
 
 	if err := a.New(tf.Name()); err != nil {
@@ -94,11 +93,10 @@ func TestApp_Add(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tf, err := os.CreateTemp("", "sif-test-*")
+			tf, err := os.CreateTemp(t.TempDir(), "sif-test-*")
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer os.Remove(tf.Name())
 			tf.Close()
 
 			if err := a.New(tf.Name()); err != nil {
@@ -119,11 +117,10 @@ func TestApp_Del(t *testing.T) {
 		t.Fatalf("failed to create app: %v", err)
 	}
 
-	tf, err := os.CreateTemp("", "sif-test-*")
+	tf, err := os.CreateTemp(t.TempDir(), "sif-test-*")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(tf.Name())
 	tf.Close()
 
 	if err := a.New(tf.Name()); err != nil {
@@ -146,11 +143,10 @@ func TestApp_Setprim(t *testing.T) {
 		t.Fatalf("failed to create app: %v", err)
 	}
 
-	tf, err := os.CreateTemp("", "sif-test-*")
+	tf, err := os.CreateTemp(t.TempDir(), "sif-test-*")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(tf.Name())
 	tf.Close()
 
 	if err := a.New(tf.Name()); err != nil {

--- a/internal/app/siftool/modif_test.go
+++ b/internal/app/siftool/modif_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"crypto"
 	"errors"
-	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/sylabs/sif/v2/pkg/sif"
@@ -21,13 +21,9 @@ func TestApp_New(t *testing.T) {
 		t.Fatalf("failed to create app: %v", err)
 	}
 
-	tf, err := os.CreateTemp(t.TempDir(), "sif-test-*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	tf.Close()
+	path := filepath.Join(t.TempDir(), "sif")
 
-	if err := a.New(tf.Name()); err != nil {
+	if err := a.New(path); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -93,18 +89,14 @@ func TestApp_Add(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tf, err := os.CreateTemp(t.TempDir(), "sif-test-*")
-			if err != nil {
-				t.Fatal(err)
-			}
-			tf.Close()
+			path := filepath.Join(t.TempDir(), "sif")
 
-			if err := a.New(tf.Name()); err != nil {
+			if err := a.New(path); err != nil {
 				t.Fatal(err)
 			}
 
 			data := bytes.NewReader(tt.data)
-			if got, want := a.Add(tf.Name(), tt.dataType, data, tt.opts...), tt.wantErr; !errors.Is(got, want) {
+			if got, want := a.Add(path, tt.dataType, data, tt.opts...), tt.wantErr; !errors.Is(got, want) {
 				t.Fatalf("got error %v, want %v", got, want)
 			}
 		})
@@ -117,22 +109,18 @@ func TestApp_Del(t *testing.T) {
 		t.Fatalf("failed to create app: %v", err)
 	}
 
-	tf, err := os.CreateTemp(t.TempDir(), "sif-test-*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	tf.Close()
+	path := filepath.Join(t.TempDir(), "sif")
 
-	if err := a.New(tf.Name()); err != nil {
+	if err := a.New(path); err != nil {
 		t.Fatal(err)
 	}
 
-	err = a.Add(tf.Name(), sif.DataGeneric, bytes.NewReader([]byte{0xde, 0xad, 0xbe, 0xef}))
+	err = a.Add(path, sif.DataGeneric, bytes.NewReader([]byte{0xde, 0xad, 0xbe, 0xef}))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := a.Del(tf.Name(), 1); err != nil {
+	if err := a.Del(path, 1); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -143,24 +131,20 @@ func TestApp_Setprim(t *testing.T) {
 		t.Fatalf("failed to create app: %v", err)
 	}
 
-	tf, err := os.CreateTemp(t.TempDir(), "sif-test-*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	tf.Close()
+	path := filepath.Join(t.TempDir(), "sif")
 
-	if err := a.New(tf.Name()); err != nil {
+	if err := a.New(path); err != nil {
 		t.Fatal(err)
 	}
 
-	err = a.Add(tf.Name(), sif.DataPartition, bytes.NewReader([]byte{0xde, 0xad, 0xbe, 0xef}),
+	err = a.Add(path, sif.DataPartition, bytes.NewReader([]byte{0xde, 0xad, 0xbe, 0xef}),
 		sif.OptPartitionMetadata(sif.FsSquash, sif.PartSystem, "386"),
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := a.Setprim(tf.Name(), 1); err != nil {
+	if err := a.Setprim(path, 1); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/pkg/sif/create_test.go
+++ b/pkg/sif/create_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"math"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -272,14 +273,9 @@ func TestCreateContainerAtPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tf, err := os.CreateTemp("", "sif-test-*")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.Remove(tf.Name())
-			tf.Close()
+			path := filepath.Join(t.TempDir(), "sif")
 
-			f, err := CreateContainerAtPath(tf.Name(), tt.opts...)
+			f, err := CreateContainerAtPath(path, tt.opts...)
 
 			if got, want := err, tt.wantErr; !errors.Is(got, want) {
 				t.Fatalf("got error %v, want %v", got, want)
@@ -290,7 +286,7 @@ func TestCreateContainerAtPath(t *testing.T) {
 					t.Error(err)
 				}
 
-				b, err := os.ReadFile(tf.Name())
+				b, err := os.ReadFile(path)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/siftool/new_test.go
+++ b/pkg/siftool/new_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -6,7 +6,7 @@
 package siftool
 
 import (
-	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -21,18 +21,13 @@ func Test_command_getNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tf, err := os.CreateTemp("", "sif-test-*")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.Remove(tf.Name())
-			tf.Close()
+			path := filepath.Join(t.TempDir(), "sif")
 
 			c := &command{opts: tt.opts}
 
 			cmd := c.getNew()
 
-			runCommand(t, cmd, []string{tf.Name()}, nil)
+			runCommand(t, cmd, []string{path}, nil)
 		})
 	}
 }

--- a/pkg/siftool/siftool_test.go
+++ b/pkg/siftool/siftool_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -7,7 +7,6 @@ package siftool
 import (
 	"bytes"
 	"errors"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -21,24 +20,19 @@ var corpus = filepath.Join("..", "..", "test", "images")
 
 //nolint:thelper // Complex enough to justify keeping file/line information on error.
 func makeTestSIF(t *testing.T, withDataObject bool) string {
-	tf, err := os.CreateTemp("", "sif-test-*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.Remove(tf.Name()) })
-	tf.Close()
-
 	app, err := siftool.New()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := app.New(tf.Name()); err != nil {
+	path := filepath.Join(t.TempDir(), "sif")
+
+	if err := app.New(path); err != nil {
 		t.Fatal(err)
 	}
 
 	if withDataObject {
-		err := app.Add(tf.Name(), sif.DataPartition, bytes.NewReader([]byte{0xde, 0xad, 0xbe, 0xef}),
+		err := app.Add(path, sif.DataPartition, bytes.NewReader([]byte{0xde, 0xad, 0xbe, 0xef}),
 			sif.OptPartitionMetadata(sif.FsSquash, sif.PartSystem, "386"),
 		)
 		if err != nil {
@@ -46,7 +40,7 @@ func makeTestSIF(t *testing.T, withDataObject bool) string {
 		}
 	}
 
-	return tf.Name()
+	return path
 }
 
 //nolint:unparam

--- a/pkg/user/unmount_test.go
+++ b/pkg/user/unmount_test.go
@@ -21,14 +21,12 @@ var corpus = filepath.Join("..", "..", "test", "images")
 
 func Test_Unmount(t *testing.T) {
 	if _, err := exec.LookPath("squashfuse"); err != nil {
-		t.Skip(" not found, skipping mount tests")
+		t.Skip("squashfuse not found, skipping mount tests")
 	}
 	fusermountPath, err := exec.LookPath("fusermount")
 	if err != nil {
-		t.Skip(" not found, skipping mount tests")
+		t.Skip("fusermount not found, skipping mount tests")
 	}
-
-	path := t.TempDir()
 
 	tests := []struct {
 		name          string
@@ -41,14 +39,14 @@ func Test_Unmount(t *testing.T) {
 		{
 			name:          "Mounted",
 			mountSIF:      filepath.Join(corpus, "one-group.sif"),
-			mountPath:     path,
+			mountPath:     t.TempDir(),
 			wantErr:       false,
 			wantUnmounted: true,
 		},
 		{
 			name:      "NotMounted",
 			mountSIF:  "",
-			mountPath: path,
+			mountPath: t.TempDir(),
 			wantErr:   true,
 		},
 		{
@@ -60,14 +58,14 @@ func Test_Unmount(t *testing.T) {
 		{
 			name:      "FusermountBare",
 			mountSIF:  "",
-			mountPath: path,
+			mountPath: t.TempDir(),
 			opts:      []UnmountOpt{OptUnmountFusermountPath("fusermount")},
 			wantErr:   true,
 		},
 		{
 			name:          "FusermountValid",
 			mountSIF:      filepath.Join(corpus, "one-group.sif"),
-			mountPath:     path,
+			mountPath:     t.TempDir(),
 			opts:          []UnmountOpt{OptUnmountFusermountPath(fusermountPath)},
 			wantErr:       false,
 			wantUnmounted: true,
@@ -76,7 +74,7 @@ func Test_Unmount(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.mountSIF != "" {
-				err := Mount(context.Background(), tt.mountSIF, path)
+				err := Mount(context.Background(), tt.mountSIF, tt.mountPath)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/user/unmount_test.go
+++ b/pkg/user/unmount_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2022-2025, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -28,13 +28,7 @@ func Test_Unmount(t *testing.T) {
 		t.Skip(" not found, skipping mount tests")
 	}
 
-	path, err := os.MkdirTemp("", "siftool-mount-*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		os.RemoveAll(path)
-	})
+	path := t.TempDir()
 
 	tests := []struct {
 		name          string


### PR DESCRIPTION
Enable `exptostd`, `nilnesserr` and `usetesting` linters.