### PR TITLE
chore: bump `golangci-lint` to v2.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:24-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v2.9
+      - image: golangci/golangci-lint:v2.12
   golang-previous:
     docker:
       - image: golang:1.25

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,7 @@ linters:
     - gocritic
     - godot
     - godox
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - govet


### PR DESCRIPTION
Replace deprecated `gomodguard` linter.