### PR TITLE
chore: bump module to Go 1.23

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,16 +9,13 @@ executors:
       - image: node:22-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.63
+      - image: golangci/golangci-lint:v1.64
   golang-previous:
     docker:
-      - image: golang:1.22
+      - image: golang:1.23
   golang-latest:
     docker:
-      - image: golang:1.23
-  golang-next:
-    docker:
-      - image: golang:1.24-rc
+      - image: golang:1.24
 
 jobs:
   lint-markdown:
@@ -132,11 +129,11 @@ workflows:
       - build-source:
           matrix:
             parameters:
-              e: ["golang-previous", "golang-latest", "golang-next"]
+              e: ["golang-previous", "golang-latest"]
       - unit-test:
           matrix:
             parameters:
-              e: ["golang-previous", "golang-latest", "golang-next"]
+              e: ["golang-previous", "golang-latest"]
       - release-test
 
   tagged-release:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sylabs/sif/v2
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/ProtonMail/go-crypto v1.1.5


### PR DESCRIPTION
Bump module Go version to 1.23, and drop testing against Go 1.22. Bump `golangci-lint` to v1.64 to ensure Go 1.24 compatibility.