### PR TITLE
fix: remove deprecated goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,11 +61,11 @@ builds:
 
 archives:
   - id: darwin-archives
-    builds:
+    ids:
       - darwin-builds
 
   - id: linux-archives
-    builds:
+    ids:
       - linux-builds
 
 sboms:


### PR DESCRIPTION
As per https://goreleaser.com/deprecations/#archivesbuilds